### PR TITLE
Switch from a build time flag to domain checking.

### DIFF
--- a/src/client/App.js
+++ b/src/client/App.js
@@ -9,14 +9,14 @@ import routes from "../data/routes";
 
 export default function App(props) {
   const hostname = props.hostname || window.location.hostname
-  const retroCertsEnabled = hostname !== "unemployment.edd.ca.gov";
+  const isProduction = hostname === "unemployment.edd.ca.gov";
 
   // Allow us to map back from the name of a page component
   // (declared in routes) to the actual page component.
   const pages = {
     "GuidePage": GuidePage,
     "RedirectToGuide": RedirectToGuide,
-    "RetroCertsPage": retroCertsEnabled ? RetroCertsAuthPage : PageNotFound
+    "RetroCertsPage": isProduction ? PageNotFound : RetroCertsAuthPage
   };
 
   return (

--- a/src/client/App.js
+++ b/src/client/App.js
@@ -1,28 +1,22 @@
 import React, { Suspense } from "react";
 import { Switch, Route } from "react-router-dom";
-import fflip from "fflip";
+import PropTypes from 'prop-types'
 import GuidePage from "./pages/GuidePage";
 import PageNotFound from "./pages/PageNotFound";
 import RedirectToGuide from "./pages/RedirectToGuide";
 import RetroCertsAuthPage from "./pages/RetroCertsAuthPage";
 import routes from "../data/routes";
-import fflipConfig from "../data/fflipConfig";
 
-// Load default feature flag values.
-fflip.config(fflipConfig);
-
-export default function App() {
-  if (process.env.NODE_ENV === "development"
-      || String(process.env.ENABLE_RETRO_CERTS) === "1") {
-    fflip.features.retroCerts.enabled = true;
-  }
+export default function App(props) {
+  const hostname = props.hostname || window.location.hostname
+  const retroCertsEnabled = hostname !== "unemployment.edd.ca.gov";
 
   // Allow us to map back from the name of a page component
   // (declared in routes) to the actual page component.
   const pages = {
     "GuidePage": GuidePage,
     "RedirectToGuide": RedirectToGuide,
-    "RetroCertsPage": fflip.features.retroCerts.enabled ? RetroCertsAuthPage : PageNotFound
+    "RetroCertsPage": retroCertsEnabled ? RetroCertsAuthPage : PageNotFound
   };
 
   return (
@@ -43,3 +37,7 @@ export default function App() {
     </Suspense>
   );
 }
+
+App.propTypes = {
+  hostname: PropTypes.string
+};

--- a/src/client/App.test.js
+++ b/src/client/App.test.js
@@ -1,19 +1,16 @@
 import App from "./App";
 import React from "react";
 import { shallow } from "enzyme";
-import fflip from "fflip";
 
 describe("<App />", () => {
   it("renders application without retro-certs", () => {
-    fflip.features.retroCerts.enabled = false;
-    const wrapper = shallow(<App />);
+    const wrapper = shallow(<App hostname='unemployment.edd.ca.gov' />);
 
     expect(wrapper).toMatchSnapshot();
   });
 
   it("renders application with retro-certs", () => {
-    fflip.features.retroCerts.enabled = true;
-    const wrapper = shallow(<App />);
+    const wrapper = shallow(<App hostname='localhost' />);
 
     expect(wrapper).toMatchSnapshot();
   });


### PR DESCRIPTION
Since we build the same artifact for staging and prod,
we can't use a compile time flag. Instead, check the
domain at runtime.

===

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [X] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
