### PR TITLE
Add eslint autofix import sorting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,7 +23,7 @@
       "jsx": true
     }
   },
-  "plugins": ["jest", "jsdoc", "jsx-a11y", "react-hooks"],
+  "plugins": ["jest", "jsdoc", "jsx-a11y", "react-hooks", "simple-import-sort"],
   "rules": {
     "jest/consistent-test-it": ["error", { "fn": "it" }],
     "jest/no-try-expect": "off",
@@ -45,7 +45,8 @@
     "react/jsx-fragments": ["error", "element"],
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
-    "sort-imports": "error",
+    "simple-import-sort/sort": "error",
+    "sort-imports": "off",
     "sort-vars": "error"
   },
   "settings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5803,6 +5803,12 @@
       "integrity": "sha512-Y2c4b55R+6ZzwtTppKwSmK/Kar8AdLiC2f9NADCuxbcTgPPg41Gyqa6b9GppgXSvCtkRw43ZE86CT5sejKC6/g==",
       "dev": true
     },
+    "eslint-plugin-simple-import-sort": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-5.0.3.tgz",
+      "integrity": "sha512-1rf3AWiHeWNCQdAq0iXNnlccnH1UDnelGgrPbjBBHE8d2hXVtOudcmy0vTF4hri3iJ0MKz8jBhmH6lJ0ZWZLHQ==",
+      "dev": true
+    },
     "eslint-plugin-standard": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz",
@@ -12995,14 +13001,6 @@
         }
       }
     },
-    "react-router-bootstrap": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/react-router-bootstrap/-/react-router-bootstrap-0.25.0.tgz",
-      "integrity": "sha512-/22eqxjn6Zv5fvY2rZHn57SKmjmJfK7xzJ6/G1OgxAjLtKVfWgV5sn41W2yiqzbtV5eE4/i4LeDLBGYTqx7jbA==",
-      "requires": {
-        "prop-types": "^15.5.10"
-      }
-    },
     "react-router-dom": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.1.2.tgz",
@@ -13015,15 +13013,6 @@
         "react-router": "5.1.2",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
-      }
-    },
-    "react-router-tabs": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/react-router-tabs/-/react-router-tabs-1.3.2.tgz",
-      "integrity": "sha512-RZLes3fUTDP4EvDuAOxXt7MRvW2Wpla1ToiNO6E3wEHJs51r4SE7UkVmqou/sBOaUvigweDcaf4f8huNiCGGzA==",
-      "requires": {
-        "@babel/runtime": "^7.4.3",
-        "prop-types": "^15.7.2"
       }
     },
     "react-test-renderer": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
         "eslint-plugin-jsx-a11y": "^6.2.3",
         "eslint-plugin-react": "^7.16.0",
         "eslint-plugin-react-hooks": "^2.3.0",
+        "eslint-plugin-simple-import-sort": "^5.0.3",
         "husky": "^3.1.0",
         "i18next": "^19.0.3",
         "i18next-hmr": "^1.4.1",


### PR DESCRIPTION
This PR allows eslint --fix to automatically sort imports. 

For example, it'll reorder 

```
import { mount } from "enzyme";
import { I18nextProvider } from "react-i18next";
import i18n from "./i18nForTests";
import React from "react";
```

to 

```
import { mount } from "enzyme";
import React from "react";
import { I18nextProvider } from "react-i18next";
import i18n from "./i18nForTests";
```

Instructions to set up sublime to automatically fix when saving: install ESLint-Formatter in Sublime’s Package Control, then allow to auto fix on save: Preferences → Package Settings → ESLint Formatter → Settings and add "format_on_save": true to the settings file:
