### PR TITLE
Add fflip for feature flags.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8023,6 +8023,11 @@
       "resolved": "https://registry.npmjs.org/feature-policy/-/feature-policy-0.3.0.tgz",
       "integrity": "sha512-ZtijOTFN7TzCujt1fnNhfWPFPSHeZkesff9AXZj+UEjYBynWNUIYpC87Ve4wHzyexQsImicLu7WsC2LHq7/xrQ=="
     },
+    "fflip": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fflip/-/fflip-4.0.0.tgz",
+      "integrity": "sha1-Q/bAoetkF+LXRdnlQrWL9t+W2Bw="
+    },
     "figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "core-js": "^3.6.5",
         "dotenv": "^8.2.0",
         "express": "^4.17.1",
+        "fflip": "^4.0.0",
         "helmet": "^3.21.2",
         "i18next-browser-languagedetector": "^4.1.1",
         "i18next-http-backend": "^1.0.9",

--- a/src/data/fflipConfig.js
+++ b/src/data/fflipConfig.js
@@ -1,0 +1,14 @@
+/**
+ * Feature and experiment flags.
+ * https://github.com/FredKSchott/fflip
+ */
+const fflipConfig = {
+  features: [{
+    id: "retroCerts",
+    description: "Allows users to retroactively certify.",
+    enabled: false
+  }],
+  criteria: []
+};
+
+module.exports = fflipConfig;


### PR DESCRIPTION
This just adds the package and creates the
config file for the retro-certs package. No
functionality change.

===

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [X] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [X] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
