### PR TITLE
Basic functionality of log in and auth.

### DIFF
--- a/src/client/__snapshots__/App.test.js.snap
+++ b/src/client/__snapshots__/App.test.js.snap
@@ -19,10 +19,30 @@ exports[`<App /> renders application with retro-certs 1`] = `
       <GuidePage />
     </Route>
     <Route
+      key="/retroactive-certification/landing"
+      path="/retroactive-certification/landing"
+    >
+      <RetroCertsLandingPage
+        setUserData={[Function]}
+        userData={
+          Object {
+            "status": "not-logged-in",
+          }
+        }
+      />
+    </Route>
+    <Route
       key="/retroactive-certification"
       path="/retroactive-certification"
     >
-      <RetroCertsAuthPage />
+      <RetroCertsAuthPage
+        setUserData={[Function]}
+        userData={
+          Object {
+            "status": "not-logged-in",
+          }
+        }
+      />
     </Route>
     <Route>
       <PageNotFound />
@@ -48,6 +68,12 @@ exports[`<App /> renders application without retro-certs 1`] = `
       path="/guide"
     >
       <GuidePage />
+    </Route>
+    <Route
+      key="/retroactive-certification/landing"
+      path="/retroactive-certification/landing"
+    >
+      <PageNotFound />
     </Route>
     <Route
       key="/retroactive-certification"

--- a/src/client/pages/RetroCertsAuthPage/index.js
+++ b/src/client/pages/RetroCertsAuthPage/index.js
@@ -1,4 +1,6 @@
+import PropTypes from 'prop-types';
 import { useTranslation } from "react-i18next";
+import { useHistory } from "react-router-dom";
 import Button from "react-bootstrap/Button";
 import Form from "react-bootstrap/Form";
 import Row from "react-bootstrap/Row";
@@ -8,14 +10,12 @@ import React, { useState } from "react";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header";
 
-function RetroCertsAuthPage() {
+function RetroCertsAuthPage(props) {
   const { t } = useTranslation();
+  const history = useHistory();
 
-  // We will probably need to move this up to the App component so this
-  // can be shared accross pages.
-  const [userData, setUserData] = useState({
-    status: "not-logged-in",
-  });
+  const userData = props.userData;
+  const setUserData = props.setUserData;
 
   const [lastName, setLastName] = useState("");
   const [eddcan, setEDDCAN] = useState("");
@@ -37,7 +37,18 @@ function RetroCertsAuthPage() {
       }),
     })
       .then((response) => response.json())
-      .then((data) => setUserData(data))
+      .then((data) => {
+        setUserData(data);
+        if (data.authToken) {
+          // Session storage is destroyed when the tab is closed! That's a bit weird.
+          // If we want to allow the user to use multiple tabs, we could sync the
+          // value across tabs:
+          // https://medium.com/@marciomariani/sharing-sessionstorage-between-tabs-5b6f42c6348c
+          sessionStorage.setItem("authToken", data.authToken);
+          history.push('/retroactive-certification/landing');
+        } else {
+          sessionStorage.removeItem("authToken");
+        }})
       .catch((error) => console.error(error));
   };
 
@@ -122,5 +133,10 @@ function RetroCertsAuthPage() {
     </div>
   );
 }
+
+RetroCertsAuthPage.propTypes = {
+  userData: PropTypes.object,
+  setUserData: PropTypes.func
+};
 
 export default RetroCertsAuthPage;

--- a/src/client/pages/RetroCertsLandingPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsLandingPage/__snapshots__/index.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<RetroCertsLandingPage /> renders the retro certs landing page (after auth) 1`] = `
+<Redirect
+  to="/retroactive-certification"
+/>
+`;

--- a/src/client/pages/RetroCertsLandingPage/index.js
+++ b/src/client/pages/RetroCertsLandingPage/index.js
@@ -1,0 +1,65 @@
+import Button from "react-bootstrap/Button";
+import PropTypes from 'prop-types';
+import { Redirect, useHistory } from "react-router-dom";
+import React from "react";
+import Footer from "../../components/Footer";
+import Header from "../../components/Header";
+
+function RetroCertsLandingPage(props) {
+  const userData = props.userData;
+  const setUserData = props.setUserData;
+  const history = useHistory();
+
+  if (!userData.weeksToCertify) {
+    const authToken = sessionStorage.getItem("authToken");
+    if (!authToken) {
+      return <Redirect to="/retroactive-certification" />;
+    }
+
+    fetch("/retroactive-certification/api/data", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({authToken})
+    })
+    .then(response => response.json())
+    .then(data => {
+      setUserData(data);
+      if (data.status !== "OK") {
+        sessionStorage.removeItem("authToken");
+      }
+    })
+    .catch(error => console.error(error));
+
+    return <div>Loading...</div>;
+  }
+
+  // Removes the users session token which logs the user out.
+  function logout() {
+    sessionStorage.removeItem("authToken");
+    setUserData({status: "not-logged-in"});
+    history.push("/retroactive-certification");
+  }
+
+  return (
+    <div id="overflow-wrapper">
+      <Header />
+      <main>
+        <div className="container p-4">
+          <h1>Hello</h1>
+          <p>Weeks to certify: {userData.weeksToCertify.join(", ")}</p>
+          <p><Button variant="link" onClick={logout}>Clear Session</Button></p>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}
+
+RetroCertsLandingPage.propTypes = {
+  userData: PropTypes.object,
+  setUserData: PropTypes.func
+};
+
+export default RetroCertsLandingPage;

--- a/src/client/pages/RetroCertsLandingPage/index.test.js
+++ b/src/client/pages/RetroCertsLandingPage/index.test.js
@@ -1,0 +1,13 @@
+import renderNonTransContent from "../../test-helpers/renderNonTransContent";
+import Component from "./index";
+
+describe("<RetroCertsLandingPage />", () => {
+  it("renders the retro certs landing page (after auth)", async () => {
+    const wrapper = renderNonTransContent(Component, "RetroCertsLandingPage", {
+      userData: {},
+      setUserData: () => {}
+    });
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/data/routes.js
+++ b/src/data/routes.js
@@ -16,9 +16,13 @@ const routes = {
     path: "/guide",
     component: "GuidePage"
   },
+  retroCertsLanding: {
+    path: "/retroactive-certification/landing",
+    component: "RetroCertsLandingPage"
+  },
   retroCerts: {
     path: "/retroactive-certification",
-    component: "RetroCertsPage"
+    component: "RetroCertsAuthPage"
   }
 };
 


### PR DESCRIPTION
You can log in with a test account. It will
redirect to a page requiring auth that shows
your weeks to certify. Reloading the tab is fine
as is going back and forward.

Click the Clear Session link to clear
credentials and return to the login page.

Write a description of the changes proposed in this pull request. Include images/GIFs if relevant for reviewers. Try Fireshot (Chrome, Firefox) for full-page screenshots and LICEcap (macOS) for GIFs.

Before submitting the PR for review, consider the checklist below and check off any completed items

===

Resolves #XXX

- [X] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
