### PR TITLE
Restore "Receive your benefits" tab link

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -71,7 +71,7 @@
   "tab0-list2-item2": "You are fully or partially unemployed. This includes layoffs, furloughs, reduced wages, or reduced hours. You can still receive unemployment benefits while working, depending on your pay.",
   "tab0-list2-item3": "Your child’s school is closed, and you need to miss work to care for them.",
   "tab0-list2-item4": "Your previous UI claim has expired.",
-  "tab0-p3": "If you're already receiving UI, review <1>Receive your benefits</1> to learn how your UI claim may be affected by COVID-19.",
+  "tab0-p3": "If you're already receiving UI, review <2>Receive your benefits</2> to learn how your UI claim may be affected by COVID-19.",
   "tab0-header4": "Pandemic Unemployment Assistance (PUA)",
   "tab0-p4": "If you are a business owner, independent contractor, self-employed worker, freelancer, or gig worker and only received a 1099 tax form last year, you are most likely eligible for PUA.",
   "tab0-header5": "Apply for PUA if your work situation changed because of COVID-19, and you meet <strong>any</strong> of these:",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -71,7 +71,7 @@
   "tab0-list2-item2": "Está completamente o parcialmente desempleado. Esto incluye despido, suspensión laboral sin sueldo (furlough), sueldos reducidos u horas reducidas. Usted puede seguir recibiendo beneficios de desempleo mientras sigue trabajando, dependiendo de su pago.",
   "tab0-list2-item3": "La escuela de su hijo está cerrada y debe faltar a su trabajo para cuidarlo.",
   "tab0-list2-item4": "La solicitud del UI anterior se ha expirado.",
-  "tab0-p3": "Si ya está recibiendo beneficios del UI, consulte <1>Reciba sus beneficios</1> para aprender cómo su solicitud del UI puede verse afectada por el COVID-19.",
+  "tab0-p3": "Si ya está recibiendo beneficios del UI, consulte <2>Reciba sus beneficios</2> para aprender cómo su solicitud del UI puede verse afectada por el COVID-19.",
   "tab0-header4": "Asistencia de Desempleo por la Pandemia (PUA)",
   "tab0-p4": "Si es dueño de un negocio, contratista independiente, persona que trabaja por cuenta propia, trabajador independiente o trabajador de la economía colaborativa y sólo recibió el Formulario 1099 el año pasado, probablemente sea elegible para PUA.",
   "tab0-header5": "Solicite PUA si su situación de trabajo cambió debido al COVID-19 y cumple con alguno de estos criterios:",

--- a/setupTestFramework.js
+++ b/setupTestFramework.js
@@ -22,9 +22,14 @@ jest.mock(
   { virtual: true }
 );
 
-jest.mock("react-router-dom", () => ({
-  useHistory: () => ({
-    push: jest.fn(),
-    listen: jest.fn(),
-  }),
-}));
+jest.mock("react-router-dom", () => {
+  const actual = jest.requireActual("react-router-dom");
+
+  return {
+    ...actual,
+    useHistory: () => ({
+      push: jest.fn(),
+      listen: jest.fn(),
+    }),
+  };
+});

--- a/src/client/components/TabPaneContent0/__snapshots__/index.test.js.snap
+++ b/src/client/components/TabPaneContent0/__snapshots__/index.test.js.snap
@@ -1,23 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<TabPaneContent0 /> renders the TabPaneContent component 1`] = `
-<TabPaneContent0
-  getTabLink={
-    [MockFunction] {
-      "calls": Array [
-        Array [
-          4,
-        ],
-      ],
-      "results": Array [
-        Object {
-          "type": "return",
-          "value": undefined,
-        },
-      ],
-    }
-  }
->
+<TabPaneContent0>
   <div>
     <div
       className="gray-box mt-0"
