### PR TITLE
Add a 30 min session timer.

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -193,7 +193,8 @@
     "eddcan-error": "Please check your EDDCAN.",
     "ssn-error": "Please check your SSN.",
     "invalid-user-error": "We couldn't find you in the system.",
-    "invalid-recaptcha-error": "Human verification expired. Please check the checkbox again."
+    "invalid-recaptcha-error": "Human verification expired. Please check the checkbox again.",
+    "session-timed-out": "Logged out after being idle for 30 minutes."
   },
   "retrocerts-what-to-expect": {
     "title": "Retroactive Unemployment Certification",

--- a/src/client/components/RetroCertsRoute/__snapshots__/index.test.js.snap
+++ b/src/client/components/RetroCertsRoute/__snapshots__/index.test.js.snap
@@ -31,6 +31,7 @@ exports[`<RetroCertsRoute /> route needing auth with user data 1`] = `
   path="/path"
 >
   <TestComponent
+    setUserData={[Function]}
     userData={
       Object {
         "weeksToCertify": Array [
@@ -38,6 +39,10 @@ exports[`<RetroCertsRoute /> route needing auth with user data 1`] = `
         ],
       }
     }
+  />
+  <SessionTimer
+    action="startOrUpdate"
+    setUserData={[Function]}
   />
 </Route>
 `;

--- a/src/client/components/RetroCertsRoute/index.js
+++ b/src/client/components/RetroCertsRoute/index.js
@@ -4,6 +4,7 @@ import React from "react";
 import { userDataPropType, setUserDataPropType } from "../../commonPropTypes";
 import AUTH_STRINGS from "../../../data/authStrings";
 import PageNotFound from "../../pages/PageNotFound";
+import SessionTimer from "../../components/SessionTimer";
 
 function userIsAuthenticated(userData) {
   return !!userData.weeksToCertify;
@@ -21,11 +22,18 @@ function RetroCertsRoute(props) {
   let routeChild = <div>Loading...</div>;
   if (isProduction) {
     routeChild = <PageNotFound />;
-  } else if (
-    !requiresAuthentication ||
-    userIsAuthenticated(pageProps.userData)
-  ) {
+  } else if (!requiresAuthentication) {
     routeChild = <Component {...pageProps} />;
+  } else if (userIsAuthenticated(pageProps.userData)) {
+    routeChild = (
+      <React.Fragment>
+        <Component {...pageProps} />
+        <SessionTimer
+          action="startOrUpdate"
+          setUserData={pageProps.setUserData}
+        />
+      </React.Fragment>
+    );
   } else {
     // This page requires authentication and the user is not authenticated.
     // Try using the auth token if they have one.

--- a/src/client/components/RetroCertsRoute/index.test.js
+++ b/src/client/components/RetroCertsRoute/index.test.js
@@ -36,6 +36,7 @@ describe("<RetroCertsRoute />", () => {
       pageComponent: TestComponent,
       pageProps: {
         userData: {},
+        setUserData: () => {},
       },
       requiresAuthentication: true,
     });
@@ -50,6 +51,7 @@ describe("<RetroCertsRoute />", () => {
       pageComponent: TestComponent,
       pageProps: {
         userData: { weeksToCertify: [0] },
+        setUserData: () => {},
       },
       requiresAuthentication: true,
     });

--- a/src/client/components/SessionTimer/__snapshots__/index.test.js.snap
+++ b/src/client/components/SessionTimer/__snapshots__/index.test.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SessionTimer /> clear 1`] = `""`;
+
+exports[`<SessionTimer /> startOrUpdate 1`] = `""`;

--- a/src/client/components/SessionTimer/index.js
+++ b/src/client/components/SessionTimer/index.js
@@ -1,0 +1,50 @@
+import { useHistory } from "react-router-dom";
+import PropTypes from "prop-types";
+import { setUserDataPropType } from "../../commonPropTypes";
+import AUTH_STRINGS from "../../../data/authStrings";
+
+let timerId = null;
+
+function SessionTimer(props) {
+  const TIMEOUT_MS = 30 * 60 * 1000;
+  const history = useHistory();
+  const { action, setUserData } = props;
+
+  function startOrUpdate() {
+    clear();
+    timerId = setTimeout(() => {
+      if (sessionStorage.getItem(AUTH_STRINGS.authToken)) {
+        sessionStorage.removeItem(AUTH_STRINGS.authToken);
+        history.push("/retroactive-certification");
+        setUserData({
+          status: AUTH_STRINGS.statusCode.sessionTimedOut,
+        });
+      }
+    }, TIMEOUT_MS);
+  }
+
+  function clear() {
+    clearTimeout(timerId);
+    timerId = null;
+  }
+
+  if (action === "startOrUpdate") {
+    startOrUpdate();
+  } else if (action === "clear") {
+    clear();
+  }
+
+  // No HTML to render.
+  return false;
+}
+
+SessionTimer.propTypes = {
+  action: PropTypes.string.isRequired,
+  setUserData: setUserDataPropType.isRequired,
+};
+
+SessionTimer.getTimerIdForTest = function () {
+  return timerId;
+};
+
+export default SessionTimer;

