### PR TITLE
Add prettier to the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,16 @@ npm run test
 ```bash
 npm run test:update-snapshots
 ```
+
+## Style
+eslint checks the JS code style and stylelint checks the CSS style.
+
+```bash
+npm run lint
+```
+
+Additionally, we use [prettier](https://prettier.io/) to format JS and CSS files. You can either [configure it with your editor](https://prettier.io/docs/en/editors.html) or run
+
+```
+npm run prettier
+```

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "lint:js": "eslint --ext .js",
         "lint:js:all": "npm run lint:js -- ./",
         "lint": "npm-run-all lint:js:all lint:css:all",
+        "prettier": "prettier --write src",
         "start": "npm-run-all -p start:dev watch:css watch:js",
         "prestart": "npm run clean-build-dir",
         "start:dev": "PORT=3000 NODE_ENV=development nodemon --inspect=0.0.0.0:9222 src --config nodemon.config.json",

--- a/src/app.test.js
+++ b/src/app.test.js
@@ -6,12 +6,7 @@ describe("Router: Single page app", () => {
   it("HTTP gets returning the single page", async () => {
     fflip.features.retroCerts.enabled = false;
     const server = init();
-    const testPaths = [
-      "/guide",
-      "/guide/",
-      "/guide/benefits",
-      "/",
-    ];
+    const testPaths = ["/guide", "/guide/", "/guide/benefits", "/"];
 
     for (const testPath of testPaths) {
       const res = await request(server).get(testPath);
@@ -24,9 +19,7 @@ describe("Router: Single page app", () => {
   it("404 for pages that don't exist", async () => {
     fflip.features.retroCerts.enabled = false;
     const server = init();
-    const testPaths = [
-      "/does-not-exist",
-    ];
+    const testPaths = ["/does-not-exist"];
 
     for (const testPath of testPaths) {
       const res = await request(server).get(testPath);

--- a/src/client/App.scss
+++ b/src/client/App.scss
@@ -38,56 +38,56 @@ h3,
 h4,
 h5,
 h6 {
-	font-weight: bold;
+  font-weight: bold;
 }
 
 h2 {
-	margin-bottom: 2rem;
+  margin-bottom: 2rem;
 }
 
 h3 {
-	margin-bottom: 0.8rem;
+  margin-bottom: 0.8rem;
 }
 
 a {
-	text-decoration: underline;
+  text-decoration: underline;
 }
 
 .btn,
 .nav-link {
-	text-decoration: none;
+  text-decoration: none;
 }
 
 .btn {
-	font-weight: bold;
+  font-weight: bold;
 }
 
 // Eliminate whitespace overflow on right half of mobile viewport
 // None of the usual solutions are compatible with sticky elements
 // But this solution is: https://stackoverflow.com/a/59019025/6074728
 #overflow-wrapper {
-	touch-action: pan-y pinch-zoom;
+  touch-action: pan-y pinch-zoom;
 }
 
 // Needed for IE11: https://stackoverflow.com/a/35820454/6074728
 main {
-	display: block;
+  display: block;
 }
 
 // This keeps the footer at the bottom of the page, even if the main
 // content is short. This doesn't work in IE, but degrades reasonably
 // well (the content doesn't grow if needed).
 #overflow-wrapper {
-	min-height: 100vh;
-	display: flex;
-	flex-direction: column;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 header {
-	flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 main {
-	flex: 1 0 auto;
+  flex: 1 0 auto;
 }
 footer {
-	flex: 0 0 auto;
+  flex: 0 0 auto;
 }

--- a/src/client/App.test.js
+++ b/src/client/App.test.js
@@ -4,13 +4,13 @@ import { shallow } from "enzyme";
 
 describe("<App />", () => {
   it("renders application without retro-certs", () => {
-    const wrapper = shallow(<App hostname='unemployment.edd.ca.gov' />);
+    const wrapper = shallow(<App hostname="unemployment.edd.ca.gov" />);
 
     expect(wrapper).toMatchSnapshot();
   });
 
   it("renders application with retro-certs", () => {
-    const wrapper = shallow(<App hostname='localhost' />);
+    const wrapper = shallow(<App hostname="localhost" />);
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/client/components/Header/_index.scss
+++ b/src/client/components/Header/_index.scss
@@ -6,13 +6,14 @@
     font-size: 14px;
   }
 
-  .icon, .text {
-  	vertical-align: middle;
-  	display: inline-block;
+  .icon,
+  .text {
+    vertical-align: middle;
+    display: inline-block;
   }
 
   .navbar-light .nav-link {
     color: #555555;
     font-size: 16px;
-  }  
+  }
 }

--- a/src/client/pages/RetroCertsWhatToExpectPage/_index.scss
+++ b/src/client/pages/RetroCertsWhatToExpectPage/_index.scss
@@ -1,8 +1,8 @@
 .what-to-expect {
   .green-highlight {
     background-color: #ecf3ec;
-    border-left: .5rem solid #01a91c;
-    padding: .6rem;
+    border-left: 0.5rem solid #01a91c;
+    padding: 0.6rem;
     margin-top: 2rem;
   }
   .white-checkmark {
@@ -11,7 +11,7 @@
     justify-content: center;
     height: 2rem;
     width: 2rem;
-    margin-right: .5rem;
+    margin-right: 0.5rem;
     color: #fff;
     background-color: #000;
     border-radius: 50%;

--- a/src/data/fflipConfig.js
+++ b/src/data/fflipConfig.js
@@ -3,12 +3,14 @@
  * https://github.com/FredKSchott/fflip
  */
 const fflipConfig = {
-  features: [{
-    id: "retroCerts",
-    description: "Allows users to retroactively certify.",
-    enabled: false
-  }],
-  criteria: []
+  features: [
+    {
+      id: "retroCerts",
+      description: "Allows users to retroactively certify.",
+      enabled: false,
+    },
+  ],
+  criteria: [],
 };
 
 module.exports = fflipConfig;

--- a/src/data/test-accounts.json
+++ b/src/data/test-accounts.json
@@ -1,19 +1,23 @@
-[{
-  "lastName": "Last",
-  "eddcan": "1234567890",
-  "ssn": "123456789",
-  "authToken": "e882639f-07b9-423d-9e1e-5f6b594b60eb",
-  "weeksToCertify": [0, 1]
-}, {
-  "lastName": "Last",
-  "eddcan": "1111122222",
-  "ssn": "888990000",
-  "authToken": "0be63615-6f3f-4e1f-a104-f1fab45c126b",
-  "weeksToCertify": [2]
-}, {
-  "lastName": "FooBar",
-  "eddcan": "1234554321",
-  "ssn": "012345678",
-  "authToken": "1701c969-2bb2-449e-8916-6f0fb87d190b",
-  "weeksToCertify": [1, 2, 3, 5]
-}]
+[
+  {
+    "lastName": "Last",
+    "eddcan": "1234567890",
+    "ssn": "123456789",
+    "authToken": "e882639f-07b9-423d-9e1e-5f6b594b60eb",
+    "weeksToCertify": [0, 1]
+  },
+  {
+    "lastName": "Last",
+    "eddcan": "1111122222",
+    "ssn": "888990000",
+    "authToken": "0be63615-6f3f-4e1f-a104-f1fab45c126b",
+    "weeksToCertify": [2]
+  },
+  {
+    "lastName": "FooBar",
+    "eddcan": "1234554321",
+    "ssn": "012345678",
+    "authToken": "1701c969-2bb2-449e-8916-6f0fb87d190b",
+    "weeksToCertify": [1, 2, 3, 5]
+  }
+]

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -7,7 +7,7 @@ function createRouter() {
   const router = Router();
 
   if (fflip.features.retroCerts.enabled) {
-    router.use(createRetroCertsRouter())
+    router.use(createRetroCertsRouter());
   }
 
   /**

--- a/src/routes/single-page-app.js
+++ b/src/routes/single-page-app.js
@@ -13,13 +13,12 @@ const singlePageAppRouter = Router();
 singlePageAppRouter.get("/*", (req, res) => {
   const cssURL = getCdnPath(`/build/css/${manifestStyles["App.css"]}`);
 
-  const is404 = !Object.values(pageRoutes)
-    .some(route => {
-      if (route.routeProps && route.routeProps.exact) {
-        return route.path === req.path;
-      }
-      return req.path.startsWith(route.path);
-    });
+  const is404 = !Object.values(pageRoutes).some((route) => {
+    if (route.routeProps && route.routeProps.exact) {
+      return route.path === req.path;
+    }
+    return req.path.startsWith(route.path);
+  });
   const statusCode = is404 ? 404 : 200;
 
   res.status(statusCode).send(


### PR DESCRIPTION
Encourage the user of prettier to format code. Add
an npm command and a link to how to integrate with
your editor.

No behavior change.

===

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
