### PR TITLE
Creates routes for all the guide pages

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -176,5 +176,7 @@
   "tab5-p5": "<strong>This provides an additional $600 per week</strong> to people receiving UI benefits. It is retroactive for claims between March 29 and July 25, 2020. This $600 benefit is issued every two weeks. You will receive it at the same time as your UI or PUA benefits.",
   "tab5-header5": "Pandemic Emergency Unemployment Compensation (PEUC)",
   "tab5-p6": "<strong>This provides an additional 13 weeks of benefits</strong> for people receiving UI benefits between March 29 and December 26, 2020. California provides up to 26 weeks of UI benefits depending on the amount of your earnings during the four-quarter period on which your claim is based. The CARES Act extends benefits to a total of 39 weeks.",
-  "tab5-blockquote1": "<strong>Note:</strong> We are still working to implement the PEUC program. Please continue to monitor our website for instructions on next steps for the PEUC program."
+  "tab5-blockquote1": "<strong>Note:</strong> We are still working to implement the PEUC program. Please continue to monitor our website for instructions on next steps for the PEUC program.",
+  "page-not-found-header": "Page Not Found",
+  "page-not-found-text": "The page or form you requested cannot be found. If your link worked before but does not work now, then this page has moved or was deleted as part of our ongoing efforts to make our website work better for you."
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -177,5 +177,7 @@
   "tab5-p5": "<strong>Esto proporciona $600 adicionales por semana</strong> para las personas que están recibiendo beneficios del UI. Es retroactivo para las solicitudes presentadas entre el 29 de marzo y el 25 de julio de 2020. Este beneficio de $600 se emite cada dos semanas. Lo recibirá al mismo tiempo que sus beneficios de UI o PUA.",
   "tab5-header5": "Compensación de Desempleo de Emergencia por la Pandemia (PEUC)",
   "tab5-p6": "<strong>Esto le da 13 semanas adicionales de beneficios</strong> para las personas que están recibiendo beneficios del UI entre el 29 de marzo y el 26 de diciembre de 2020. California le da hasta 26 semanas de beneficios del UI dependiendo de la cantidad de sus ingresos durante el periodo de cuatro trimestres en los que se basa su solicitud. La Ley CARES alarga los beneficios a un total de 39 semanas.",
-  "tab5-blockquote1": "<strong>Nota:</strong> Aún estamos trabajando en la implementación del programa PEUC. Por favor continúe revisando nuestro sitio web para ver instrucciones sobre los próximos pasos para el programa PEUC."
+  "tab5-blockquote1": "<strong>Nota:</strong> Aún estamos trabajando en la implementación del programa PEUC. Por favor continúe revisando nuestro sitio web para ver instrucciones sobre los próximos pasos para el programa PEUC.",
+  "page-not-found-header": "Page Not Found",
+  "page-not-found-text": "The page or form you requested cannot be found. If your link worked before but does not work now, then this page has moved or was deleted as part of our ongoing efforts to make our website work better for you."
 }

--- a/src/client/App.js
+++ b/src/client/App.js
@@ -1,10 +1,33 @@
 import React, { Suspense } from "react";
+import { Switch, Route } from "react-router-dom";
 import GuidePage from "./pages/GuidePage";
+import PageNotFound from "./pages/PageNotFound";
+import RedirectToGuide from "./pages/RedirectToGuide";
+import routes from "../data/routes";
+
+// Allow us to map back from the name of a page component
+// (declared in routes) to the actual page component.
+const pages = {
+  "GuidePage": GuidePage,
+  "RedirectToGuide": RedirectToGuide
+};
 
 export default function App() {
   return (
     <Suspense fallback="Loading...">
-      <GuidePage />
+      <Switch>
+        {Object.values(routes).map(route => {
+          const PageComponent = pages[route.component];
+          return (
+            <Route key={route.path} path={route.path} exact>
+              <PageComponent />
+            </Route>
+          );
+        })}
+        <Route>
+          <PageNotFound />
+        </Route>
+      </Switch>
     </Suspense>
   );
 }