--- a/src/client/components/SessionTimer/index.test.js
+++ b/src/client/components/SessionTimer/index.test.js
@@ -1,0 +1,25 @@
+import renderNonTransContent from "../../test-helpers/renderNonTransContent";
+import Component from "./index";
+
+describe("<SessionTimer />", () => {
+  it("startOrUpdate", async () => {
+    const wrapper = renderNonTransContent(Component, "SessionTimer", {
+      action: "startOrUpdate",
+      setUserData: () => {},
+    });
+
+    expect(wrapper).toMatchSnapshot();
+    expect(Component.getTimerIdForTest()).not.toBeNull();
+    clearTimeout(Component.getTimerIdForTest());
+  });
+
+  it("clear", async () => {
+    const wrapper = renderNonTransContent(Component, "SessionTimer", {
+      action: "clear",
+      setUserData: () => {},
+    });
+
+    expect(wrapper).toMatchSnapshot();
+    expect(Component.getTimerIdForTest()).toBeNull();
+  });
+});

--- a/src/client/pages/RetroCertsAuthPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsAuthPage/__snapshots__/index.test.js.snap
@@ -1,6 +1,126 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<RetroCertsAuthPage /> renders the retro certs main page 1`] = `
+exports[`<RetroCertsAuthPage /> retro certs auth page 1`] = `
+<div
+  id="overflow-wrapper"
+>
+  <Header />
+  <main>
+    <div
+      className="container p-4"
+    >
+      <h1>
+        Retroactive Unemployment Certification
+      </h1>
+      <h2
+        className="mt-4"
+      >
+        Help us find you
+      </h2>
+      <p>
+        We need to make sure your identity matches EDD records so that we show you accurate records.
+      </p>
+      <Form
+        inline={false}
+        onSubmit={[Function]}
+      >
+        <Row
+          noGutters={false}
+        >
+          <FormGroup
+            className="col-md-6"
+            controlId="formLastName"
+          >
+            <FormLabel
+              column={false}
+              srOnly={false}
+            >
+              Last name
+            </FormLabel>
+            <FormControl
+              onChange={[Function]}
+              type="text"
+              value=""
+            />
+          </FormGroup>
+        </Row>
+        <Row
+          noGutters={false}
+        >
+          <FormGroup
+            className="col-md-6"
+            controlId="formEddcan"
+          >
+            <FormLabel
+              column={false}
+              srOnly={false}
+            >
+              EDDCAN
+            </FormLabel>
+            <FormControl
+              onChange={[Function]}
+              type="text"
+              value=""
+            />
+          </FormGroup>
+        </Row>
+        <Row
+          noGutters={false}
+        >
+          <FormGroup
+            className="col-md-6"
+            controlId="formSsn"
+          >
+            <FormLabel
+              column={false}
+              srOnly={false}
+            >
+              Social Security Number
+            </FormLabel>
+            <FormControl
+              onChange={[Function]}
+              type="password"
+              value=""
+            />
+          </FormGroup>
+        </Row>
+        <Row
+          noGutters={false}
+        >
+          <FormGroup
+            className="col-md-6"
+            controlId="formReCaptcha"
+          >
+            <AsyncScriptLoader(ReCAPTCHA)
+              sitekey="6Lf-DQEVAAAAABCMwJ-Gnbqec08RuiPhMZPtZPm9"
+            />
+            <FormText
+              className="text-muted"
+            >
+              Security check provided by reCAPTCHA.
+            </FormText>
+          </FormGroup>
+        </Row>
+        <Button
+          active={false}
+          disabled={false}
+          type="submit"
+          variant="secondary"
+        >
+          Find me
+        </Button>
+      </Form>
+    </div>
+  </main>
+  <SessionTimer
+    action="clear"
+    setUserData={[Function]}
+  />
+  <Footer />
+</div>
+`;
+
+exports[`<RetroCertsAuthPage /> retro certs auth page with captcha timeout error 1`] = `
 <div
   id="overflow-wrapper"
 >
@@ -103,7 +223,33 @@ exports[`<RetroCertsAuthPage /> renders the retro certs main page 1`] = `
         </Row>
         <Row
           noGutters={false}
