### PR TITLE
Refactor to auth logic into <RetroCertsRoute>

### DIFF
--- a/src/client/App.js
+++ b/src/client/App.js
@@ -27,17 +27,19 @@ export default function App(props) {
           path="/retroactive-certification/landing"
           isProduction={isProduction}
           pageComponent={RetroCertsLandingPage}
-          pageProps={{userData: retroCertsUserData, setUserData: setRetroCertsUserData}}/>
+          pageProps={{userData: retroCertsUserData, setUserData: setRetroCertsUserData}}
+          requiresAuthentication />
         <RetroCertsRoute
           path="/retroactive-certification/what-to-expect"
           isProduction={isProduction}
           pageComponent={RetroCertsWhatToExpectPage}
-          pageProps={{userData: retroCertsUserData, setUserData: setRetroCertsUserData}}/>
+          pageProps={{userData: retroCertsUserData, setUserData: setRetroCertsUserData}}
+          requiresAuthentication />
         <RetroCertsRoute
           path="/retroactive-certification"
           isProduction={isProduction}
           pageComponent={RetroCertsAuthPage}
-          pageProps={{userData: retroCertsUserData, setUserData: setRetroCertsUserData}}/>
+          pageProps={{userData: retroCertsUserData, setUserData: setRetroCertsUserData}} />
         <Route>
           <PageNotFound />
         </Route>

--- a/src/client/__snapshots__/App.test.js.snap
+++ b/src/client/__snapshots__/App.test.js.snap
@@ -26,6 +26,7 @@ exports[`<App /> renders application with retro-certs 1`] = `
         }
       }
       path="/retroactive-certification/landing"
+      requiresAuthentication={true}
     />
     <RetroCertsRoute
       isProduction={false}
@@ -39,6 +40,7 @@ exports[`<App /> renders application with retro-certs 1`] = `
         }
       }
       path="/retroactive-certification/what-to-expect"
+      requiresAuthentication={true}
     />
     <RetroCertsRoute
       isProduction={false}
@@ -86,6 +88,7 @@ exports[`<App /> renders application without retro-certs 1`] = `
         }
       }
       path="/retroactive-certification/landing"
+      requiresAuthentication={true}
     />
     <RetroCertsRoute
       isProduction={true}
@@ -99,6 +102,7 @@ exports[`<App /> renders application without retro-certs 1`] = `
         }
       }
       path="/retroactive-certification/what-to-expect"
+      requiresAuthentication={true}
     />
     <RetroCertsRoute
       isProduction={true}

--- a/src/client/commonPropTypes.js
+++ b/src/client/commonPropTypes.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 export const userDataPropType = PropTypes.shape({
   status: PropTypes.string,
   lastName: PropTypes.string,
-  weeksToCertify: PropTypes.arrayOf(PropTypes.string)
+  weeksToCertify: PropTypes.arrayOf(PropTypes.number)
 });
 
 export const setUserDataPropType = PropTypes.func;

