### PR TITLE
Add the What to Expect page.

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -192,5 +192,21 @@
     "eddcan-error": "Please check your EDDCAN.",
     "ssn-error": "Please check your SSN.",
     "invalid-user-error": "We couldn't find you in the system."
+  },
+  "retrocerts-what-to-expect": {
+    "title": "Retroactive Unemployment Certification",
+    "subheader": "We found your information, <strong>{{name}}</strong>!",
+    "header1": "What to expect",
+    "p1a": "We'll ask you about your unemployment status, including the following:",
+    "list-item1": "Were you too sick or injured to work?",
+    "list-item2": "Was there any reason (other than sickness or injury) that you could not have accepted full-time work each work day?",
+    "list-item3": "Did you look for work?",
+    "list-item4": "Did you refuse any work?",
+    "list-item5": "Did you begin attending any kind of school or training?",
+    "list-item6": "Did you work or earn money, whether you were paid or not?",
+    "p1b": "You'll need to gather these details about your work, education, and other income for the time period from March 14 to May 9, 2020.",
+    "header2": "What if I already submitted my overpayments through AskEDD?",
+    "p2": "Please submit your eligibility information again.",
+    "button-start-certification": "Start certification"
   }
 }

--- a/src/client/App.js
+++ b/src/client/App.js
@@ -1,60 +1,43 @@
 import React, { Suspense, useState } from "react";
 import { Switch, Route } from "react-router-dom";
 import PropTypes from "prop-types";
+import RetroCertsRoute from "./components/RetroCertsRoute";
 import GuidePage from "./pages/GuidePage";
 import PageNotFound from "./pages/PageNotFound";
 import RedirectToGuide from "./pages/RedirectToGuide";
 import RetroCertsAuthPage from "./pages/RetroCertsAuthPage";
 import RetroCertsLandingPage from "./pages/RetroCertsLandingPage";
+import RetroCertsWhatToExpectPage from "./pages/RetroCertsWhatToExpectPage";
 import AUTH_STRINGS from "../data/authStrings";