--- a/src/client/__snapshots__/App.test.js.snap
+++ b/src/client/__snapshots__/App.test.js.snap
@@ -4,6 +4,73 @@ exports[`<App /> renders application 1`] = `
 <Suspense
   fallback="Loading..."
 >
-  <GuidePage />
+  <Switch>
+    <Route
+      exact={true}
+      key="/guide"
+      path="/guide"
+    >
+      <GuidePage />
+    </Route>
+    <Route
+      exact={true}
+      key="/guide/benefits"
+      path="/guide/benefits"
+    >
+      <GuidePage />
+    </Route>
+    <Route
+      exact={true}
+      key="/guide/before-you-apply"
+      path="/guide/before-you-apply"
+    >
+      <GuidePage />
+    </Route>
+    <Route
+      exact={true}
+      key="/guide/how-to-apply"
+      path="/guide/how-to-apply"
+    >
+      <GuidePage />
+    </Route>
+    <Route
+      exact={true}
+      key="/guide/after-you-submit"
+      path="/guide/after-you-submit"
+    >
+      <GuidePage />
+    </Route>
+    <Route
+      exact={true}
+      key="/guide/receive-benefits"
+      path="/guide/receive-benefits"
+    >
+      <GuidePage />
+    </Route>
+    <Route
+      exact={true}
+      key="/guide/more-resources"
+      path="/guide/more-resources"
+    >
+      <GuidePage />
+    </Route>
+    <Route
+      exact={true}
+      key="/"
+      path="/"
+    >
+      <RedirectToGuide />
+    </Route>
+    <Route
+      exact={true}
+      key="/guide/"
+      path="/guide/"
+    >
+      <RedirectToGuide />
+    </Route>
+    <Route>
+      <PageNotFound />
+    </Route>
+  </Switch>
 </Suspense>
 `;

--- a/src/client/pages/PageNotFound/__snapshots__/index.test.js.snap
+++ b/src/client/pages/PageNotFound/__snapshots__/index.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<PageNotFound /> renders a 404 page 1`] = `
+<div
+  id="overflow-wrapper"
+>
+  <Header />
+  <main>
+    <div
+      className="container p-4"
+    >
+      <h1>
+        Page Not Found
+      </h1>
+      <p>
+        The page or form you requested cannot be found. If your link worked before but does not work now, then this page has moved or was deleted as part of our ongoing efforts to make our website work better for you.
+      </p>
+    </div>
+  </main>
+  <Footer />
+</div>
+`;

--- a/src/client/pages/PageNotFound/index.js
+++ b/src/client/pages/PageNotFound/index.js
@@ -1,0 +1,23 @@
+import { useTranslation } from "react-i18next";
+import React from "react";
+import Footer from "../../components/Footer";
+import Header from "../../components/Header";
+
+function PageNotFound() {
+  const { t } = useTranslation();
+
+  return (
+    <div id="overflow-wrapper">
+      <Header />
+      <main>
+        <div className="container p-4">
+          <h1>{t("page-not-found-header")}</h1>
+          <p>{t("page-not-found-text")}</p>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}
+
+export default PageNotFound;

--- a/src/client/pages/PageNotFound/index.test.js
+++ b/src/client/pages/PageNotFound/index.test.js
@@ -1,0 +1,10 @@
+import renderNonTransContent from "../../test-helpers/renderNonTransContent";
+import Component from "./index";
+
+describe("<PageNotFound />", () => {
+  it("renders a 404 page", async () => {
+    const wrapper = renderNonTransContent(Component, "PageNotFound");
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/client/pages/RedirectToGuide/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RedirectToGuide/__snapshots__/index.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<RedirectToGuide /> renders a redirect to the guide 1`] = `<RedirectToGuide />`;

--- a/src/client/pages/RedirectToGuide/index.js
+++ b/src/client/pages/RedirectToGuide/index.js
@@ -1,0 +1,8 @@
+import React from "react";
+import { Redirect } from "react-router-dom";
+
+function RedirectToGuide() {
+  return <Redirect to="/guide/benefits" />;
+}
+
+export default RedirectToGuide;

