### PR TITLE
Add Tony as codeowner

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,4 +1,4 @@
 # Owners below will be automatically requested for review on new pull requests
 # For details see: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-*	@kalvinwang @sharonwarner
+*	@kalvinwang @sharonwarner @idealisms


### PR DESCRIPTION
Right now, we only have 2 people listed as codeowners. This means that if either of us are on PTO or away from our computer for whatever reason, all merges to master are blocked. This PR adds Tony as a third codeowner so we have some more coverage.