### PR TITLE
Add the feature flag handling to the client JS.

### DIFF
--- a/src/client/App.js
+++ b/src/client/App.js
@@ -1,18 +1,30 @@
 import React, { Suspense } from "react";
 import { Switch, Route } from "react-router-dom";
+import fflip from "fflip";
 import GuidePage from "./pages/GuidePage";
 import PageNotFound from "./pages/PageNotFound";
 import RedirectToGuide from "./pages/RedirectToGuide";
+import RetroCertsPage from "./pages/RetroCertsPage";
 import routes from "../data/routes";
+import fflipConfig from "../data/fflipConfig";
 
-// Allow us to map back from the name of a page component
-// (declared in routes) to the actual page component.
-const pages = {
-  "GuidePage": GuidePage,
-  "RedirectToGuide": RedirectToGuide
-};
+// Load default feature flag values.
+fflip.config(fflipConfig);
 
 export default function App() {
+  if (process.env.NODE_ENV === "development"
+      || String(process.env.ENABLE_RETRO_CERTS) === "1") {
+    fflip.features.retroCerts.enabled = true;
+  }
+
+  // Allow us to map back from the name of a page component
+  // (declared in routes) to the actual page component.
+  const pages = {
+    "GuidePage": GuidePage,
+    "RedirectToGuide": RedirectToGuide,
+    "RetroCertsPage": fflip.features.retroCerts.enabled ? RetroCertsPage : PageNotFound
+  };
+
   return (
     <Suspense fallback="Loading...">
       <Switch>

--- a/src/client/App.test.js
+++ b/src/client/App.test.js
@@ -1,9 +1,18 @@
 import App from "./App";
 import React from "react";
 import { shallow } from "enzyme";
+import fflip from "fflip";
 
 describe("<App />", () => {
-  it("renders application", () => {
+  it("renders application without retro-certs", () => {
+    fflip.features.retroCerts.enabled = false;
+    const wrapper = shallow(<App />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("renders application with retro-certs", () => {
+    fflip.features.retroCerts.enabled = true;
     const wrapper = shallow(<App />);
 
     expect(wrapper).toMatchSnapshot();

--- a/src/client/__snapshots__/App.test.js.snap
+++ b/src/client/__snapshots__/App.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<App /> renders application 1`] = `
+exports[`<App /> renders application with retro-certs 1`] = `
 <Suspense
   fallback="Loading..."
 >
@@ -17,6 +17,43 @@ exports[`<App /> renders application 1`] = `
       path="/guide"
     >
       <GuidePage />
+    </Route>
+    <Route
+      key="/retroactive-certification"
+      path="/retroactive-certification"
+    >
+      <RetroCertsPage />
+    </Route>
+    <Route>
+      <PageNotFound />
+    </Route>
+  </Switch>
+</Suspense>
+`;
+
+exports[`<App /> renders application without retro-certs 1`] = `
+<Suspense
+  fallback="Loading..."
+>
+  <Switch>
+    <Route
+      exact={true}
+      key="/"
+      path="/"
+    >
+      <RedirectToGuide />
+    </Route>
+    <Route
+      key="/guide"
+      path="/guide"
+    >
+      <GuidePage />
+    </Route>
+    <Route
+      key="/retroactive-certification"
+      path="/retroactive-certification"
+    >
+      <PageNotFound />
     </Route>
     <Route>
       <PageNotFound />

--- a/src/client/pages/RetroCertsPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsPage/__snapshots__/index.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<RetroCertsPage /> renders the retro certs main page 1`] = `
+<div
+  id="overflow-wrapper"
+>
+  <Header />
+  <main>
+    <div
+      className="container p-4"
+    >
+      <h1>
+        Retroactive Certifications
+      </h1>
+    </div>
+  </main>
+  <Footer />
+</div>
+`;

--- a/src/client/pages/RetroCertsPage/index.js
+++ b/src/client/pages/RetroCertsPage/index.js
@@ -1,0 +1,19 @@
+import React from "react";
+import Footer from "../../components/Footer";
+import Header from "../../components/Header";
+
+function RetroCertsPage() {
+  return (
+    <div id="overflow-wrapper">
+      <Header />
+      <main>
+        <div className="container p-4">
+          <h1>Retroactive Certifications</h1>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}
+
+export default RetroCertsPage;

--- a/src/client/pages/RetroCertsPage/index.test.js
+++ b/src/client/pages/RetroCertsPage/index.test.js
@@ -1,0 +1,10 @@
+import renderNonTransContent from "../../test-helpers/renderNonTransContent";
+import Component from "./index";
+
+describe("<RetroCertsPage />", () => {
+  it("renders the retro certs main page", async () => {
+    const wrapper = renderNonTransContent(Component, "RetroCertsPage");
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/data/routes.js
+++ b/src/data/routes.js
@@ -15,6 +15,10 @@ const routes = {
   guide: {
     path: "/guide",
     component: "GuidePage"
+  },
+  retroCerts: {
+    path: "/retroactive-certification",
+    component: "RetroCertsPage"
   }
 };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -112,6 +112,7 @@ if (!IS_DEV) {
     // Define process.env.NODE_ENV for optimized React bundles
     new webpack.DefinePlugin({
       "process.env.NODE_ENV": JSON.stringify(env),
+      "process.env.ENABLE_RETRO_CERTS": process.env.ENABLE_RETRO_CERTS,
     }),
     new webpack.optimize.AggressiveMergingPlugin(),
   ];


### PR DESCRIPTION
In development or if ENABLE_RETRO_CERTS=1 is set at
webpack time (before running npm run build), show the
placeholder RetroCertsPage. Otherwise, show the
PageNotFound page.

Test locally by going to localhost:3000/retroactive-certification in dev or from a prod build.

===

Resolves #XXX

- [X] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
