### PR TITLE
PEUC content workaround 

### DIFF
--- a/src/client/components/TabPaneContent5/__snapshots__/index.test.js.snap
+++ b/src/client/components/TabPaneContent5/__snapshots__/index.test.js.snap
@@ -127,19 +127,14 @@ exports[`<TabPaneContent5 /> renders the TabPaneContent component 1`] = `
     <div
       className="highlight-blockquote"
     >
-      <Trans
-        i18nKey="tab5-blockquote1"
-        t={[Function]}
+      For more information, visit
+       
+      <a
+        href="http://https://edd.ca.gov/about_edd/coronavirus-2019/cares-act.htm"
       >
-        For more information, visit 
-        <a
-          href="https://edd.ca.gov/about_edd/coronavirus-2019/cares-act.htm"
-          key="1"
-        >
-          CARES Act Provisions
-          .
-        </a>
-      </Trans>
+        CARES Act Provisions
+      </a>
+      .
     </div>
   </div>
 </TabPaneContent5>

--- a/src/client/components/TabPaneContent5/index.js
+++ b/src/client/components/TabPaneContent5/index.js
@@ -57,10 +57,11 @@ function TabPaneContent5() {
         <Trans t={t} i18nKey="tab5-p6" />
       </p>
       <div className="highlight-blockquote">
-        <Trans t={t} i18nKey="tab5-blockquote1">
-          For more information, visit{" "}
-          <a href={t("links.edd-cares")}>CARES Act Provisions</a>.
-        </Trans>
+        For more information, visit{" "}
+        <a href="http://https://edd.ca.gov/about_edd/coronavirus-2019/cares-act.htm">
+          CARES Act Provisions
+        </a>
+        .
       </div>
     </div>
   );


### PR DESCRIPTION
Since we have an issue on production that prevents this link from appearing properly when using translations.json, this PR hardcodes it as a temporary workaround

===

- [x] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