@@ -268,7 +252,22 @@ exports[`<TabPaneContent0 /> renders the TabPaneContent component 1`] = `
         t={[Function]}
       >
         If you're already receiving UI, review 
-        Receive your benefits
+        <Link
+          key="1"
+          to="/guide/receive-benefits"
+        >
+          <LinkAnchor
+            href="/guide/receive-benefits"
+            navigate={[Function]}
+          >
+            <a
+              href="/guide/receive-benefits"
+              onClick={[Function]}
+            >
+              Receive your benefits
+            </a>
+          </LinkAnchor>
+        </Link>
          to learn how your UI claim may be affected by COVID-19.
       </Trans>
     </p>

--- a/src/client/components/TabPaneContent0/index.js
+++ b/src/client/components/TabPaneContent0/index.js
@@ -1,10 +1,9 @@
 import { Trans, useTranslation } from "react-i18next";
-import PropTypes from "prop-types";
+import { Link } from "react-router-dom";
 import React from "react";
 
-function TabPaneContent0({ getTabLink }) {
+function TabPaneContent0() {
   const { t } = useTranslation();
-  const tabLink = getTabLink(4); // Receive your benefits
 
   return (
     <div>
@@ -92,13 +91,14 @@ function TabPaneContent0({ getTabLink }) {
         </li>
       </ul>
       <p>
-        <Trans t={t} i18nKey="tab0-p3" tabLink={tabLink}>
+        <Trans t={t} i18nKey="tab0-p3">
           {
             // The text in this <Trans> must *approximately* match translation.json
             // otherwise the link won't render.
           }
-          If you're already receiving UI, review {{ tabLink }} to learn how your
-          UI claim may be affected by COVID-19.
+          If you're already receiving UI, review{" "}
+          <Link to="/guide/receive-benefits">Receive your benefits</Link> to
+          learn how your UI claim may be affected by COVID-19.
         </Trans>
       </p>
       <h3>
@@ -186,9 +186,5 @@ function TabPaneContent0({ getTabLink }) {
     </div>
   );
 }
-
-TabPaneContent0.propTypes = {
-  getTabLink: PropTypes.func,
-};
 
 export default TabPaneContent0;

--- a/src/client/components/TabPaneContent0/index.test.js
+++ b/src/client/components/TabPaneContent0/index.test.js
@@ -3,10 +3,7 @@ import TabPaneContent from "./index";
 
 describe("<TabPaneContent0 />", () => {
   it("renders the TabPaneContent component", async () => {
-    const props = {
-      getTabLink: jest.fn(),
-    };
-    const content = renderTransContent(TabPaneContent, props);
+    const content = renderTransContent(TabPaneContent);
     expect(content).toMatchSnapshot();
   });
 });

--- a/src/client/components/TabbedContainer/__snapshots__/index.test.js.snap
+++ b/src/client/components/TabbedContainer/__snapshots__/index.test.js.snap
@@ -29,7 +29,14 @@ exports[`<TabbedContainer /> renders the component 1`] = `
               as={
                 Object {
                   "$$typeof": Symbol(react.forward_ref),
-                  "displayName": "SafeAnchor",
+                  "displayName": "Link",
+                  "propTypes": Object {
+                    "innerRef": [Function],
+                    "onClick": [Function],
+                    "replace": [Function],
+                    "target": [Function],
+                    "to": [Function],
+                  },
                   "render": [Function],
                 }
               }
@@ -50,7 +57,14 @@ exports[`<TabbedContainer /> renders the component 1`] = `
               as={
                 Object {
                   "$$typeof": Symbol(react.forward_ref),
-                  "displayName": "SafeAnchor",
+                  "displayName": "Link",
+                  "propTypes": Object {
+                    "innerRef": [Function],
+                    "onClick": [Function],
+                    "replace": [Function],
+                    "target": [Function],
+                    "to": [Function],
+                  },
                   "render": [Function],
                 }
               }
@@ -71,7 +85,14 @@ exports[`<TabbedContainer /> renders the component 1`] = `
               as={
                 Object {
                   "$$typeof": Symbol(react.forward_ref),
-                  "displayName": "SafeAnchor",
+                  "displayName": "Link",
+                  "propTypes": Object {
+                    "innerRef": [Function],
+                    "onClick": [Function],
+                    "replace": [Function],
+                    "target": [Function],
+                    "to": [Function],
+                  },
                   "render": [Function],
                 }
               }