-        />
+        >
+          <div
+            className="col-md-6"
+          >
+            <Alert
+              closeLabel="Close alert"
+              show={true}
+              transition={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "defaultProps": Object {
+                    "appear": false,
+                    "in": false,
+                    "mountOnEnter": false,
+                    "timeout": 300,
+                    "unmountOnExit": false,
+                  },
+                  "displayName": "Fade",
+                  "render": [Function],
+                }
+              }
+              variant="danger"
+            >
+              Human verification expired. Please check the checkbox again.
+            </Alert>
+          </div>
+        </Row>
         <Button
           active={false}
           disabled={false}
@@ -115,6 +261,308 @@ exports[`<RetroCertsAuthPage /> renders the retro certs main page 1`] = `
       </Form>
     </div>
   </main>
+  <SessionTimer
+    action="clear"
+    setUserData={[Function]}
+  />
+  <Footer />
+</div>
+`;
+
+exports[`<RetroCertsAuthPage /> retro certs auth page with session timeout 1`] = `
+<div
+  id="overflow-wrapper"
+>
+  <Header />
+  <main>
+    <div
+      className="container p-4"
+    >
+      <h1>
+        Retroactive Unemployment Certification
+      </h1>
+      <h2
+        className="mt-4"
+      >
+        Help us find you
+      </h2>
+      <p>
+        We need to make sure your identity matches EDD records so that we show you accurate records.
+      </p>
+      <Form
+        inline={false}
+        onSubmit={[Function]}
+      >
+        <Row
+          noGutters={false}
+        >
+          <div
+            className="col-md-6"
+          >
+            <Alert
+              closeLabel="Close alert"
+              show={true}
+              transition={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "defaultProps": Object {
+                    "appear": false,
+                    "in": false,
+                    "mountOnEnter": false,
+                    "timeout": 300,
+                    "unmountOnExit": false,
+                  },
+                  "displayName": "Fade",
+                  "render": [Function],
+                }
+              }
+              variant="danger"
+            >
+              Logged out after being idle for 30 minutes.
+            </Alert>
+          </div>
+        </Row>
+        <Row
+          noGutters={false}
+        >
+          <FormGroup
+            className="col-md-6"
+            controlId="formLastName"
+          >
+            <FormLabel
+              column={false}
+              srOnly={false}
+            >
+              Last name
+            </FormLabel>
+            <FormControl
+              onChange={[Function]}
+              type="text"
+              value=""
+            />
+          </FormGroup>
+        </Row>
+        <Row
+          noGutters={false}
+        >
+          <FormGroup
+            className="col-md-6"
+            controlId="formEddcan"
+          >
+            <FormLabel
+              column={false}
+              srOnly={false}
+            >
+              EDDCAN
+            </FormLabel>
+            <FormControl
+              onChange={[Function]}
+              type="text"
+              value=""
+            />
+          </FormGroup>
+        </Row>
+        <Row
+          noGutters={false}
+        >
+          <FormGroup
+            className="col-md-6"
+            controlId="formSsn"
+          >
+            <FormLabel
+              column={false}
+              srOnly={false}
+            >
+              Social Security Number
+            </FormLabel>
+            <FormControl
+              onChange={[Function]}
+              type="password"
+              value=""
+            />
+          </FormGroup>
+        </Row>
+        <Row
+          noGutters={false}
+        >
+          <FormGroup
+            className="col-md-6"
+            controlId="formReCaptcha"
+          >
+            <AsyncScriptLoader(ReCAPTCHA)
+              sitekey="6Lf-DQEVAAAAABCMwJ-Gnbqec08RuiPhMZPtZPm9"
+            />
+            <FormText
+              className="text-muted"
+            >
+              Security check provided by reCAPTCHA.
+            </FormText>
+          </FormGroup>
+        </Row>
+        <Button
+          active={false}
+          disabled={false}
+          type="submit"
+          variant="secondary"
+        >
+          Find me
+        </Button>
+      </Form>
+    </div>
+  </main>
+  <SessionTimer
+    action="clear"
+    setUserData={[Function]}
+  />
+  <Footer />
+</div>
+`;
+
+exports[`<RetroCertsAuthPage /> retro certs auth page with user not found error 1`] = `
+<div
+  id="overflow-wrapper"
+>
+  <Header />
+  <main>
+    <div
+      className="container p-4"
+    >
+      <h1>
+        Retroactive Unemployment Certification
+      </h1>
+      <h2
+        className="mt-4"
+      >
+        Help us find you
+      </h2>
+      <p>
+        We need to make sure your identity matches EDD records so that we show you accurate records.
+      </p>
+      <Form
+        inline={false}
+        onSubmit={[Function]}
+      >
+        <Row
+          noGutters={false}
+        >
+          <FormGroup
+            className="col-md-6"
+            controlId="formLastName"
+          >
+            <FormLabel
+              column={false}
+              srOnly={false}
+            >
+              Last name
+            </FormLabel>
+            <FormControl
+              onChange={[Function]}
+              type="text"
+              value=""
+            />
+          </FormGroup>
+        </Row>
+        <Row
+          noGutters={false}
+        >
+          <FormGroup
+            className="col-md-6"
+            controlId="formEddcan"
+          >
+            <FormLabel
+              column={false}
+              srOnly={false}
+            >
+              EDDCAN
+            </FormLabel>
+            <FormControl
+              onChange={[Function]}
+              type="text"
+              value=""
+            />
+          </FormGroup>
+        </Row>
+        <Row
+          noGutters={false}
+        >
+          <FormGroup
+            className="col-md-6"
+            controlId="formSsn"
+          >
+            <FormLabel
+              column={false}
+              srOnly={false}
+            >
+              Social Security Number
+            </FormLabel>
+            <FormControl
+              onChange={[Function]}
+              type="password"
+              value=""
+            />
+          </FormGroup>
+        </Row>
+        <Row
+          noGutters={false}
+        >
+          <FormGroup
+            className="col-md-6"
+            controlId="formReCaptcha"
+          >
+            <AsyncScriptLoader(ReCAPTCHA)
+              sitekey="6Lf-DQEVAAAAABCMwJ-Gnbqec08RuiPhMZPtZPm9"
+            />
+            <FormText
+              className="text-muted"
+            >
+              Security check provided by reCAPTCHA.
+            </FormText>
+          </FormGroup>
+        </Row>
+        <Row
+          noGutters={false}
+        >
+          <div
+            className="col-md-6"
+          >
+            <Alert
+              closeLabel="Close alert"
+              show={true}
+              transition={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "defaultProps": Object {
+                    "appear": false,
+                    "in": false,
+                    "mountOnEnter": false,
+                    "timeout": 300,
+                    "unmountOnExit": false,
+                  },
+                  "displayName": "Fade",
+                  "render": [Function],
+                }
+              }
+              variant="danger"
+            >
+              We couldn't find you in the system.
+            </Alert>
+          </div>
+        </Row>
+        <Button
+          active={false}
+          disabled={false}
+          type="submit"
+          variant="secondary"
+        >
+          Find me
+        </Button>
+      </Form>
+    </div>
+  </main>
+  <SessionTimer
+    action="clear"
+    setUserData={[Function]}
+  />
   <Footer />
 </div>
 `;