--- a/src/client/pages/RedirectToGuide/index.test.js
+++ b/src/client/pages/RedirectToGuide/index.test.js
@@ -1,0 +1,8 @@
+import React from "react";
+import Component from "./index";
+
+describe("<RedirectToGuide />", () => {
+  it("renders a redirect to the guide", async () => {
+    expect(<Component />).toMatchSnapshot();
+  });
+});

--- a/src/data/routes.js
+++ b/src/data/routes.js
@@ -5,9 +5,41 @@
  * the single page app (`client/App.js`).
  */
 const routes = {
+  guide: {
+    path: "/guide",
+    component: "GuidePage"
+  },
+  guideBenefits: {
+    path: "/guide/benefits",
+    component: "GuidePage"
+  },
+  guideBeforeYouApply: {
+    path: "/guide/before-you-apply",
+    component: "GuidePage"
+  },
+  guideHowToApply: {
+    path: "/guide/how-to-apply",
+    component: "GuidePage"
+  },
+  guideAfterYouSubmit: {
+    path: "/guide/after-you-submit",
+    component: "GuidePage"
+  },
+  guideReceiveBenefits: {
+    path: "/guide/receive-benefits",
+    component: "GuidePage"
+  },
+  guideReceiveMoreResources: {
+    path: "/guide/more-resources",
+    component: "GuidePage"
+  },
   home: {
-    path: "/guide"
-    // We exclude the Home `component` so we can manually import it into pages/index.js
+    path: "/",
+    component: "RedirectToGuide"
+  },
+  guideSlash: {
+    path: "/guide/",
+    component: "RedirectToGuide"
   }
 };
 

--- a/src/routes/single-page-app.js
+++ b/src/routes/single-page-app.js
@@ -13,15 +13,12 @@ const singlePageAppRouter = Router();
 singlePageAppRouter.get("/*", (req, res) => {
   const cssURL = getCdnPath(`/build/css/${manifestStyles["App.css"]}`);
 
-  const shouldRedirect = !Object.values(pageRoutes)
-    .map((r) => r.path)
-    .some(path => req.path.startsWith(path))
-  if (shouldRedirect) {
-    res.status(301).location(pageRoutes.home.path).send();
-    return;
-  }
+  const is404 = !Object.values(pageRoutes)
+    .map(r => r.path)
+    .includes(req.path);
+  const statusCode = is404 ? 404 : 200;
 
-  res.status(200).send(
+  res.status(statusCode).send(
     `<!doctype html>
     <html lang="en">
     <head>

--- a/src/routes/single-page-app.test.js
+++ b/src/routes/single-page-app.test.js
@@ -27,10 +27,17 @@ describe("Router: Single page app", () => {
     expect(res.text).toMatch(/<html/);
   });
 
-  it("/ returns 301 status code", async () => {
+  it("/ uses <Redirect> to go to the guide", async () => {
     const res = await request(server).get("/");
 
-    expect(res.status).toBe(301);
-    expect(res.get('Location')).toBe('/guide');
+    expect(res.status).toBe(200);
+    expect(res.text).toMatch(/<html/);
+  });
+
+  it("/does-not-exist returns 404 status code", async () => {
+    const res = await request(server).get("/does-not-exist");
+
+    expect(res.status).toBe(404);
+    expect(res.text).toMatch(/<html/);
   });
 });


### PR DESCRIPTION
We declare all the known paths in src/data/routes.js (shared by
both the client and the server). If the path isn't in routes.js,
the server returns a 404. In the client, we use a <Switch> to
load the correct path.
    
This does change user behavior because it introduces the 404 page.
Previously, we redirected everything to the guide, but now we
show a 404 page except for / and /guide/, which both get redirected
to /guide/benefits.

I tried to run lighthouse on the 404 page, but [apparently that doesn't work](https://github.com/GoogleChrome/lighthouse/issues/10493).

===

Resolves #227 

- [X] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [X] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [X] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [X] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [X] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