@@ -92,7 +113,14 @@ exports[`<TabbedContainer /> renders the component 1`] = `
               as={
                 Object {
                   "$$typeof": Symbol(react.forward_ref),
-                  "displayName": "SafeAnchor",
+                  "displayName": "Link",
+                  "propTypes": Object {
+                    "innerRef": [Function],
+                    "onClick": [Function],
+                    "replace": [Function],
+                    "target": [Function],
+                    "to": [Function],
+                  },
                   "render": [Function],
                 }
               }
@@ -113,7 +141,14 @@ exports[`<TabbedContainer /> renders the component 1`] = `
               as={
                 Object {
                   "$$typeof": Symbol(react.forward_ref),
-                  "displayName": "SafeAnchor",
+                  "displayName": "Link",
+                  "propTypes": Object {
+                    "innerRef": [Function],
+                    "onClick": [Function],
+                    "replace": [Function],
+                    "target": [Function],
+                    "to": [Function],
+                  },
                   "render": [Function],
                 }
               }
@@ -134,7 +169,14 @@ exports[`<TabbedContainer /> renders the component 1`] = `
               as={
                 Object {
                   "$$typeof": Symbol(react.forward_ref),
-                  "displayName": "SafeAnchor",
+                  "displayName": "Link",
+                  "propTypes": Object {
+                    "innerRef": [Function],
+                    "onClick": [Function],
+                    "replace": [Function],
+                    "target": [Function],
+                    "to": [Function],
+                  },
                   "render": [Function],
                 }
               }
@@ -154,8 +196,8 @@ exports[`<TabbedContainer /> renders the component 1`] = `
         sm={8}
       >
         <ForwardRef>
-          <Component>
-            <Component
+          <Switch>
+            <Route
               key="0"
               path="/guide/benefits"
             >
@@ -168,6 +210,20 @@ exports[`<TabbedContainer /> renders the component 1`] = `
               <TabPaneContent0 />
               <Button
                 active={false}
+                as={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Link",
+                    "propTypes": Object {
+                      "innerRef": [Function],
+                      "onClick": [Function],
+                      "replace": [Function],
+                      "target": [Function],
+                      "to": [Function],
+                    },
+                    "render": [Function],
+                  }
+                }
                 disabled={false}
                 onClick={[Function]}
                 to="/guide/before-you-apply"
@@ -176,8 +232,8 @@ exports[`<TabbedContainer /> renders the component 1`] = `
               >
                 Next: What you need before you apply
               </Button>
-            </Component>
-            <Component
+            </Route>
+            <Route
               key="1"
               path="/guide/before-you-apply"
             >
@@ -190,6 +246,20 @@ exports[`<TabbedContainer /> renders the component 1`] = `
               <TabPaneContent1 />
               <Button
                 active={false}
+                as={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Link",
+                    "propTypes": Object {
+                      "innerRef": [Function],
+                      "onClick": [Function],
+                      "replace": [Function],
+                      "target": [Function],
+                      "to": [Function],
+                    },
+                    "render": [Function],
+                  }
+                }
                 disabled={false}
                 onClick={[Function]}
                 to="/guide/how-to-apply"
@@ -198,8 +268,8 @@ exports[`<TabbedContainer /> renders the component 1`] = `
               >
                 Next: How to apply
               </Button>
-            </Component>
-            <Component
+            </Route>
+            <Route
               key="2"
               path="/guide/how-to-apply"
             >
