### PR TITLE
Make buttons bold

### DIFF
--- a/src/client/App.scss
+++ b/src/client/App.scss
@@ -57,6 +57,10 @@ a {
 	text-decoration: none;
 }
 
+.btn:not(.dropdown-toggle) {
+	font-weight: bold;
+}
+
 // Eliminate whitespace overflow on right half of mobile viewport
 // None of the usual solutions are compatible with sticky elements
 // But this solution is: https://stackoverflow.com/a/59019025/6074728

--- a/src/client/App.scss
+++ b/src/client/App.scss
@@ -57,7 +57,7 @@ a {
 	text-decoration: none;
 }
 
-.btn:not(.dropdown-toggle) {
+.btn {
 	font-weight: bold;
 }
 


### PR DESCRIPTION
This PR makes buttons bold, in-line with USWDS guidelines, and it makes buttons look more clickable!

Ignore the lack of sidebar, that's an issue with the screenshot extension:
![086 - Guide to applying for unemployment benefits - localhost](https://user-images.githubusercontent.com/82277/82499409-9f48c980-9abf-11ea-9f8b-9bf6d33e765a.jpg)

===

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
