### PR TITLE
Add the days sick question.

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -181,6 +181,10 @@
   "tab5-blockquote1": "For more information, visit <2>CARES Act Provisions<2>.",
   "page-not-found-header": "Page Not Found",
   "page-not-found-text": "The page or form you requested cannot be found. If your link worked before but does not work now, then this page has moved or was deleted as part of our ongoing efforts to make our website work better for you.",
+  "yesnoquestion": {
+    "Yes": "Yes",
+    "No": "No"
+  },
   "retrocert-login": {
     "title": "Retroactive Unemployment Certification",
     "subheader": "Help us find you",
@@ -222,6 +226,7 @@
     "form-header": "Week {{weekForUser}}: {{weekString}}",
     "q-tooSick": "Were you too sick or injured to work?",
     "qhelp-tooSick": "You must be well enough to work every day of the week to receive full benefits.",
+    "q-tooSickNumberOfDays": "Enter the number of days (1 through 7) you were unable to work.",
     "q-fullTime": "Was there any reason (other than sickness or injury) that you could not have accepted full-time work each workday?",
     "qhelp-fullTime": "Available means you are ready and willing to accept work that matches your occupational skills and educational background.",
     "q-didYouLook": "Did you look for work?",

--- a/src/client/components/DaysSickQuestion/__snapshots__/index.test.js.snap
+++ b/src/client/components/DaysSickQuestion/__snapshots__/index.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<DaysSickQuestion /> renders the component 1`] = `
+<Form
+  inline={false}
+>
+  <FormGroup>
+    <FormLabel
+      column={true}
+      md="10"
+      srOnly={false}
+    >
+      Enter the number of days (1 through 7) you were unable to work.
+    </FormLabel>
+    <FormControl
+      onChange={[Function]}
+      type="text"
+      value=""
+    />
+  </FormGroup>
+</Form>
+`;

--- a/src/client/components/DaysSickQuestion/__snapshots__/index.test.js.snap
+++ b/src/client/components/DaysSickQuestion/__snapshots__/index.test.js.snap
@@ -6,14 +6,19 @@ exports[`<DaysSickQuestion /> renders the component 1`] = `
 >
   <FormGroup>
     <FormLabel
-      column={true}
-      md="10"
+      column={false}
       srOnly={false}
     >
       Enter the number of days (1 through 7) you were unable to work.
     </FormLabel>
     <FormControl
+      maxLength={1}
       onChange={[Function]}
+      style={
+        Object {
+          "width": "3rem",
+        }
+      }
       type="text"
       value=""
     />

--- a/src/client/components/DaysSickQuestion/index.js
+++ b/src/client/components/DaysSickQuestion/index.js
@@ -1,0 +1,43 @@
+import Form from "react-bootstrap/Form";
+import PropTypes from "prop-types";
+import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+function DaysSickQuestion(props) {
+  const { t } = useTranslation();
+
+  const [numDays, setNumDays] = useState(
+    props.numDays !== undefined ? String(props.numDays) : ""
+  );
+
+  function onChange(event) {
+    setNumDays(event.target.value);
+
+    let numDays = parseInt(event.target.value, 10);
+    if (isNaN(numDays)) {
+      numDays = undefined;
+    }
+    props.onChange({
+      name: "tooSickNumberOfDays",
+      value: numDays,
+    });
+  }
+
+  return (
+    <Form>
+      <Form.Group>
+        <Form.Label column md="10">
+          {t("retrocerts-certification.q-tooSickNumberOfDays")}
+        </Form.Label>
+        <Form.Control type="text" value={numDays} onChange={onChange} />
+      </Form.Group>
+    </Form>
+  );
+}
+
+DaysSickQuestion.propTypes = {
+  onChange: PropTypes.func.isRequired,
+  numDays: PropTypes.number,
+};
+
+export default DaysSickQuestion;

--- a/src/client/components/DaysSickQuestion/index.js
+++ b/src/client/components/DaysSickQuestion/index.js
@@ -26,10 +26,16 @@ function DaysSickQuestion(props) {
   return (
     <Form>
       <Form.Group>
-        <Form.Label column md="10">
+        <Form.Label>
           {t("retrocerts-certification.q-tooSickNumberOfDays")}
         </Form.Label>
-        <Form.Control type="text" value={numDays} onChange={onChange} />
+        <Form.Control
+          style={{ width: "3rem" }}
+          type="text"
+          value={numDays}
+          onChange={onChange}
+          maxLength={1}
+        />
       </Form.Group>
     </Form>
   );

--- a/src/client/components/DaysSickQuestion/index.test.js
+++ b/src/client/components/DaysSickQuestion/index.test.js
@@ -1,0 +1,12 @@
+import renderNonTransContent from "../../test-helpers/renderNonTransContent";
+import Component from "./index";
+
+describe("<DaysSickQuestion />", () => {
+  it("renders the component", async () => {
+    const wrapper = renderNonTransContent(Component, "DaysSickQuestion", {
+      onChange: () => {},
+    });
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/client/components/YesNoQuestion/index.js
+++ b/src/client/components/YesNoQuestion/index.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { Form } from "react-bootstrap";
+import { useTranslation } from "react-i18next";
 
 function YesNoQuestion(props) {
   const {
@@ -10,8 +11,10 @@ function YesNoQuestion(props) {
     inputName,
     onChange,
     ifYes,
+    children,
   } = props;
   const [isYes, setIsYes] = useState(ifYes);
+  const { t } = useTranslation();
 
   function onSelectionChanged(e) {
     const value = e.target.value;
@@ -40,9 +43,9 @@ function YesNoQuestion(props) {
             <Form.Check
               key={value}
               inline
-              label={value}
+              label={t(`yesnoquestion.${value}`)}
               type="radio"
-              id={`radio${value}`}
+              id={`${inputName}radio${value}`}
               onChange={onSelectionChanged}
               name={inputName}
               value={value}
@@ -51,17 +54,7 @@ function YesNoQuestion(props) {
           ))}
         </Form.Group>
       </Form>
-      <div hidden={isYes === null || !isYes}>
-        <p className="text-muted">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur
-          cursus neque risus, id efficitur felis tincidunt in. Mauris pretium
-          tortor orci, ac pharetra ipsum vulputate quis. Maecenas sit amet
-          libero ut elit ornare imperdiet sit amet ac velit. Nunc sit amet
-          lacinia velit, a tincidunt nibh. Ut porttitor finibus dolor, non porta
-          dolor ornare sed. Aenean nunc dolor, congue quis sodales eu, viverra
-          tristique ipsum. Ut nec iaculis ipsum, at bibendum sem.
-        </p>
-      </div>
+      <div hidden={isYes === null || !isYes}>{children}</div>
     </div>
   );
 }
@@ -73,6 +66,10 @@ YesNoQuestion.propTypes = {
   inputName: PropTypes.string.isRequired,
   onChange: PropTypes.func,
   ifYes: PropTypes.bool,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
 };
 
 export default YesNoQuestion;

--- a/src/client/pages/RetroCertsCertificationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsCertificationPage/__snapshots__/index.test.js.snap
@@ -37,7 +37,6 @@ exports[`<RetroCertsCertificationPage /> Certify for 2nd week of 2 1`] = `
         />
       </h3>
       <Row
-        key="1-0"
         noGutters={false}
       >
         <Col>
@@ -45,14 +44,19 @@ exports[`<RetroCertsCertificationPage /> Certify for 2nd week of 2 1`] = `
             helpText="You must be well enough to work every day of the week to receive full benefits."
             ifYes={false}
             inputName="tooSick"
+            key="1tooSick"
             onChange={[Function]}
             questionNumber={1}
             questionText="Were you too sick or injured to work?"
-          />
+          >
+            <DaysSickQuestion
+              onChange={[Function]}
+            />
+          </YesNoQuestion>
         </Col>
       </Row>
       <Row
-        key="1-1"
+        key="1fullTime"
         noGutters={false}
       >
         <Col>
@@ -67,7 +71,7 @@ exports[`<RetroCertsCertificationPage /> Certify for 2nd week of 2 1`] = `
         </Col>
       </Row>
       <Row
-        key="1-2"
+        key="1didYouLook"
         noGutters={false}
       >
         <Col>
@@ -82,7 +86,7 @@ exports[`<RetroCertsCertificationPage /> Certify for 2nd week of 2 1`] = `
         </Col>
       </Row>
       <Row
-        key="1-3"
+        key="1refuseWork"
         noGutters={false}
       >
         <Col>
@@ -97,7 +101,7 @@ exports[`<RetroCertsCertificationPage /> Certify for 2nd week of 2 1`] = `
         </Col>
       </Row>
       <Row
-        key="1-4"
+        key="1schoolOrTraining"
         noGutters={false}
       >
         <Col>
@@ -112,7 +116,7 @@ exports[`<RetroCertsCertificationPage /> Certify for 2nd week of 2 1`] = `
         </Col>
       </Row>
       <Row
-        key="1-5"
+        key="1workOrEarn"
         noGutters={false}
       >
         <Col>
@@ -216,7 +220,6 @@ exports[`<RetroCertsCertificationPage /> Certify for one week of 2 1`] = `
         />
       </h3>
       <Row
-        key="0-0"
         noGutters={false}
       >
         <Col>
@@ -224,14 +227,19 @@ exports[`<RetroCertsCertificationPage /> Certify for one week of 2 1`] = `
             helpText="You must be well enough to work every day of the week to receive full benefits."
             ifYes={false}
             inputName="tooSick"
+            key="0tooSick"
             onChange={[Function]}
             questionNumber={1}
             questionText="Were you too sick or injured to work?"
-          />
+          >
+            <DaysSickQuestion
+              onChange={[Function]}
+            />
+          </YesNoQuestion>
         </Col>
       </Row>
       <Row
-        key="0-1"
+        key="0fullTime"
         noGutters={false}
       >
         <Col>
@@ -246,7 +254,7 @@ exports[`<RetroCertsCertificationPage /> Certify for one week of 2 1`] = `
         </Col>
       </Row>
       <Row
-        key="0-2"
+        key="0didYouLook"
         noGutters={false}
       >
         <Col>
@@ -260,7 +268,7 @@ exports[`<RetroCertsCertificationPage /> Certify for one week of 2 1`] = `
         </Col>
       </Row>
       <Row
-        key="0-3"
+        key="0refuseWork"
         noGutters={false}
       >
         <Col>
@@ -274,7 +282,7 @@ exports[`<RetroCertsCertificationPage /> Certify for one week of 2 1`] = `
         </Col>
       </Row>
       <Row
-        key="0-4"
+        key="0schoolOrTraining"
         noGutters={false}
       >
         <Col>
@@ -288,7 +296,7 @@ exports[`<RetroCertsCertificationPage /> Certify for one week of 2 1`] = `
         </Col>
       </Row>
       <Row
-        key="0-5"
+        key="0workOrEarn"
         noGutters={false}
       >
         <Col>

--- a/src/client/pages/RetroCertsCertificationPage/index.js
+++ b/src/client/pages/RetroCertsCertificationPage/index.js
@@ -17,6 +17,7 @@ import AUTH_STRINGS from "../../../data/authStrings";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header";
 import YesNoQuestion from "../../components/YesNoQuestion";
+import DaysSickQuestion from "../../components/DaysSickQuestion";
 
 function RetroCertsCertificationPage(props) {
   const { t } = useTranslation();
@@ -50,7 +51,7 @@ function RetroCertsCertificationPage(props) {
   const formDataArray = userData.formData || [];
   const formData = formDataArray[weekForUser - 1] || { weekIndex };
 
-  const handleYesNoChange = (event) => {
+  const handleFormDataChange = (event) => {
     const { value, name } = event;
     formDataArray[weekForUser - 1] = {
       ...formData,
@@ -107,22 +108,39 @@ function RetroCertsCertificationPage(props) {
               values={{ weekForUser, weekString: toWeekString(weekIndex) }}
             />
           </h3>
+          <Row>
+            <Col>
+              <YesNoQuestion
+                key={weekIndex + "tooSick"}
+                questionNumber={1}
+                questionText={t("retrocerts-certification.q-tooSick")}
+                helpText={t("retrocerts-certification.qhelp-tooSick")}
+                ifYes={formData.tooSick}
+                onChange={(e) => handleFormDataChange(e)}
+                inputName="tooSick"
+              >
+                <DaysSickQuestion
+                  numDays={formData.tooSickNumberOfDays}
+                  onChange={(e) => handleFormDataChange(e)}
+                />
+              </YesNoQuestion>
+            </Col>
+          </Row>
           {[
-            "tooSick",
             "fullTime",
             "didYouLook",
             "refuseWork",
             "schoolOrTraining",
             "workOrEarn",
           ].map((name, index) => (
-            <Row key={`${weekIndex}-${index}`}>
+            <Row key={weekIndex + name}>
               <Col>
                 <YesNoQuestion
-                  questionNumber={index + 1}
+                  questionNumber={index + 2}
                   questionText={t(`retrocerts-certification.q-${name}`)}
                   helpText={t(`retrocerts-certification.qhelp-${name}`)}
                   ifYes={formData[name]}
-                  onChange={(e) => handleYesNoChange(e)}
+                  onChange={(e) => handleFormDataChange(e)}
                   inputName={name}
                 />
               </Col>

--- a/src/client/pages/RetroCertsWeeksToCertifyPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsWeeksToCertifyPage/__snapshots__/index.test.js.snap
@@ -75,27 +75,6 @@ exports[`<RetroCertsWeeksToCertifyPage /> has user data 1`] = `
           </Button>
         </div>
       </Row>
-      <YesNoQuestion
-        helpText="Aliquam fermentum, tortor in pulvinar."
-        inputName="YesNo1"
-        key="1"
-        questionNumber={1}
-        questionText="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec scelerisque."
-      />
-      <YesNoQuestion
-        helpText="Aliquam fermentum, tortor in pulvinar."
-        inputName="YesNo2"
-        key="2"
-        questionNumber={2}
-        questionText="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec scelerisque."
-      />
-      <YesNoQuestion
-        helpText="Aliquam fermentum, tortor in pulvinar."
-        inputName="YesNo3"
-        key="3"
-        questionNumber={3}
-        questionText="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec scelerisque."
-      />
     </div>
   </main>
   <Footer />

--- a/src/client/pages/RetroCertsWeeksToCertifyPage/index.js
+++ b/src/client/pages/RetroCertsWeeksToCertifyPage/index.js
@@ -8,7 +8,6 @@ import { fromIndexToPathString } from "../../../utils/retroCertsWeeks";
 import routes from "../../../data/routes";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header";
-import YesNoQuestion from "../../components/YesNoQuestion";
 
 function RetroCertsWeeksToCertifyPage(props) {
   const userData = props.userData;
@@ -46,16 +45,6 @@ function RetroCertsWeeksToCertifyPage(props) {
               </Button>
             </div>
           </Row>
-
-          {[1, 2, 3].map((index) => (
-            <YesNoQuestion
-              key={index}
-              questionNumber={index}
-              questionText="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec scelerisque."
-              helpText="Aliquam fermentum, tortor in pulvinar."
-              inputName={`YesNo${index}`}
-            />
-          ))}
         </div>
       </main>
       <Footer />


### PR DESCRIPTION
When the user answers Yes to if they were sick,
show the question asking how many days they
were sick.

Store the answer in formData[X].tooSickNumberOfDays.

Still need validation on the certification page.

===

- [X] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made

![screencapture-localhost-3000-retroactive-certification-certify-2020-05-02-2020-06-17-18_17_49](https://user-images.githubusercontent.com/175378/84966657-e0d09280-b0c6-11ea-8579-ccbbf8905c39.png)