-import routes from "../data/routes";
 
 export default function App(props) {
   const hostname = props.hostname || window.location.hostname
   const isProduction = hostname === "unemployment.edd.ca.gov";
 
-  // TODO: Move status strings into constants in src/data.
   const [retroCertsUserData, setRetroCertsUserData] = useState({
     status: AUTH_STRINGS.statusCode.notLoggedIn,
   });
-  // Allow us to map back from the name of a page component
-  // (declared in routes) to the actual page component.
-  const pages = {
-    [routes.home.component]: {component: RedirectToGuide},
-    [routes.guide.component]: {component: GuidePage},
-    [routes.retroCertsLanding.component]: {component: PageNotFound},
-    [routes.retroCerts.component]: {component: PageNotFound},
-  };
-  if (!isProduction) {
-    Object.assign(pages, {
-      "RetroCertsAuthPage": {
-        component: RetroCertsAuthPage,
-        props: {
-            userData: retroCertsUserData,
-            setUserData: setRetroCertsUserData
-        }
-      },
-      "RetroCertsLandingPage": {
-        component: RetroCertsLandingPage,
-        props: {
-            userData: retroCertsUserData,
-            setUserData: setRetroCertsUserData
-        }
-      },
-    });
-  };
 
   return (
     <Suspense fallback="Loading...">
       <Switch>
-        {Object.values(routes).map(route => {
-          const page = pages[route.component];
-          return (
-            <Route key={route.path} path={route.path} {...route.routeProps}>
-              <page.component {...page.props}/>
-            </Route>
-          );
-        })}
+        <Route path="/" exact component={RedirectToGuide} />
+        <Route path="/guide" component={GuidePage} />
+        <RetroCertsRoute
+          path="/retroactive-certification/landing"
+          isProduction={isProduction}
+          pageComponent={RetroCertsLandingPage}
+          pageProps={{userData: retroCertsUserData, setUserData: setRetroCertsUserData}}/>
+        <RetroCertsRoute
+          path="/retroactive-certification/what-to-expect"
+          isProduction={isProduction}
+          pageComponent={RetroCertsWhatToExpectPage}
+          pageProps={{userData: retroCertsUserData, setUserData: setRetroCertsUserData}}/>
+        <RetroCertsRoute
+          path="/retroactive-certification"
+          isProduction={isProduction}
+          pageComponent={RetroCertsAuthPage}
+          pageProps={{userData: retroCertsUserData, setUserData: setRetroCertsUserData}}/>
         <Route>
           <PageNotFound />
         </Route>

--- a/src/client/App.scss
+++ b/src/client/App.scss
@@ -30,6 +30,7 @@ $font-family-sans-serif: "Source Sans Pro", sans-serif !default;
 @import "components/Header/index";
 @import "components/Footer/index";
 @import "components/TabbedContainer/index";
+@import "pages/RetroCertsWhatToExpectPage/index";
 
 h1,
 h2,

--- a/src/client/__snapshots__/App.test.js.snap
+++ b/src/client/__snapshots__/App.test.js.snap
@@ -6,44 +6,53 @@ exports[`<App /> renders application with retro-certs 1`] = `
 >
   <Switch>
     <Route
+      component={[Function]}
       exact={true}
-      key="/"
       path="/"
-    >
-      <RedirectToGuide />
-    </Route>
+    />
     <Route
-      key="/guide"
+      component={[Function]}
       path="/guide"
-    >
-      <GuidePage />
-    </Route>
-    <Route
-      key="/retroactive-certification/landing"
+    />
+    <RetroCertsRoute
+      isProduction={false}
+      pageComponent={[Function]}
+      pageProps={
+        Object {
+          "setUserData": [Function],
+          "userData": Object {
+            "status": "not-logged-in",
+          },
+        }
+      }
       path="/retroactive-certification/landing"
-    >
-      <RetroCertsLandingPage
-        setUserData={[Function]}
-        userData={
-          Object {
+    />
+    <RetroCertsRoute
+      isProduction={false}
+      pageComponent={[Function]}
+      pageProps={
+        Object {
+          "setUserData": [Function],
+          "userData": Object {
             "status": "not-logged-in",
-          }
+          },
         }
-      />
-    </Route>
-    <Route
-      key="/retroactive-certification"
+      }
+      path="/retroactive-certification/what-to-expect"
+    />
+    <RetroCertsRoute
+      isProduction={false}
+      pageComponent={[Function]}
+      pageProps={
+        Object {
+          "setUserData": [Function],
+          "userData": Object {
+            "status": "not-logged-in",
+          },
+        }
+      }
       path="/retroactive-certification"
-    >
-      <RetroCertsAuthPage
-        setUserData={[Function]}
-        userData={
-          Object {
-            "status": "not-logged-in",
-          }
-        }
-      />
-    </Route>
+    />
     <Route>
       <PageNotFound />
     </Route>
@@ -57,30 +66,53 @@ exports[`<App /> renders application without retro-certs 1`] = `
 >
   <Switch>
     <Route
+      component={[Function]}
       exact={true}
-      key="/"
       path="/"
-    >
-      <RedirectToGuide />
-    </Route>
+    />
     <Route
-      key="/guide"
+      component={[Function]}
       path="/guide"
-    >
-      <GuidePage />
-    </Route>
-    <Route
-      key="/retroactive-certification/landing"
+    />
+    <RetroCertsRoute
+      isProduction={true}
+      pageComponent={[Function]}
+      pageProps={
+        Object {
+          "setUserData": [Function],
+          "userData": Object {
+            "status": "not-logged-in",
+          },
+        }
+      }
       path="/retroactive-certification/landing"
-    >
-      <PageNotFound />
-    </Route>
-    <Route
-      key="/retroactive-certification"
+    />
+    <RetroCertsRoute
+      isProduction={true}
+      pageComponent={[Function]}
+      pageProps={
+        Object {
+          "setUserData": [Function],
+          "userData": Object {
+            "status": "not-logged-in",
+          },
+        }
+      }
+      path="/retroactive-certification/what-to-expect"
+    />
+    <RetroCertsRoute
+      isProduction={true}
+      pageComponent={[Function]}
+      pageProps={
+        Object {
+          "setUserData": [Function],
+          "userData": Object {
+            "status": "not-logged-in",
+          },
+        }
+      }
       path="/retroactive-certification"
-    >
-      <PageNotFound />
-    </Route>
+    />
     <Route>
       <PageNotFound />
     </Route>

--- a/src/client/commonPropTypes.js
+++ b/src/client/commonPropTypes.js
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 
 export const userDataPropType = PropTypes.shape({
   status: PropTypes.string,
+  lastName: PropTypes.string,
   weeksToCertify: PropTypes.arrayOf(PropTypes.string)
 });
 

--- a/src/client/components/RetroCertsRoute/index.js
+++ b/src/client/components/RetroCertsRoute/index.js
@@ -1,0 +1,32 @@
+import PropTypes from "prop-types";
+import { Route } from "react-router-dom";
+import React from "react";
+import { userDataPropType, setUserDataPropType } from "../../commonPropTypes";
+import PageNotFound from "../../pages/PageNotFound";
+
+function RetroCertsRoute(props) {
+  const { pageComponent: Component, isProduction, pageProps, ...routeProps } = props;
+
+  // TODO: Move authentication logic into this component.
+
+  return (
+      <Route {...routeProps}>
+        {isProduction
+          ? <PageNotFound />
+          : <Component {...pageProps} /> }
+      </Route>
+    )
+}
+
+RetroCertsRoute.propTypes = {
+  exact: PropTypes.bool,
+  isProduction: PropTypes.bool,
+  pageComponent: PropTypes.func.isRequired,
+  pageProps: PropTypes.shape({
+    userData: userDataPropType,
+    setUserData: setUserDataPropType,
+  }),
+  path: PropTypes.string,
+};
+
+export default RetroCertsRoute;

--- a/src/client/pages/RetroCertsAuthPage/index.js
+++ b/src/client/pages/RetroCertsAuthPage/index.js
@@ -46,7 +46,7 @@ function RetroCertsAuthPage(props) {
           // value across tabs:
           // https://medium.com/@marciomariani/sharing-sessionstorage-between-tabs-5b6f42c6348c
           sessionStorage.setItem(AUTH_STRINGS.authToken, data.authToken);
-          history.push("/retroactive-certification/landing");
+          history.push("/retroactive-certification/what-to-expect");
         } else {
           sessionStorage.removeItem(AUTH_STRINGS.authToken);
         }})

