### PR TITLE
Keep the current tab selected on reload.

### DIFF
--- a/src/client/components/TabbedContainer/__snapshots__/index.test.js.snap
+++ b/src/client/components/TabbedContainer/__snapshots__/index.test.js.snap
@@ -159,7 +159,9 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               key="0"
               path="/guide/benefits"
             >
-              <ScrollToTopOnMount />
+              <TabPaneContentOnMount
+                tabIndex={0}
+              />
               <h2>
                 tabTitles.0
               </h2>
@@ -181,7 +183,9 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               key="1"
               path="/guide/before-you-apply"
             >
-              <ScrollToTopOnMount />
+              <TabPaneContentOnMount
+                tabIndex={1}
+              />
               <h2>
                 tabTitles.1
               </h2>
@@ -203,7 +207,9 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               key="2"
               path="/guide/how-to-apply"
             >
-              <ScrollToTopOnMount />
+              <TabPaneContentOnMount
+                tabIndex={2}
+              />
               <h2>
                 tabTitles.2
               </h2>
@@ -225,7 +231,9 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               key="3"
               path="/guide/after-you-submit"
             >
-              <ScrollToTopOnMount />
+              <TabPaneContentOnMount
+                tabIndex={3}
+              />
               <h2>
                 tabTitles.3
               </h2>
@@ -247,7 +255,9 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               key="4"
               path="/guide/receive-benefits"
             >
-              <ScrollToTopOnMount />
+              <TabPaneContentOnMount
+                tabIndex={4}
+              />
               <h2>
                 tabTitles.4
               </h2>
@@ -269,7 +279,9 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               key="5"
               path="/guide/more-resources"
             >
-              <ScrollToTopOnMount />
+              <TabPaneContentOnMount
+                tabIndex={5}
+              />
               <h2>
                 tabTitles.5
               </h2>

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -101,7 +101,7 @@ function TabbedContainer() {
         left: 0,
         behavior: "smooth",
       });
-    }, [tabIndex]);
+    });
 
     return null;
   }

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -84,7 +84,7 @@ function TabbedContainer() {
     useEffect(() => {
       // If make sure the correct tab is active (e.g., if the
       // user is loading a tab directly).
-      if (activeTabIndex != tabIndex) {
+      if (activeTabIndex !== tabIndex) {
         setActiveTabIndex(tabIndex);
         return;
       }
@@ -101,7 +101,7 @@ function TabbedContainer() {
         left: 0,
         behavior: "smooth",
       });
-    }, []);
+    }, [tabIndex]);
 
     return null;
   }

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -79,9 +79,16 @@ function TabbedContainer() {
   const history = useHistory();
   history.listen((location) => logPage(location.pathname));
 
-  // Scroll to the top of the sidebar when a tab content pane loads
-  function ScrollToTopOnMount() {
+  // Runs when a tab content pane loads.
+  function TabPaneContentOnMount({ tabIndex }) {
     useEffect(() => {
+      // If make sure the correct tab is active (e.g., if the
+      // user is loading a tab directly).
+      if (activeTabIndex != tabIndex) {
+        setActiveTabIndex(tabIndex);
+        return;
+      }
+
       // Don't scroll down to the top of the sidebar on initial page load
       if (initialPageLoad.current) {
         initialPageLoad.current = false;
@@ -161,7 +168,7 @@ function TabbedContainer() {
                   const TabPaneContentTagName = tabPaneContent[index];
                   return (
                     <Route path={prefix + value} key={index}>
-                      <ScrollToTopOnMount />
+                      <TabPaneContentOnMount tabIndex={index} />
                       <h2>{getTabTitle(index)}</h2>
                       <TabPaneContentTagName getTabLink={getTabLink} />
                       {renderNextButton(index)}


### PR DESCRIPTION
The tab contents were correct (using <Route>), but the nav tab
was always set to 0 on load. When the tab contents mount, set the
nav tab as well.

Write a description of the changes proposed in this pull request. Include images/GIFs if relevant for reviewers. Try Fireshot (Chrome, Firefox) for full-page screenshots and LICEcap (macOS) for GIFs.

Before submitting the PR for review, consider the checklist below and check off any completed items

===

Resolves #130 

- [X] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [X] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