--- a/src/client/pages/RetroCertsAuthPage/index.js
+++ b/src/client/pages/RetroCertsAuthPage/index.js
@@ -10,6 +10,7 @@ import AUTH_STRINGS from "../../../data/authStrings";
 import { userDataPropType, setUserDataPropType } from "../../commonPropTypes";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header";
+import SessionTimer from "../../components/SessionTimer";
 
 function RetroCertsAuthPage(props) {
   const { t } = useTranslation();
@@ -21,6 +22,30 @@ function RetroCertsAuthPage(props) {
   const [lastName, setLastName] = useState("");
   const [eddcan, setEddcan] = useState("");
   const [ssn, setSsn] = useState("");
+
+  const status = userData && userData.status;
+  const errorTransKey = new Map([
+    [
+      AUTH_STRINGS.statusCode.userNotFound,
+      "retrocert-login.invalid-user-error",
+    ],
+    [
+      AUTH_STRINGS.statusCode.recaptchaInvalid,
+      "retrocert-login.invalid-recaptcha-error",
+    ],
+    [
+      AUTH_STRINGS.statusCode.sessionTimedOut,
+      "retrocert-login.session-timed-out",
+    ],
+  ]).get(status);
+
+  const errorAlert = errorTransKey && (
+    <Row>
+      <div className="col-md-6">
+        <Alert variant="danger">{t(errorTransKey)}</Alert>
+      </div>
+    </Row>
+  );
 
   const recaptchaRef = React.createRef();
 
@@ -77,6 +102,8 @@ function RetroCertsAuthPage(props) {
           <h2 className="mt-4">{t("retrocert-login.subheader")}</h2>
           <p>{t("retrocert-login.help-text")}</p>
           <Form onSubmit={handleSubmit}>
+            {errorTransKey === "retrocert-login.session-timed-out" &&
+              errorAlert}
             <Row>
               <Form.Group controlId="formLastName" className="col-md-6">
                 <Form.Label>{t("retrocert-login.last-name-label")}</Form.Label>
@@ -118,32 +145,16 @@ function RetroCertsAuthPage(props) {
                 </Form.Text>
               </Form.Group>
             </Row>
-            <Row>
-              {(() => {
-                const status = userData && userData.status;
-                let transKey = "";
-                if (status === AUTH_STRINGS.statusCode.userNotFound) {
-                  transKey = "retrocert-login.invalid-user-error";
-                } else if (
-                  status === AUTH_STRINGS.statusCode.recaptchaInvalid
-                ) {
-                  transKey = "retrocert-login.invalid-recaptcha-error";
-                }
-                if (transKey) {
-                  return (
-                    <div className="col-md-6">
-                      <Alert variant="danger">{t(transKey)}</Alert>
-                    </div>
-                  );
-                }
-              })()}
-            </Row>
+            {(errorTransKey === "retrocert-login.invalid-user-error" ||
+              errorTransKey === "retrocert-login.invalid-recaptcha-error") &&
+              errorAlert}
             <Button variant="secondary" type="submit">
               {t("retrocert-login.submit")}
             </Button>
           </Form>
         </div>
       </main>
+      <SessionTimer action="clear" setUserData={setUserDataPropType} />
       <Footer />
     </div>
   );

--- a/src/client/pages/RetroCertsAuthPage/index.test.js
+++ b/src/client/pages/RetroCertsAuthPage/index.test.js
@@ -1,9 +1,34 @@
 import renderNonTransContent from "../../test-helpers/renderNonTransContent";
+import AUTH_STRINGS from "../../../data/authStrings";
 import Component from "./index";
 
 describe("<RetroCertsAuthPage />", () => {
-  it("renders the retro certs main page", async () => {
+  it("retro certs auth page", async () => {
     const wrapper = renderNonTransContent(Component, "RetroCertsAuthPage");
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("retro certs auth page with user not found error", async () => {
+    const wrapper = renderNonTransContent(Component, "RetroCertsAuthPage", {
+      userData: { status: AUTH_STRINGS.statusCode.userNotFound },
+    });
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("retro certs auth page with captcha timeout error", async () => {
+    const wrapper = renderNonTransContent(Component, "RetroCertsAuthPage", {
+      userData: { status: AUTH_STRINGS.statusCode.recaptchaInvalid },
+    });
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("retro certs auth page with session timeout", async () => {
+    const wrapper = renderNonTransContent(Component, "RetroCertsAuthPage", {
+      userData: { status: AUTH_STRINGS.statusCode.sessionTimedOut },
+    });
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/data/authStrings.js
+++ b/src/data/authStrings.js
@@ -15,6 +15,7 @@ const AUTH_STRINGS = {
     notLoggedIn: "not-logged-in",
     userNotFound: "user-not-found",
     recaptchaInvalid: "recaptcha-invalid",
+    sessionTimedOut: "session-timed-out",
   },
 };
 


### PR DESCRIPTION
This is implemented as a component with two modes:
- On the login page, it just clears any timers.
- On any page that requires authentication, it starts or
  restarts a timer for 30 min. When it fires, it clears
  the user's authToken and redirects them to the login
  page.

Also add another error alert for being timed out.
This shows above the login form so even on a phone,
you can see the message.

===

Resolves #302 

- [X] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [X] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [X] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made

![screencapture-localhost-3000-retroactive-certification-2020-06-15-15_42_29](https://user-images.githubusercontent.com/175378/84714925-ed68b580-af23-11ea-90c8-27c9ac60b7ce.png)