@@ -212,6 +282,20 @@ exports[`<TabbedContainer /> renders the component 1`] = `
               <TabPaneContent2 />
               <Button
                 active={false}
+                as={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Link",
+                    "propTypes": Object {
+                      "innerRef": [Function],
+                      "onClick": [Function],
+                      "replace": [Function],
+                      "target": [Function],
+                      "to": [Function],
+                    },
+                    "render": [Function],
+                  }
+                }
                 disabled={false}
                 onClick={[Function]}
                 to="/guide/after-you-submit"
@@ -220,8 +304,8 @@ exports[`<TabbedContainer /> renders the component 1`] = `
               >
                 Next: After you submit your application
               </Button>
-            </Component>
-            <Component
+            </Route>
+            <Route
               key="3"
               path="/guide/after-you-submit"
             >
@@ -234,6 +318,20 @@ exports[`<TabbedContainer /> renders the component 1`] = `
               <TabPaneContent3 />
               <Button
                 active={false}
+                as={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Link",
+                    "propTypes": Object {
+                      "innerRef": [Function],
+                      "onClick": [Function],
+                      "replace": [Function],
+                      "target": [Function],
+                      "to": [Function],
+                    },
+                    "render": [Function],
+                  }
+                }
                 disabled={false}
                 onClick={[Function]}
                 to="/guide/receive-benefits"
@@ -242,8 +340,8 @@ exports[`<TabbedContainer /> renders the component 1`] = `
               >
                 Next: Receive your benefits
               </Button>
-            </Component>
-            <Component
+            </Route>
+            <Route
               key="4"
               path="/guide/receive-benefits"
             >
@@ -256,6 +354,20 @@ exports[`<TabbedContainer /> renders the component 1`] = `
               <TabPaneContent4 />
               <Button
                 active={false}
+                as={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Link",
+                    "propTypes": Object {
+                      "innerRef": [Function],
+                      "onClick": [Function],
+                      "replace": [Function],
+                      "target": [Function],
+                      "to": [Function],
+                    },
+                    "render": [Function],
+                  }
+                }
                 disabled={false}
                 onClick={[Function]}
                 to="/guide/more-resources"
@@ -264,8 +376,8 @@ exports[`<TabbedContainer /> renders the component 1`] = `
               >
                 Next: More resources
               </Button>
-            </Component>
-            <Component
+            </Route>
+            <Route
               key="5"
               path="/guide/more-resources"
             >
@@ -276,12 +388,12 @@ exports[`<TabbedContainer /> renders the component 1`] = `
                 More resources
               </h2>
               <TabPaneContent5 />
-            </Component>
-            <Component
+            </Route>
+            <Redirect
               from="/"
               to="/guide/benefits"
             />
-          </Component>
+          </Switch>
         </ForwardRef>
       </Col>
     </Row>

--- a/src/client/components/TabbedContainer/__snapshots__/index.test.js.snap
+++ b/src/client/components/TabbedContainer/__snapshots__/index.test.js.snap
@@ -165,9 +165,7 @@ exports[`<TabbedContainer /> renders the component 1`] = `
               <h2>
                 Start here
               </h2>
-              <TabPaneContent0
-                getTabLink={[Function]}
-              />
+              <TabPaneContent0 />
               <Button
                 active={false}
                 disabled={false}
@@ -189,9 +187,7 @@ exports[`<TabbedContainer /> renders the component 1`] = `
               <h2>
                 What you need before you apply
               </h2>
-              <TabPaneContent1
-                getTabLink={[Function]}
-              />
+              <TabPaneContent1 />
               <Button
                 active={false}
                 disabled={false}
@@ -213,9 +209,7 @@ exports[`<TabbedContainer /> renders the component 1`] = `
               <h2>
                 How to apply
               </h2>
-              <TabPaneContent2
-                getTabLink={[Function]}
-              />
+              <TabPaneContent2 />
               <Button
                 active={false}
                 disabled={false}