--- a/src/client/components/RetroCertsRoute/__snapshots__/index.test.js.snap
+++ b/src/client/components/RetroCertsRoute/__snapshots__/index.test.js.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<RetroCertsRoute /> basic route 1`] = `
+<Route
+  path="/path"
+>
+  <TestComponent />
+</Route>
+`;
+
+exports[`<RetroCertsRoute /> route in production (should be PageNotFound) 1`] = `
+<Route
+  path="/path"
+>
+  <PageNotFound />
+</Route>
+`;
+
+exports[`<RetroCertsRoute /> route needing auth with authToken 1`] = `
+<Route
+  path="/path"
+>
+  <div>
+    Loading...
+  </div>
+</Route>
+`;
+
+exports[`<RetroCertsRoute /> route needing auth with user data 1`] = `
+<Route
+  path="/path"
+>
+  <TestComponent
+    userData={
+      Object {
+        "weeksToCertify": Array [
+          0,
+        ],
+      }
+    }
+  />
+</Route>
+`;
+
+exports[`<RetroCertsRoute /> route needing auth, but no data 1`] = `
+<Route
+  path="/path"
+>
+  <Redirect
+    push={true}
+    to="/retroactive-certification"
+  />
+</Route>
+`;

--- a/src/client/components/RetroCertsRoute/index.test.js
+++ b/src/client/components/RetroCertsRoute/index.test.js
@@ -1,0 +1,102 @@
+import renderNonTransContent from "../../test-helpers/renderNonTransContent";
+import React from "react";
+import Component from "./index";
+import AUTH_STRINGS from "../../../data/authStrings";
+
+const TestComponent = () => {
+  return <div>TestComponent</div>;
+};
+
+describe("<RetroCertsRoute />", () => {
+
+  it("basic route", async () => {
+    sessionStorage.removeItem(AUTH_STRINGS.authToken);
+    const wrapper = renderNonTransContent(Component, "RetroCertsRoute", {
+      path: '/path',
+      pageComponent: TestComponent
+    });
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("route in production (should be PageNotFound)", async () => {
+    sessionStorage.removeItem(AUTH_STRINGS.authToken);
+    const wrapper = renderNonTransContent(Component, "RetroCertsRoute", {
+      path: '/path',
+      pageComponent: TestComponent,
+      isProduction: true
+    });
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("route needing auth, but no data", async () => {
+    sessionStorage.removeItem(AUTH_STRINGS.authToken);
+    const wrapper = renderNonTransContent(Component, "RetroCertsRoute", {
+      path: '/path',
+      pageComponent: TestComponent,
+      pageProps: {
+        userData: {}
+      },
+      requiresAuthentication: true
+    });
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("route needing auth with user data", async () => {
+    sessionStorage.removeItem(AUTH_STRINGS.authToken);
+    const wrapper = renderNonTransContent(Component, "RetroCertsRoute", {
+      path: '/path',
+      pageComponent: TestComponent,
+      pageProps: {
+        userData: {weeksToCertify: [0]},
+      },
+      requiresAuthentication: true
+    });
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("route needing auth with authToken", async () => {
+    sessionStorage.setItem(AUTH_STRINGS.authToken, 'TEST_TOKEN');
+
+    // fetch isn't part of nodejs. If we pull in node-fetch, we
+    // need to update the test codes to mock global.fetch.
+    expect(global.fetch).toBeUndefined();
+    const mockFetch = jest.fn(() => Promise.resolve({
+      json: () => Promise.resolve({
+        status: AUTH_STRINGS.statusCode.ok,
+        weeksToCertify: [0, 1],
+      }),
+    }));
+    global.fetch = mockFetch;
+
+    const wrapper = renderNonTransContent(Component, "RetroCertsRoute", {
+      path: '/path',
+      pageComponent: TestComponent,
+      pageProps: {
+        userData: {},
+        setUserData: () => {},
+      },
+      requiresAuthentication: true
+    });
+
+    // Test cleanup.
+    sessionStorage.removeItem(AUTH_STRINGS.authToken);
+    global.fetch = undefined;
+
+    expect(mockFetch.mock.calls.length).toBe(1);
+    expect(mockFetch.mock.calls[0]).toEqual([
+      AUTH_STRINGS.apiPath.data, {
+        body: JSON.stringify({ authToken: "TEST_TOKEN" }),
+        headers: {
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      }
+    ]);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/client/pages/RetroCertsLandingPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsLandingPage/__snapshots__/index.test.js.snap
@@ -14,7 +14,7 @@ exports[`<RetroCertsLandingPage /> has user data 1`] = `
       </h1>
       <p>
         Weeks to certify: 
-        2020-01-01
+        0
       </p>
       <p>
         <Button

--- a/src/client/pages/RetroCertsLandingPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsLandingPage/__snapshots__/index.test.js.snap
@@ -32,16 +32,3 @@ exports[`<RetroCertsLandingPage /> has user data 1`] = `
   <Footer />
 </div>
 `;
