### PR TITLE
Save query param when click links.

### DIFF
--- a/setupTestFramework.js
+++ b/setupTestFramework.js
@@ -31,5 +31,12 @@ jest.mock("react-router-dom", () => {
       push: jest.fn(),
       listen: jest.fn(),
     }),
+    useLocation: () => ({
+      pathname: '',
+      search: '',
+      hash: '',
+      state: null,
+      key: '',
+    }),
   };
 });

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -1,4 +1,4 @@
-import { Link, Redirect, Route, Switch, useHistory } from "react-router-dom";
+import { Link, Redirect, Route, Switch, useHistory, useLocation } from "react-router-dom";
 import React, { useEffect, useRef, useState } from "react";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
@@ -70,11 +70,13 @@ function TabbedContainer() {
     // WAI-ARIA: "It is recommended that tabs activate automatically when
     // they receive focus as long as their associated tab panels are displayed
     // without noticeable latency."
-    history.push(prefix + tabSlugs[targetTabIndex]);
+    history.push(prefix + tabSlugs[targetTabIndex] + queryParams);
   };
 
   const tabbedContainer = useRef(null);
   const prefix = "/guide/";
+  const queryParams = useLocation().search;
+
   const initialPageLoad = useRef(true);
   const history = useHistory();
   history.listen((location) => logPage(location.pathname));
@@ -119,7 +121,7 @@ function TabbedContainer() {
       <Button
         variant="secondary"
         as={Link}
-        to={prefix + tabSlugs[nextTabIndex]}
+        to={prefix + tabSlugs[nextTabIndex] + queryParams}
         onClick={() => setActiveTabIndex(nextTabIndex)}
       >
         {t("buttonNextPrefix") + getTabTitle(nextTabIndex)}
@@ -139,7 +141,7 @@ function TabbedContainer() {
                     <Nav.Link
                       as={Link}
                       eventKey={index}
-                      to={prefix + value}
+                      to={prefix + value + queryParams}
                       onClick={() => setActiveTabIndex(index)}
                       onKeyDown={(event) => handleKeyDown(event, index)}
                     >
@@ -164,7 +166,7 @@ function TabbedContainer() {
                     </Route>
                   );
                 })}
-                <Redirect from="/" to={prefix + tabSlugs[initialTabIndex]} />
+                <Redirect from="/" to={prefix + tabSlugs[initialTabIndex] + queryParams} />
               </Switch>
             </Tab.Content>
           </Col>


### PR DESCRIPTION
This allows us to keep the language param
when the user navigates within the app.

Fixes #204

Write a description of the changes proposed in this pull request. Include images/GIFs if relevant for reviewers. Try Fireshot (Chrome, Firefox) for full-page screenshots and LICEcap (macOS) for GIFs.

Before submitting the PR for review, consider the checklist below and check off any completed items

===

Resolves #XXX

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [X] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