--- a/src/client/pages/RetroCertsWhatToExpectPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsWhatToExpectPage/__snapshots__/index.test.js.snap
@@ -1,0 +1,103 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<RetroCertsWhatToExpectPage /> has user data 1`] = `
+<div
+  className="what-to-expect"
+  id="overflow-wrapper"
+>
+  <Header />
+  <main>
+    <div
+      className="container p-4"
+    >
+      <h1>
+        Retroactive Unemployment Certification
+      </h1>
+      <p
+        className="green-highlight"
+      >
+        <span
+          className="white-checkmark"
+        >
+          ✔
+        </span>
+        <Trans
+          i18nKey="retrocerts-what-to-expect.subheader"
+          t={[Function]}
+          values={
+            Object {
+              "name": "Lastname",
+            }
+          }
+        />
+      </p>
+      <h2>
+        What to expect
+      </h2>
+      <p>
+        We'll ask you about your unemployment status, including the following:
+      </p>
+      <ul>
+        <li>
+          Were you too sick or injured to work?
+        </li>
+        <li>
+          Was there any reason (other than sickness or injury) that you could not have accepted full-time work each work day?
+        </li>
+        <li>
+          Did you look for work?
+        </li>
+        <li>
+          Did you refuse any work?
+        </li>
+        <li>
+          Did you begin attending any kind of school or training?
+        </li>
+        <li>
+          Did you work or earn money, whether you were paid or not?
+        </li>
+      </ul>
+      <p>
+        You'll need to gather these details about your work, education, and other income for the time period from March 14 to May 9, 2020.
+      </p>
+      <h2>
+        What if I already submitted my overpayments through AskEDD?
+      </h2>
+      <p>
+        Please submit your eligibility information again.
+      </p>
+      <Button
+        active={false}
+        as={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "displayName": "Link",
+            "propTypes": Object {
+              "innerRef": [Function],
+              "onClick": [Function],
+              "replace": [Function],
+              "target": [Function],
+              "to": [Function],
+            },
+            "render": [Function],
+          }
+        }
+        disabled={false}
+        to="/retroactive-certification/landing"
+        type="button"
+        variant="secondary"
+      >
+        Start certification
+      </Button>
+    </div>
+  </main>
+  <Footer />
+</div>
+`;
+
+exports[`<RetroCertsWhatToExpectPage /> no authToken or user data 1`] = `
+<Redirect
+  push={true}
+  to="/retroactive-certification"
+/>
+`;

--- a/src/client/pages/RetroCertsWhatToExpectPage/_index.scss
+++ b/src/client/pages/RetroCertsWhatToExpectPage/_index.scss
@@ -1,0 +1,18 @@
+.what-to-expect {
+  .green-highlight {
+    background-color: #ecf3ec;
+    border-left: .5rem solid #01a91c;
+    padding: .6rem;
+  }
+  .white-checkmark {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 2rem;
+    width: 2rem;
+    margin-right: .5rem;
+    color: #fff;
+    background-color: #000;
+    border-radius: 50%;
+  }
+}

--- a/src/client/pages/RetroCertsWhatToExpectPage/_index.scss
+++ b/src/client/pages/RetroCertsWhatToExpectPage/_index.scss
@@ -3,6 +3,7 @@
     background-color: #ecf3ec;
     border-left: .5rem solid #01a91c;
     padding: .6rem;
+    margin-top: 2rem;
   }
   .white-checkmark {
     display: inline-flex;

--- a/src/client/pages/RetroCertsWhatToExpectPage/index.js
+++ b/src/client/pages/RetroCertsWhatToExpectPage/index.js
@@ -1,0 +1,84 @@
+import Button from "react-bootstrap/Button";
+import { Link, Redirect } from "react-router-dom";
+import React from "react";
+import AUTH_STRINGS from "../../../data/authStrings";
+import { userDataPropType, setUserDataPropType } from "../../commonPropTypes";
+import Footer from "../../components/Footer";
+import Header from "../../components/Header";
+import { useTranslation, Trans } from "react-i18next";
+
+function RetroCertsWhatToExpectPage(props) {
+  const { t } = useTranslation();
+
+  const userData = props.userData;
+  const setUserData = props.setUserData;
+
+  if (!userData.weeksToCertify) {
+    const authToken = sessionStorage.getItem(AUTH_STRINGS.authToken);
+    if (!authToken) {
+      return <Redirect to="/retroactive-certification" push />;
+    }
+
+    fetch(AUTH_STRINGS.apiPath.data, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({authToken})
+    })
+    .then(response => response.json())
+    .then(data => {
+      setUserData(data);
+      if (data.status !== AUTH_STRINGS.statusCode.ok) {
+        sessionStorage.removeItem(AUTH_STRINGS.authToken);
+      }
+    })
+    .catch(error => console.error(error));
+
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div id="overflow-wrapper" className="what-to-expect">
+      <Header />
+      <main>
+        <div className="container p-4">
+          <h1>{t("retrocerts-what-to-expect.title")}</h1>
+          <p className="green-highlight">
+            <span className="white-checkmark">✔</span>
+            <Trans t={t} i18nKey="retrocerts-what-to-expect.subheader" values={{name: userData.lastName}} />
+          </p>
+
+          <h2>{t("retrocerts-what-to-expect.header1")}</h2>
+          <p>{t("retrocerts-what-to-expect.p1a")}</p>
+          <ul>
+            <li>{t("retrocerts-what-to-expect.list-item1")}</li>
+            <li>{t("retrocerts-what-to-expect.list-item2")}</li>
+            <li>{t("retrocerts-what-to-expect.list-item3")}</li>
+            <li>{t("retrocerts-what-to-expect.list-item4")}</li>
+            <li>{t("retrocerts-what-to-expect.list-item5")}</li>
+            <li>{t("retrocerts-what-to-expect.list-item6")}</li>
+          </ul>
+          <p>{t("retrocerts-what-to-expect.p1b")}</p>
+          <h2>{t("retrocerts-what-to-expect.header2")}</h2>
+          <p>{t("retrocerts-what-to-expect.p2")}</p>
+
+          <Button
+              variant="secondary"
+              as={Link}
+              to="/retroactive-certification/landing">
+            {t("retrocerts-what-to-expect.button-start-certification")}
+          </Button>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}
+
+RetroCertsWhatToExpectPage.propTypes = {
+  userData: userDataPropType,
+  setUserData: setUserDataPropType,
+};
+
+export default RetroCertsWhatToExpectPage;

--- a/src/client/pages/RetroCertsWhatToExpectPage/index.test.js
+++ b/src/client/pages/RetroCertsWhatToExpectPage/index.test.js
@@ -1,0 +1,28 @@
+import renderNonTransContent from "../../test-helpers/renderNonTransContent";
+import Component from "./index";
+import AUTH_STRINGS from "../../../data/authStrings";
+
+describe("<RetroCertsWhatToExpectPage />", () => {
+  it("no authToken or user data", async () => {
+    sessionStorage.removeItem(AUTH_STRINGS.authToken);
+    const wrapper = renderNonTransContent(Component, "RetroCertsWhatToExpectPage", {
+      userData: {},
+      setUserData: () => {},
+    });
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("has user data", async () => {
+    const wrapper = renderNonTransContent(Component, "RetroCertsWhatToExpectPage", {
+      userData: {
+        status: AUTH_STRINGS.statusCode.ok,
+        lastName: "Lastname",
+        weeksToCertify: ["2020-01-01"],
+      },
+      setUserData: () => {},
+    });
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/data/routes.js
+++ b/src/data/routes.js
@@ -16,6 +16,10 @@ const routes = {
     path: "/guide",
     component: "GuidePage"
   },
+  retroCertsWhatToExpect: {
+    path: "/retroactive-certification/what-to-expect",
+    component: "RetroCertsWhatToExpectPage",
+  },
   retroCertsLanding: {
     path: "/retroactive-certification/landing",
     component: "RetroCertsLandingPage"

--- a/src/data/test-accounts.json
+++ b/src/data/test-accounts.json
@@ -1,17 +1,17 @@
 [{
-  "lastName": "last",
+  "lastName": "Last",
   "eddcan": "1234567890",
   "ssn": "123456789",
   "authToken": "e882639f-07b9-423d-9e1e-5f6b594b60eb",
   "weeksToCertify": ["2020-04-03", "2020-04-10"]
 }, {
-  "lastName": "last",
+  "lastName": "Last",
   "eddcan": "1111122222",
   "ssn": "888990000",
   "authToken": "0be63615-6f3f-4e1f-a104-f1fab45c126b",
   "weeksToCertify": ["2020-03-27"]
 }, {
-  "lastName": "foobar",
+  "lastName": "FooBar",
   "eddcan": "1234554321",
   "ssn": "012345678",
   "authToken": "1701c969-2bb2-449e-8916-6f0fb87d190b",

--- a/src/routes/retro-certs.js
+++ b/src/routes/retro-certs.js
@@ -8,11 +8,12 @@ function createRouter() {
   function authStatus(postJson, responseJson) {
     responseJson.status = AUTH_STRINGS.statusCode.userNotFound;
     for (const testAccount of testAccounts) {
-      if ((postJson.lastName || "").toLowerCase() === testAccount.lastName
+      if ((postJson.lastName || "").toLowerCase() === testAccount.lastName.toLowerCase()
           && postJson.ssn === testAccount.ssn
           && postJson.eddcan === testAccount.eddcan) {
         responseJson.status = AUTH_STRINGS.statusCode.ok;
         responseJson.authToken = testAccount.authToken;
+        responseJson.lastName = testAccount.lastName;
         responseJson.weeksToCertify = Array.from(testAccount.weeksToCertify);
         break;
       } else if (postJson.ssn === testAccount.ssn
@@ -34,6 +35,7 @@ function createRouter() {
       for (const testAccount of testAccounts) {
         if (postJson.authToken === testAccount.authToken) {
           responseJson.status = AUTH_STRINGS.statusCode.ok;
+          responseJson.lastName = testAccount.lastName;
           responseJson.weeksToCertify = Array.from(testAccount.weeksToCertify);
           break;
         }

--- a/src/routes/retro-certs.test.js
+++ b/src/routes/retro-certs.test.js
@@ -36,6 +36,7 @@ describe("Router: API tests", () => {
       [{lastName: "Last", eddcan: "1234567890", ssn: "123456789"}, 200, {
         status: AUTH_STRINGS.statusCode.ok,
         authToken: "e882639f-07b9-423d-9e1e-5f6b594b60eb",
+        lastName: "Last",
         weeksToCertify: ["2020-04-03", "2020-04-10"]}],
       [{lastName: "Incorrect", eddcan: "1234567890", ssn: "0"}, 401, {
         status: AUTH_STRINGS.statusCode.wrongSsn}],
@@ -46,6 +47,7 @@ describe("Router: API tests", () => {
       [{lastName: "LaSt", eddcan: "1111122222", ssn: "888990000"}, 200, {
         status: AUTH_STRINGS.statusCode.ok,
         authToken: "0be63615-6f3f-4e1f-a104-f1fab45c126b",
+        lastName: "Last",
         weeksToCertify: ["2020-03-27"]}]
     ];
 
@@ -70,9 +72,11 @@ describe("Router: API tests", () => {
         status: AUTH_STRINGS.statusCode.userNotFound}],
       [{authToken: "e882639f-07b9-423d-9e1e-5f6b594b60eb"}, 200, {
         status: AUTH_STRINGS.statusCode.ok,
+        lastName: "Last",
         weeksToCertify: ["2020-04-03", "2020-04-10"]}],
       [{authToken: "0be63615-6f3f-4e1f-a104-f1fab45c126b"}, 200, {
         status: AUTH_STRINGS.statusCode.ok,
+        lastName: "Last",
         weeksToCertify: ["2020-03-27"]}]
       ];
 


### PR DESCRIPTION
This renders the successful login page with the
user's last name.

In addition to that, I refactored the routes and
introduced a <RetroCertsRoute> which I saw here:
https://stackoverflow.com/a/48497783

It currently handles the logic related to serving
PageNotFound when not in prod, and in a follow up,
I'll add logic for authenticating pages with an
auth token (this logic is current copied and
pasted from the LandingPage into the
WhatToExpectPage).

===

Resolves #289

- [X] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [X] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [X] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [X] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made

![screencapture-localhost-3000-retroactive-certification-what-to-expect-2020-06-09-17_56_36](https://user-images.githubusercontent.com/175378/84215274-9887f380-aa7a-11ea-886b-39036383cc01.png)