-
-exports[`<RetroCertsLandingPage /> no authToken or user data 1`] = `
-<Redirect
-  push={true}
-  to="/retroactive-certification"
-/>
-`;
-
-exports[`<RetroCertsLandingPage /> re-fetch data with authToken 1`] = `
-<div>
-  Loading...
-</div>
-`;

--- a/src/client/pages/RetroCertsLandingPage/index.js
+++ b/src/client/pages/RetroCertsLandingPage/index.js
@@ -1,5 +1,5 @@
 import Button from "react-bootstrap/Button";
-import { Redirect, useHistory } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import React from "react";
 import AUTH_STRINGS from "../../../data/authStrings";
 import { userDataPropType, setUserDataPropType } from "../../commonPropTypes";
@@ -10,31 +10,6 @@ function RetroCertsLandingPage(props) {
   const userData = props.userData;
   const setUserData = props.setUserData;
   const history = useHistory();
-
-  if (!userData.weeksToCertify) {
-    const authToken = sessionStorage.getItem(AUTH_STRINGS.authToken);
-    if (!authToken) {
-      return <Redirect to="/retroactive-certification" push />;
-    }
-
-    fetch(AUTH_STRINGS.apiPath.data, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json"
-      },
-      body: JSON.stringify({authToken})
-    })
-    .then(response => response.json())
-    .then(data => {
-      setUserData(data);
-      if (data.status !== AUTH_STRINGS.statusCode.ok) {
-        sessionStorage.removeItem(AUTH_STRINGS.authToken);
-      }
-    })
-    .catch(error => console.error(error));
-
-    return <div>Loading...</div>;
-  }
 
   // Removes the users session token which logs the user out.
   function logout() {

--- a/src/client/pages/RetroCertsLandingPage/index.test.js
+++ b/src/client/pages/RetroCertsLandingPage/index.test.js
@@ -3,48 +3,6 @@ import Component from "./index";
 import AUTH_STRINGS from "../../../data/authStrings";
 
 describe("<RetroCertsLandingPage />", () => {
-  it("no authToken or user data", async () => {
-    sessionStorage.removeItem(AUTH_STRINGS.authToken);
-    const wrapper = renderNonTransContent(Component, "RetroCertsLandingPage", {
-      userData: {},
-      setUserData: () => {},
-    });
-
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it("re-fetch data with authToken", async () => {
-    sessionStorage.setItem(AUTH_STRINGS.authToken, 'TEST_TOKEN');
-    // fetch isn't part of nodejs. If we pull in node-fetch, we
-    // need to update the test codes to mock global.fetch.
-    expect(global.fetch).toBeUndefined();
-    const mockFetch = jest.fn(() => Promise.resolve({
-      json: () => Promise.resolve({
-        status: AUTH_STRINGS.statusCode.ok,
-        weeksToCertify: ["2020-02-01"],
-      }),
-    }));
-    global.fetch = mockFetch;
-
-    const wrapper = renderNonTransContent(Component, "RetroCertsLandingPage", {
-      userData: {},
-      setUserData: () => {},
-    });
-
-    global.fetch = undefined;
-    expect(mockFetch.mock.calls.length).toBe(1);
-    expect(mockFetch.mock.calls[0]).toEqual([
-      AUTH_STRINGS.apiPath.data, {
-        body: JSON.stringify({ authToken: "TEST_TOKEN" }),
-        headers: {
-          "Content-Type": "application/json",
-        },
-        method: "POST",
-      }
-    ]);
-    expect(wrapper).toMatchSnapshot();
-  });
-
   it("has user data", async () => {
     const wrapper = renderNonTransContent(Component, "RetroCertsLandingPage", {
       userData: {

--- a/src/client/pages/RetroCertsLandingPage/index.test.js
+++ b/src/client/pages/RetroCertsLandingPage/index.test.js
@@ -7,7 +7,7 @@ describe("<RetroCertsLandingPage />", () => {
     const wrapper = renderNonTransContent(Component, "RetroCertsLandingPage", {
       userData: {
         status: AUTH_STRINGS.statusCode.ok,
-        weeksToCertify: ["2020-01-01"],
+        weeksToCertify: [0],
       },
       setUserData: () => {},
     });

--- a/src/client/pages/RetroCertsWhatToExpectPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsWhatToExpectPage/__snapshots__/index.test.js.snap
@@ -94,10 +94,3 @@ exports[`<RetroCertsWhatToExpectPage /> has user data 1`] = `
   <Footer />
 </div>
 `;
-
-exports[`<RetroCertsWhatToExpectPage /> no authToken or user data 1`] = `
-<Redirect
-  push={true}
-  to="/retroactive-certification"
-/>
-`;

--- a/src/client/pages/RetroCertsWhatToExpectPage/index.js
+++ b/src/client/pages/RetroCertsWhatToExpectPage/index.js
@@ -1,8 +1,7 @@
 import Button from "react-bootstrap/Button";
-import { Link, Redirect } from "react-router-dom";
+import { Link } from "react-router-dom";
 import React from "react";
-import AUTH_STRINGS from "../../../data/authStrings";
-import { userDataPropType, setUserDataPropType } from "../../commonPropTypes";
+import { userDataPropType } from "../../commonPropTypes";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header";
 import { useTranslation, Trans } from "react-i18next";
@@ -11,32 +10,6 @@ function RetroCertsWhatToExpectPage(props) {
   const { t } = useTranslation();
 
   const userData = props.userData;
-  const setUserData = props.setUserData;
-
-  if (!userData.weeksToCertify) {
-    const authToken = sessionStorage.getItem(AUTH_STRINGS.authToken);
-    if (!authToken) {
-      return <Redirect to="/retroactive-certification" push />;
-    }
-
-    fetch(AUTH_STRINGS.apiPath.data, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json"
-      },
-      body: JSON.stringify({authToken})
-    })
-    .then(response => response.json())
-    .then(data => {
-      setUserData(data);
-      if (data.status !== AUTH_STRINGS.statusCode.ok) {
-        sessionStorage.removeItem(AUTH_STRINGS.authToken);
-      }
-    })
-    .catch(error => console.error(error));
-
-    return <div>Loading...</div>;
-  }
 
   return (
     <div id="overflow-wrapper" className="what-to-expect">
@@ -78,7 +51,6 @@ function RetroCertsWhatToExpectPage(props) {
 
 RetroCertsWhatToExpectPage.propTypes = {
   userData: userDataPropType,
-  setUserData: setUserDataPropType,
 };
 
 export default RetroCertsWhatToExpectPage;

--- a/src/client/pages/RetroCertsWhatToExpectPage/index.test.js
+++ b/src/client/pages/RetroCertsWhatToExpectPage/index.test.js
@@ -3,24 +3,13 @@ import Component from "./index";
 import AUTH_STRINGS from "../../../data/authStrings";
 
 describe("<RetroCertsWhatToExpectPage />", () => {
-  it("no authToken or user data", async () => {
-    sessionStorage.removeItem(AUTH_STRINGS.authToken);
-    const wrapper = renderNonTransContent(Component, "RetroCertsWhatToExpectPage", {
-      userData: {},
-      setUserData: () => {},
-    });
-
-    expect(wrapper).toMatchSnapshot();
-  });
-
   it("has user data", async () => {
     const wrapper = renderNonTransContent(Component, "RetroCertsWhatToExpectPage", {
       userData: {
         status: AUTH_STRINGS.statusCode.ok,
         lastName: "Lastname",
         weeksToCertify: ["2020-01-01"],
-      },
-      setUserData: () => {},
+      }
     });
 
     expect(wrapper).toMatchSnapshot();

--- a/src/client/pages/RetroCertsWhatToExpectPage/index.test.js
+++ b/src/client/pages/RetroCertsWhatToExpectPage/index.test.js
@@ -8,7 +8,7 @@ describe("<RetroCertsWhatToExpectPage />", () => {
       userData: {
         status: AUTH_STRINGS.statusCode.ok,
         lastName: "Lastname",
-        weeksToCertify: ["2020-01-01"],
+        weeksToCertify: [1, 2],
       }
     });
 

--- a/src/data/routes.js
+++ b/src/data/routes.js
@@ -7,26 +7,21 @@
 const routes = {
   home: {
     path: "/",
-    component: "RedirectToGuide",
     routeProps: {
       exact: true
     }
   },
   guide: {
     path: "/guide",
-    component: "GuidePage"
   },
   retroCertsWhatToExpect: {
     path: "/retroactive-certification/what-to-expect",
-    component: "RetroCertsWhatToExpectPage",
   },
   retroCertsLanding: {
     path: "/retroactive-certification/landing",
-    component: "RetroCertsLandingPage"
   },
   retroCerts: {
     path: "/retroactive-certification",
-    component: "RetroCertsAuthPage"
   }
 };
 

--- a/src/data/test-accounts.json
+++ b/src/data/test-accounts.json
@@ -3,17 +3,17 @@
   "eddcan": "1234567890",
   "ssn": "123456789",
   "authToken": "e882639f-07b9-423d-9e1e-5f6b594b60eb",
-  "weeksToCertify": ["2020-04-03", "2020-04-10"]
+  "weeksToCertify": [0, 1]
 }, {
   "lastName": "Last",
   "eddcan": "1111122222",
   "ssn": "888990000",
   "authToken": "0be63615-6f3f-4e1f-a104-f1fab45c126b",
-  "weeksToCertify": ["2020-03-27"]
+  "weeksToCertify": [2]
 }, {
   "lastName": "FooBar",
   "eddcan": "1234554321",
   "ssn": "012345678",
   "authToken": "1701c969-2bb2-449e-8916-6f0fb87d190b",
-  "weeksToCertify": ["2020-03-20", "2020-03-27", "2020-04-03", "2020-04-10"]
+  "weeksToCertify": [1, 2, 3, 5]
 }]

--- a/src/routes/retro-certs.test.js
+++ b/src/routes/retro-certs.test.js
@@ -37,7 +37,7 @@ describe("Router: API tests", () => {
         status: AUTH_STRINGS.statusCode.ok,
         authToken: "e882639f-07b9-423d-9e1e-5f6b594b60eb",
         lastName: "Last",
-        weeksToCertify: ["2020-04-03", "2020-04-10"]}],
+        weeksToCertify: [0, 1]}],
       [{lastName: "Incorrect", eddcan: "1234567890", ssn: "0"}, 401, {
         status: AUTH_STRINGS.statusCode.wrongSsn}],
       [{lastName: "Incorrect", eddcan: "0", ssn: "123456789"}, 401, {
@@ -48,7 +48,7 @@ describe("Router: API tests", () => {
         status: AUTH_STRINGS.statusCode.ok,
         authToken: "0be63615-6f3f-4e1f-a104-f1fab45c126b",
         lastName: "Last",
-        weeksToCertify: ["2020-03-27"]}]
+        weeksToCertify: [2]}]
     ];
 
     for (const testCase of testCases) {
@@ -73,11 +73,11 @@ describe("Router: API tests", () => {
       [{authToken: "e882639f-07b9-423d-9e1e-5f6b594b60eb"}, 200, {
         status: AUTH_STRINGS.statusCode.ok,
         lastName: "Last",
-        weeksToCertify: ["2020-04-03", "2020-04-10"]}],
+        weeksToCertify: [0, 1]}],
       [{authToken: "0be63615-6f3f-4e1f-a104-f1fab45c126b"}, 200, {
         status: AUTH_STRINGS.statusCode.ok,
         lastName: "Last",
-        weeksToCertify: ["2020-03-27"]}]
+        weeksToCertify: [2]}]
       ];
 
     for (const testCase of testCases) {


### PR DESCRIPTION
This moves the logic to check if the user is logged in
and refetch data with the auth token into <RetroCertsRoute>.
This means for new pages, when adding to App.js, you can
add requiresAuthentication to the route and it will handle
auth logic for you.

The behavior should be the same as before this change, but
less duplicated code. This also makes testing Page components
easier.

===

Resolves #XXX

- [X] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [X] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
