### PR TITLE
Remove alphabetical ordering rules from linter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -45,8 +45,6 @@
     "react/jsx-fragments": ["error", "element"],
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
-    "sort-imports": "error",
-    "sort-vars": "error"
   },
   "settings": {
     "react": {


### PR DESCRIPTION
After discussing with @sharonwarner we decided to remove alphabetical ordering rules from linter, because we prefer being able to group imports and variables by what makes sense.