### PR TITLE
Update pr template

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,7 +1,6 @@
-1. A description of the changes proposed in this pull request. 
-     * Include images/GIFs if helpful for reviewers. Try Fireshot ([Chrome](https://chrome.google.com/webstore/detail/take-webpage-screenshots/mcbpblocgmgfnpjjppndjkmgjaogfceg?hl=en), [Firefox](https://addons.mozilla.org/en-US/firefox/addon/fireshot/)) for full-page screenshots and LICEcap ([MacOS](https://www.cockos.com/licecap/)) for GIFs.
-2. A [reference to the related Github Issue(s)](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue), e.g. "fixes #29"
-3. Before submitting the PR for review, consider the checklist below and check off any completed items
+Write a description of the changes proposed in this pull request. Include images/GIFs if relevant for reviewers. Try Fireshot (Chrome, Firefox) for full-page screenshots and LICEcap (macOS) for GIFs.
+
+Before submitting the PR for review, consider the checklist below and check off any completed items
 
 ===
 


### PR DESCRIPTION
I didn't realize in #134 that I shouldn't use Markdown in the PR template, because it'll appear as raw Markdown in the textarea of every new PR. So I've stripped it down to the basics here.