### PR TITLE
Anonymize the IP address when sending to GA

### DIFF
--- a/src/routes/single-page-app.js
+++ b/src/routes/single-page-app.js
@@ -32,8 +32,9 @@ singlePageAppRouter.get("/*", (req, res) => {
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
         // For details see: https://support.google.com/analytics/answer/9310895?hl=en
-        gtag('config', 'UA-3419582-2'); // www.ca.gov
-        gtag('config', 'UA-3419582-31'); // edd.ca.gov
+        // https://developers.google.com/analytics/devguides/collection/gtagjs/ip-anonymization
+        gtag('config', 'UA-3419582-2', { 'anonymize_ip': true }); // www.ca.gov
+        gtag('config', 'UA-3419582-31', { 'anonymize_ip': true }); // edd.ca.gov
       </script>
       <meta http-equiv="X-UA-Compatible" content="IE=edge" />
       <meta charset="utf-8" />


### PR DESCRIPTION
This option causes the last part of the users IP
address to be ignored by GA. Requested by ISO to
increase the amount of user privacy.

===

Resolves #XXX

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
