### PR TITLE
Outline button styling

### DIFF
--- a/src/client/App.scss
+++ b/src/client/App.scss
@@ -47,6 +47,10 @@ a {
 	text-decoration: none;
 }
 
+.btn {
+	color: #000000;
+}
+
 // Eliminate whitespace overflow on right half of mobile viewport
 // None of the usual solutions are compatible with sticky elements
 // But this solution is: https://stackoverflow.com/a/59019025/6074728

--- a/src/client/components/TabbedContainer/__snapshots__/index.test.js.snap
+++ b/src/client/components/TabbedContainer/__snapshots__/index.test.js.snap
@@ -172,9 +172,11 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
                 onClick={[Function]}
                 to="/guide/before-you-apply"
                 type="button"
-                variant="secondary"
+                variant="outline-secondary"
               >
-                buttonNextPrefixtabTitles.1
+                <strong>
+                  buttonNextPrefixtabTitles.1
+                </strong>
               </Button>
             </Component>
             <Component
@@ -194,9 +196,11 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
                 onClick={[Function]}
                 to="/guide/how-to-apply"
                 type="button"
-                variant="secondary"
+                variant="outline-secondary"
               >
-                buttonNextPrefixtabTitles.2
+                <strong>
+                  buttonNextPrefixtabTitles.2
+                </strong>
               </Button>
             </Component>
             <Component
@@ -216,9 +220,11 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
                 onClick={[Function]}
                 to="/guide/after-you-submit"
                 type="button"
-                variant="secondary"
+                variant="outline-secondary"
               >
-                buttonNextPrefixtabTitles.3
+                <strong>
+                  buttonNextPrefixtabTitles.3
+                </strong>
               </Button>
             </Component>
             <Component
@@ -238,9 +244,11 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
                 onClick={[Function]}
                 to="/guide/receive-benefits"
                 type="button"
-                variant="secondary"
+                variant="outline-secondary"
               >
-                buttonNextPrefixtabTitles.4
+                <strong>
+                  buttonNextPrefixtabTitles.4
+                </strong>
               </Button>
             </Component>
             <Component
@@ -260,9 +268,11 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
                 onClick={[Function]}
                 to="/guide/more-resources"
                 type="button"
-                variant="secondary"
+                variant="outline-secondary"
               >
-                buttonNextPrefixtabTitles.5
+                <strong>
+                  buttonNextPrefixtabTitles.5
+                </strong>
               </Button>
             </Component>
             <Component

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -121,12 +121,12 @@ function TabbedContainer() {
     const nextTabIndex = tabIndex + 1;
     return (
       <Button
-        variant="secondary"
+        variant="outline-secondary"
         as={Link}
         to={prefix + tabSlugs[nextTabIndex]}
         onClick={() => setActiveTabIndex(nextTabIndex)}
       >
-        {t("buttonNextPrefix") + getTabTitle(nextTabIndex)}
+        <strong>{t("buttonNextPrefix") + getTabTitle(nextTabIndex)}</strong>
       </Button>
     );
   };


### PR DESCRIPTION
Updates "next" buttons to be outlined in yellow, and have black, bolded text.
 
<img width="934" alt="Screen Shot 2020-05-07 at 5 25 21 PM" src="https://user-images.githubusercontent.com/4306128/81346136-c3e87e80-9087-11ea-8441-92f2b39e6535.png">


===

Resolves #110 

- [x] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [x] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [x] Automated tests added, if new functionality added
- [x] Documentation (e.g. READMEs) updated, if relevant
- [x] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [x] Accessibility & performance audit run using Google Lighthouse, if major changes made