@@ -237,9 +231,7 @@ exports[`<TabbedContainer /> renders the component 1`] = `
               <h2>
                 After you submit your application
               </h2>
-              <TabPaneContent3
-                getTabLink={[Function]}
-              />
+              <TabPaneContent3 />
               <Button
                 active={false}
                 disabled={false}
@@ -261,9 +253,7 @@ exports[`<TabbedContainer /> renders the component 1`] = `
               <h2>
                 Receive your benefits
               </h2>
-              <TabPaneContent4
-                getTabLink={[Function]}
-              />
+              <TabPaneContent4 />
               <Button
                 active={false}
                 disabled={false}
@@ -285,9 +275,7 @@ exports[`<TabbedContainer /> renders the component 1`] = `
               <h2>
                 More resources
               </h2>
-              <TabPaneContent5
-                getTabLink={[Function]}
-              />
+              <TabPaneContent5 />
             </Component>
             <Component
               from="/"

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -90,7 +90,8 @@ function TabbedContainer() {
       }
 
       // Don't scroll down to the top of the sidebar on initial page load
-      if (initialPageLoad.current) {
+      // unless it's loading a secondary page
+      if (initialPageLoad.current && tabIndex === 0) {
         initialPageLoad.current = false;
         return;
       }
@@ -108,17 +109,6 @@ function TabbedContainer() {
 
   function getTabTitle(tabIndex) {
     return t("tabTitles." + tabIndex);
-  }
-
-  function getTabLink(tabIndex) {
-    return (
-      <Link
-        to={prefix + tabSlugs[tabIndex]}
-        onClick={() => setActiveTabIndex(tabIndex)}
-      >
-        {getTabTitle(tabIndex)}
-      </Link>
-    );
   }
 
   const renderNextButton = (tabIndex) => {
@@ -170,7 +160,7 @@ function TabbedContainer() {
                     <Route path={prefix + value} key={index}>
                       <TabPaneContentOnMount tabIndex={index} />
                       <h2>{getTabTitle(index)}</h2>
-                      <TabPaneContentTagName getTabLink={getTabLink} />
+                      <TabPaneContentTagName />
                       {renderNextButton(index)}
                     </Route>
                   );

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -90,7 +90,6 @@ function TabbedContainer() {
       }
 
       // Don't scroll down to the top of the sidebar on initial page load
-      // unless it's loading a secondary page
       if (initialPageLoad.current) {
         initialPageLoad.current = false;
         return;

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -91,7 +91,7 @@ function TabbedContainer() {
 
       // Don't scroll down to the top of the sidebar on initial page load
       // unless it's loading a secondary page
-      if (initialPageLoad.current && tabIndex === 0) {
+      if (initialPageLoad.current) {
         initialPageLoad.current = false;
         return;
       }

--- a/src/client/test-helpers/renderTransContent.js
+++ b/src/client/test-helpers/renderTransContent.js
@@ -1,13 +1,16 @@
 import React from "react";
+import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
 import { I18nextProvider } from "react-i18next";
 import i18n from "./i18nForTests";
 
 function renderTransContent(Component, props = {}) {
   const wrapper = mount(
-    <I18nextProvider i18n={i18n}>
-      <Component {...props} />
-    </I18nextProvider>
+    <MemoryRouter>
+      <I18nextProvider i18n={i18n}>
+        <Component {...props} />
+      </I18nextProvider>
+    </MemoryRouter>
   );
 
   // Filter out the very verbose I18nextProvider component wrapper


### PR DESCRIPTION
This PR restores the "Receive your benefits" tab link

Fixing it directly by replacing {{tabLink}} with {tabLink} results in a console warning from i18next-react when generating snapshots (`react-i18next:: Trans: the passed in value is invalid`), so I refactored the code to remove the getTabLink functionality (which hasn't been necessary since we started using real URLs instead of hashes) and simplify the code.

This PR also un-mocks react-router-dom functions other than useHistory, which was the only function that should have been mocked. Without that fix, enzyme fails on this PR. The un-mocking also resolves #129.

===

Resolves #196
Resolves #129

- [x] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
