### PR TITLE
Only redirect if not on /guide

### DIFF
--- a/src/routes/single-page-app.js
+++ b/src/routes/single-page-app.js
@@ -15,7 +15,7 @@ singlePageAppRouter.get("/*", (req, res) => {
 
   const shouldRedirect = !Object.values(pageRoutes)
     .map((r) => r.path)
-    .includes(req.path);
+    .some(path => req.path.startsWith(path))
   if (shouldRedirect) {
     res.status(301).location(pageRoutes.home.path).send();
     return;
@@ -25,6 +25,7 @@ singlePageAppRouter.get("/*", (req, res) => {
     `<!doctype html>
     <html lang="en">
     <head>
+      <base href="/">
       <!-- Global site tag (gtag.js) - Google Analytics -->
       <script async src="https://www.googletagmanager.com/gtag/js?id=UA-3419582-2"></script>
       <script>

--- a/src/routes/single-page-app.test.js
+++ b/src/routes/single-page-app.test.js
@@ -11,11 +11,20 @@ describe("Router: Single page app", () => {
     expect(res.text).toMatch(/<html/);
   });
 
-  it("/guide/ returns 301 status code", async () => {
+  it("/guide/ returns 200 status code", async () => {
+    // The router will re-write this to the first tab.
     const res = await request(server).get("/guide/");
 
-    expect(res.status).toBe(301);
-    expect(res.get('Location')).toBe('/guide');
+    expect(res.status).toBe(200);
+    expect(res.text).toMatch(/<base href="\/">/);
+  });
+
+  it("/guide/benefits returns 200 status code", async () => {
+    // No need to do a redirect here since we're loading a guide page.
+    const res = await request(server).get("/guide/benefits");
+
+    expect(res.status).toBe(200);
+    expect(res.text).toMatch(/<html/);
   });
 
   it("/ returns 301 status code", async () => {


### PR DESCRIPTION
Limit the redirect to ignore tabs like
/guide/benefits. The tabs still aren't loading,
but I will fix that in a follow up change.

I noticed that images were broken on /guide/benefits
because the URLs were relative. Add a <base> tag to
ensure that relative URLs still work.

Write a description of the changes proposed in this pull request. Include images/GIFs if relevant for reviewers. Try Fireshot (Chrome, Firefox) for full-page screenshots and LICEcap (macOS) for GIFs.

Before submitting the PR for review, consider the checklist below and check off any completed items

===

Resolves #XXX

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [X] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [X] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
