### PR TITLE
Move CosmosDB endpoint to .env

### DIFF
--- a/src/data/cosmosConfig.js
+++ b/src/data/cosmosConfig.js
@@ -1,5 +1,5 @@
 const COSMOS_CONFIG = {
-  endpoint: "https://cdbbnscnd001.documents.azure.com:443/",
+  endpoint: getRetrocertEndpoint(),
   key: getRetrocertDbKey(),
   databaseName: "retrocert",
   formsContainerName: "forms",
@@ -8,7 +8,7 @@ const COSMOS_CONFIG = {
 };
 
 function getRetrocertDbKey() {
-  // todo(kalvin): retrieve this key from azure instead of a local uncommitted file
+  // todo(kalvin): retrieve this key from azure instead of uncommitted .env
   const key = process.env.COSMOS_DB_KEY;
 
   if (!key) {
@@ -16,6 +16,16 @@ function getRetrocertDbKey() {
   }
 
   return key;
+}
+
+function getRetrocertEndpoint() {
+  const endpoint = process.env.COSMOS_ENDPOINT;
+
+  if (!endpoint) {
+    console.error("CosmosDB endpoint URL is missing");
+  }
+
+  return endpoint;
 }
 
 module.exports = COSMOS_CONFIG;


### PR DESCRIPTION
This PR moves the CosmosDB endpoint to .env, now that we have endpoints for both staging and prod. I've already added the new application variable COSMOS_ENDPOINT to staging and will add it to prod tonight. 

===

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
