### PR TITLE
Add form validation to the certification page.

### DIFF
--- a/src/client/App.scss
+++ b/src/client/App.scss
@@ -99,6 +99,7 @@ footer {
 }
 
 // This removes the green border around validated fields.
-.form-control.is-valid, .was-validated .form-control:valid {
+.form-control.is-valid,
+.was-validated .form-control:valid {
   border-color: rgb(206, 212, 218) !important;
 }

--- a/src/client/components/DaysSickQuestion/__snapshots__/index.test.js.snap
+++ b/src/client/components/DaysSickQuestion/__snapshots__/index.test.js.snap
@@ -1,32 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<DaysSickQuestion /> renders the component 1`] = `
-<Form
-  inline={false}
->
-  <FormGroup>
-    <FormLabel
-      column={false}
-      srOnly={false}
-    >
-      If Yes, enter the number of days (1 - 7) you were unable to work.
-    </FormLabel>
-    <FormText
-      muted={true}
-    >
-      You must report the numbers of days that you could not work during this week.
-    </FormText>
-    <FormControl
-      maxLength={1}
-      onChange={[Function]}
-      style={
-        Object {
-          "width": "3rem",
-        }
+<FormGroup>
+  <FormLabel
+    column={false}
+    srOnly={false}
+  >
+    If Yes, enter the number of days (1 - 7) you were unable to work.
+  </FormLabel>
+  <FormText
+    muted={true}
+  >
+    You must report the numbers of days that you could not work during this week.
+  </FormText>
+  <FormControl
+    maxLength={1}
+    onChange={[Function]}
+    pattern="[1234567]"
+    required={true}
+    style={
+      Object {
+        "width": "6rem",
       }
-      type="text"
-      value=""
-    />
-  </FormGroup>
-</Form>
+    }
+    type="text"
+    value=""
+  />
+</FormGroup>
 `;

--- a/src/client/components/DaysSickQuestion/index.js
+++ b/src/client/components/DaysSickQuestion/index.js
@@ -21,19 +21,19 @@ function DaysSickQuestion(props) {
   }
 
   return (
-    <Form>
-      <Form.Group>
-        <Form.Label>{props.questionText}</Form.Label>
-        <Form.Text muted>{props.helpText}</Form.Text>
-        <Form.Control
-          style={{ width: "3rem" }}
-          type="text"
-          value={numDays}
-          onChange={onChange}
-          maxLength={1}
-        />
-      </Form.Group>
-    </Form>
+    <Form.Group>
+      <Form.Label>{props.questionText}</Form.Label>
+      <Form.Text muted>{props.helpText}</Form.Text>
+      <Form.Control
+        style={{ width: "6rem" }}
+        type="text"
+        value={numDays}
+        onChange={onChange}
+        maxLength={1}
+        required
+        pattern="[1234567]"
+      />
+    </Form.Group>
   );
 }
 

--- a/src/client/components/EmployersQuestions/index.js
+++ b/src/client/components/EmployersQuestions/index.js
@@ -50,7 +50,7 @@ function EmployerQuestions(props) {
   /**
    * Create a text input element.
    * @param {string} name The name for the employer data field.
-   * @param {Object?} options Optional controls:
+   * @param {object?} options Optional controls:
    *     className: The classname for applying styles.
    *     required: defaults to true, but set to false to make the input not required.
    *     pattern: A regex if the field requires specific values.

--- a/src/client/components/EmployersQuestions/index.js
+++ b/src/client/components/EmployersQuestions/index.js
@@ -47,15 +47,28 @@ function EmployerQuestions(props) {
     dateTokens.length === 3 ? dateTokens[1] : ""
   );
 
-  function renderTextInput(name, className) {
+  /**
+   * Create a text input element.
+   * @param {string} name The name for the employer data field.
+   * @param {Object?} options Optional controls:
+   *     className: The classname for applying styles.
+   *     required: defaults to true, but set to false to make the input not required.
+   *     pattern: A regex if the field requires specific values.
+   * @returns {React.ReactElement}
+   */
+  function renderTextInput(name, options) {
+    options = options || {};
+    const required = options.required === undefined ? true : options.required;
     return (
       <Form.Group>
         <Form.Label>{t(tk(name))}</Form.Label>
         <Form.Control
-          className={className}
+          className={options.className}
           type="text"
           value={stateFuncs[name].get}
           onChange={(e) => handleChange(name, e.target.value)}
+          required={required}
+          pattern={options.pattern}
         />
       </Form.Group>
     );
@@ -81,10 +94,10 @@ function EmployerQuestions(props) {
   }
 
   return (
-    <Form>
+    <React.Fragment>
       {renderTextInput("employerName")}
       {renderTextInput("address1")}
-      {renderTextInput("address2")}
+      {renderTextInput("address2", { required: false })}
       <Form.Row>
         <Col md={8}>{renderTextInput("city")}</Col>
         <Form.Group as={Col}>
@@ -93,6 +106,7 @@ function EmployerQuestions(props) {
             as="select"
             value={stateFuncs.state.get}
             onChange={(e) => handleChange("state", e.target.value)}
+            required
           >
             <option />
             {stateCodes.map((code) => (
@@ -101,7 +115,10 @@ function EmployerQuestions(props) {
           </Form.Control>
         </Form.Group>
       </Form.Row>
-      {renderTextInput("zipcode", "col-md-2")}
+      {renderTextInput("zipcode", {
+        className: "col-md-3",
+        pattern: "\\d{5}|\\d{5}-\\d{4}",
+      })}
 
       <p>{t(tk("lastDateWorked"))}</p>
       <Form.Row>
@@ -112,6 +129,8 @@ function EmployerQuestions(props) {
             value={lastDateWorkedMonth}
             maxLength={2}
             onChange={(e) => handleDateChange("month", e.target.value)}
+            required
+            pattern="0?[1-9]|10|11|12"
           />
         </Form.Group>
         <Form.Group as={Col} md={2}>
@@ -121,6 +140,8 @@ function EmployerQuestions(props) {
             value={lastDateWorkedDay}
             maxLength={2}
             onChange={(e) => handleDateChange("day", e.target.value)}
+            required
+            pattern="0?[1-9]|1\d|2\d|3[01]"
           />
         </Form.Group>
         <Form.Group as={Col} md={2}>
@@ -128,8 +149,14 @@ function EmployerQuestions(props) {
           <Form.Control type="text" value="2020" disabled />
         </Form.Group>
       </Form.Row>
-      {renderTextInput("totalHoursWorked", "col-md-2")}
-      {renderTextInput("grossEarnings", "col-md-2")}
+      {renderTextInput("totalHoursWorked", {
+        className: "col-md-2",
+        pattern: "\\d+[.]?\\d*",
+      })}
+      {renderTextInput("grossEarnings", {
+        className: "col-md-2",
+        pattern: "[$]?\\d+[.]?(\\d{2})?",
+      })}
       <Form.Group>
         <Form.Label>{t(tk("reason"))}</Form.Label>
         <Form.Control
@@ -154,10 +181,11 @@ function EmployerQuestions(props) {
             rows="3"
             value={stateFuncs.moreDetails.get}
             onChange={(e) => handleChange("moreDetails", e.target.value)}
+            required
           />
         </Form.Group>
       )}
-    </Form>
+    </React.Fragment>
   );
 }
 

--- a/src/client/components/YesNoQuestion/index.js
+++ b/src/client/components/YesNoQuestion/index.js
@@ -35,28 +35,28 @@ function YesNoQuestion(props) {
 
   return (
     <div className="bg-light p-2 m-2">
-      <Form>
-        <Form.Group>
-          <Form.Label>
-            {questionNumber}.&nbsp;{questionText}
-          </Form.Label>
-          <Form.Text muted>{helpText}</Form.Text>
-          {["Yes", "No"].map((value) => (
-            <Form.Check
-              key={value}
-              inline
-              label={t(`yesnoquestion.${value}`)}
-              type="radio"
-              id={`${inputName}radio${value}`}
-              onChange={onSelectionChanged}
-              name={inputName}
-              value={value}
-              checked={isChecked(value)}
-            />
-          ))}
-        </Form.Group>
-      </Form>
-      <div hidden={isYes === null || !isYes}>{children}</div>
+      <Form.Group>
+        <Form.Label>
+          {questionNumber}.&nbsp;{questionText}
+        </Form.Label>
+        <Form.Text muted>{helpText}</Form.Text>
+
+        {["Yes", "No"].map((value) => (
+          <Form.Check
+            key={value}
+            inline
+            label={t(`yesnoquestion.${value}`)}
+            type="radio"
+            id={`${inputName}radio${value}`}
+            onChange={onSelectionChanged}
+            name={inputName}
+            value={value}
+            checked={isChecked(value)}
+            required
+          />
+        ))}
+      </Form.Group>
+      {isYes === true && children}
     </div>
   );
 }

--- a/src/client/pages/RetroCertsCertificationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsCertificationPage/__snapshots__/index.test.js.snap
@@ -36,192 +36,160 @@ exports[`<RetroCertsCertificationPage /> Certify for 2nd week of 2 1`] = `
           }
         />
       </h3>
-      <Row
-        noGutters={false}
+      <Form
+        inline={false}
+        noValidate={true}
+        onSubmit={[Function]}
+        validated={false}
       >
-        <Col>
-          <YesNoQuestion
-            helpText="You must be well enough to work everyday of the week to receive full benefits. Check ‘yes’ if a workday was missed due to being sick or injured."
-            ifYes={false}
-            inputName="tooSick"
-            key="1tooSick"
+        <YesNoQuestion
+          helpText="You must be well enough to work everyday of the week to receive full benefits. Check ‘yes’ if a workday was missed due to being sick or injured."
+          ifYes={false}
+          inputName="tooSick"
+          key="1tooSick"
+          onChange={[Function]}
+          questionNumber={1}
+          questionText="Were you too sick or injured to work?"
+        >
+          <DaysSickQuestion
+            helpText="You must report the numbers of days that you could not work during this week. Unemployment benefits are paid according to the number of days you are able to work this week."
             onChange={[Function]}
-            questionNumber={1}
-            questionText="Were you too sick or injured to work?"
-          >
-            <DaysSickQuestion
-              helpText="You must report the numbers of days that you could not work during this week. Unemployment benefits are paid according to the number of days you are able to work this week."
-              onChange={[Function]}
-              questionText="If Yes, enter the number of days (1 - 7) you were unable to work."
+            questionText="If Yes, enter the number of days (1 - 7) you were unable to work."
+          />
+        </YesNoQuestion>
+        <YesNoQuestion
+          helpText={
+            <Trans
+              i18nKey="retrocerts-certification.questions.ui-part-time.help-couldNotAcceptWork"
+              t={[Function]}
             />
-          </YesNoQuestion>
-        </Col>
-      </Row>
-      <Row
-        key="1couldNotAcceptWork"
-        noGutters={false}
-      >
-        <Col>
-          <YesNoQuestion
-            helpText={
-              <Trans
-                i18nKey="retrocerts-certification.questions.ui-part-time.help-couldNotAcceptWork"
-                t={[Function]}
-              />
-            }
-            inputName="couldNotAcceptWork"
-            onChange={[Function]}
-            questionNumber={2}
-            questionText={
-              <Trans
-                i18nKey="retrocerts-certification.questions.ui-part-time.couldNotAcceptWork"
-                t={[Function]}
-              />
-            }
-          />
-        </Col>
-      </Row>
-      <Row
-        key="1didYouLook"
-        noGutters={false}
-      >
-        <Col>
-          <YesNoQuestion
-            helpText={
-              <Trans
-                i18nKey="retrocerts-certification.questions.ui-part-time.help-didYouLook"
-                t={[Function]}
-              />
-            }
-            ifYes={false}
-            inputName="didYouLook"
-            onChange={[Function]}
-            questionNumber={3}
-            questionText={
-              <Trans
-                i18nKey="retrocerts-certification.questions.ui-part-time.didYouLook"
-                t={[Function]}
-              />
-            }
-          />
-        </Col>
-      </Row>
-      <Row
-        key="1refuseWork"
-        noGutters={false}
-      >
-        <Col>
-          <YesNoQuestion
-            helpText={
-              <Trans
-                i18nKey="retrocerts-certification.questions.ui-part-time.help-refuseWork"
-                t={[Function]}
-              />
-            }
-            ifYes={false}
-            inputName="refuseWork"
-            onChange={[Function]}
-            questionNumber={4}
-            questionText={
-              <Trans
-                i18nKey="retrocerts-certification.questions.ui-part-time.refuseWork"
-                t={[Function]}
-              />
-            }
-          />
-        </Col>
-      </Row>
-      <Row
-        key="1schoolOrTraining"
-        noGutters={false}
-      >
-        <Col>
-          <YesNoQuestion
-            helpText={
-              <Trans
-                i18nKey="retrocerts-certification.questions.ui-part-time.help-schoolOrTraining"
-                t={[Function]}
-              />
-            }
-            ifYes={false}
-            inputName="schoolOrTraining"
-            onChange={[Function]}
-            questionNumber={5}
-            questionText={
-              <Trans
-                i18nKey="retrocerts-certification.questions.ui-part-time.schoolOrTraining"
-                t={[Function]}
-              />
-            }
-          />
-        </Col>
-      </Row>
-      <Row
-        noGutters={false}
-      >
-        <Col>
-          <YesNoQuestion
-            helpText="Look at the date each week begins and ends. If you performed any work during this week, all earnings must be reported regardless if payment has been received."
-            ifYes={false}
-            inputName="workOrEarn"
-            key="1workOrEarn"
-            onChange={[Function]}
-            questionNumber={6}
-            questionText="Did you work or earn any money, whether you were paid or not?"
-          >
-            <EmployersQuestions
-              onChange={[Function]}
+          }
+          inputName="couldNotAcceptWork"
+          key="1couldNotAcceptWork"
+          onChange={[Function]}
+          questionNumber={2}
+          questionText={
+            <Trans
+              i18nKey="retrocerts-certification.questions.ui-part-time.couldNotAcceptWork"
+              t={[Function]}
             />
-          </YesNoQuestion>
-        </Col>
-      </Row>
-      <Row
-        noGutters={false}
-      >
-        <Col>
-          <Button
-            active={false}
-            as={
+          }
+        />
+        <YesNoQuestion
+          helpText={
+            <Trans
+              i18nKey="retrocerts-certification.questions.ui-part-time.help-didYouLook"
+              t={[Function]}
+            />
+          }
+          ifYes={false}
+          inputName="didYouLook"
+          key="1didYouLook"
+          onChange={[Function]}
+          questionNumber={3}
+          questionText={
+            <Trans
+              i18nKey="retrocerts-certification.questions.ui-part-time.didYouLook"
+              t={[Function]}
+            />
+          }
+        />
+        <YesNoQuestion
+          helpText={
+            <Trans
+              i18nKey="retrocerts-certification.questions.ui-part-time.help-refuseWork"
+              t={[Function]}
+            />
+          }
+          ifYes={false}
+          inputName="refuseWork"
+          key="1refuseWork"
+          onChange={[Function]}
+          questionNumber={4}
+          questionText={
+            <Trans
+              i18nKey="retrocerts-certification.questions.ui-part-time.refuseWork"
+              t={[Function]}
+            />
+          }
+        />
+        <YesNoQuestion
+          helpText={
+            <Trans
+              i18nKey="retrocerts-certification.questions.ui-part-time.help-schoolOrTraining"
+              t={[Function]}
+            />
+          }
+          ifYes={false}
+          inputName="schoolOrTraining"
+          key="1schoolOrTraining"
+          onChange={[Function]}
+          questionNumber={5}
+          questionText={
+            <Trans
+              i18nKey="retrocerts-certification.questions.ui-part-time.schoolOrTraining"
+              t={[Function]}
+            />
+          }
+        />
+        <YesNoQuestion
+          helpText="Look at the date each week begins and ends. If you performed any work during this week, all earnings must be reported regardless if payment has been received."
+          ifYes={false}
+          inputName="workOrEarn"
+          key="1workOrEarn"
+          onChange={[Function]}
+          questionNumber={6}
+          questionText="Did you work or earn any money, whether you were paid or not?"
+        >
+          <EmployersQuestions
+            onChange={[Function]}
+          />
+        </YesNoQuestion>
+        <FormRow>
+          <Col>
+            <Button
+              active={false}
+              as={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "displayName": "Link",
+                  "propTypes": Object {
+                    "innerRef": [Function],
+                    "onClick": [Function],
+                    "replace": [Function],
+                    "target": [Function],
+                    "to": [Function],
+                  },
+                  "render": [Function],
+                }
+              }
+              className="text-dark bg-light"
+              disabled={false}
+              to="/retroactive-certification/certify/2020-02-08"
+              type="button"
+              variant="outline-secondary"
+            >
+              Back
+            </Button>
+          </Col>
+          <Col
+            style={
               Object {
-                "$$typeof": Symbol(react.forward_ref),
-                "displayName": "Link",
-                "propTypes": Object {
-                  "innerRef": [Function],
-                  "onClick": [Function],
-                  "replace": [Function],
-                  "target": [Function],
-                  "to": [Function],
-                },
-                "render": [Function],
+                "textAlign": "end",
               }
             }
-            className="text-dark bg-light"
-            disabled={false}
-            to="/retroactive-certification/certify/2020-02-08"
-            type="button"
-            variant="outline-secondary"
           >
-            Back
-          </Button>
-        </Col>
-        <Col
-          style={
-            Object {
-              "textAlign": "end",
-            }
-          }
-        >
-          <Button
-            active={false}
-            disabled={false}
-            onClick={[Function]}
-            type="button"
-            variant="secondary"
-          >
-            Submit your certification
-          </Button>
-        </Col>
-      </Row>
+            <Button
+              active={false}
+              disabled={false}
+              type="submit"
+              variant="secondary"
+            >
+              Submit your certification
+            </Button>
+          </Col>
+        </FormRow>
+      </Form>
     </div>
   </main>
   <Footer />
@@ -264,210 +232,164 @@ exports[`<RetroCertsCertificationPage /> Certify for one week of 2 1`] = `
           }
         />
       </h3>
-      <Row
-        noGutters={false}
+      <Form
+        inline={false}
+        noValidate={true}
+        onSubmit={[Function]}
+        validated={false}
       >
-        <Col>
-          <YesNoQuestion
-            helpText="You must be well enough to work everyday of the week to receive full benefits. Check ‘yes’ if a workday was missed due to being sick or injured."
-            ifYes={false}
-            inputName="tooSick"
-            key="0tooSick"
-            onChange={[Function]}
-            questionNumber={1}
-            questionText="Were you too sick or injured to work?"
-          >
-            <DaysSickQuestion
-              helpText="You must report the numbers of days that you could not work during this week. Unemployment benefits are paid according to the number of days you are able to work this week."
-              onChange={[Function]}
-              questionText="If Yes, enter the number of days (1 - 7) you were unable to work."
-            />
-          </YesNoQuestion>
-        </Col>
-      </Row>
-      <Row
-        key="0couldNotAcceptWork"
-        noGutters={false}
-      >
-        <Col>
-          <YesNoQuestion
-            helpText={
-              <Trans
-                i18nKey="retrocerts-certification.questions.ui-full-time.help-couldNotAcceptWork"
-                t={[Function]}
-              />
-            }
-            inputName="couldNotAcceptWork"
-            onChange={[Function]}
-            questionNumber={2}
-            questionText={
-              <Trans
-                i18nKey="retrocerts-certification.questions.ui-full-time.couldNotAcceptWork"
-                t={[Function]}
-              />
-            }
-          />
-        </Col>
-      </Row>
-      <Row
-        key="0didYouLook"
-        noGutters={false}
-      >
-        <Col>
-          <YesNoQuestion
-            helpText={
-              <Trans
-                i18nKey="retrocerts-certification.questions.ui-full-time.help-didYouLook"
-                t={[Function]}
-              />
-            }
-            inputName="didYouLook"
-            onChange={[Function]}
-            questionNumber={3}
-            questionText={
-              <Trans
-                i18nKey="retrocerts-certification.questions.ui-full-time.didYouLook"
-                t={[Function]}
-              />
-            }
-          />
-        </Col>
-      </Row>
-      <Row
-        key="0refuseWork"
-        noGutters={false}
-      >
-        <Col>
-          <YesNoQuestion
-            helpText={
-              <Trans
-                i18nKey="retrocerts-certification.questions.ui-full-time.help-refuseWork"
-                t={[Function]}
-              />
-            }
-            inputName="refuseWork"
-            onChange={[Function]}
-            questionNumber={4}
-            questionText={
-              <Trans
-                i18nKey="retrocerts-certification.questions.ui-full-time.refuseWork"
-                t={[Function]}
-              />
-            }
-          />
-        </Col>
-      </Row>
-      <Row
-        key="0schoolOrTraining"
-        noGutters={false}
-      >
-        <Col>
-          <YesNoQuestion
-            helpText={
-              <Trans
-                i18nKey="retrocerts-certification.questions.ui-full-time.help-schoolOrTraining"
-                t={[Function]}
-              />
-            }
-            inputName="schoolOrTraining"
-            onChange={[Function]}
-            questionNumber={5}
-            questionText={
-              <Trans
-                i18nKey="retrocerts-certification.questions.ui-full-time.schoolOrTraining"
-                t={[Function]}
-              />
-            }
-          />
-        </Col>
-      </Row>
-      <Row
-        noGutters={false}
-      >
-        <Col>
-          <YesNoQuestion
-            helpText="Look at the date each week begins and ends. If you performed any work during this week, all earnings must be reported regardless if payment has been received."
-            inputName="workOrEarn"
-            key="0workOrEarn"
-            onChange={[Function]}
-            questionNumber={6}
-            questionText="Did you work or earn any money, whether you were paid or not?"
-          >
-            <EmployersQuestions
-              onChange={[Function]}
-            />
-          </YesNoQuestion>
-        </Col>
-      </Row>
-      <Row
-        noGutters={false}
-      >
-        <Col>
-          <Button
-            active={false}
-            as={
-              Object {
-                "$$typeof": Symbol(react.forward_ref),
-                "displayName": "Link",
-                "propTypes": Object {
-                  "innerRef": [Function],
-                  "onClick": [Function],
-                  "replace": [Function],
-                  "target": [Function],
-                  "to": [Function],
-                },
-                "render": [Function],
-              }
-            }
-            className="text-dark bg-light"
-            disabled={false}
-            to="/retroactive-certification/weeks-to-certify"
-            type="button"
-            variant="outline-secondary"
-          >
-            Back
-          </Button>
-        </Col>
-        <Col
-          style={
-            Object {
-              "textAlign": "end",
-            }
-          }
+        <YesNoQuestion
+          helpText="You must be well enough to work everyday of the week to receive full benefits. Check ‘yes’ if a workday was missed due to being sick or injured."
+          ifYes={false}
+          inputName="tooSick"
+          key="0tooSick"
+          onChange={[Function]}
+          questionNumber={1}
+          questionText="Were you too sick or injured to work?"
         >
-          <Button
-            active={false}
-            as={
-              Object {
-                "$$typeof": Symbol(react.forward_ref),
-                "displayName": "Link",
-                "propTypes": Object {
-                  "innerRef": [Function],
-                  "onClick": [Function],
-                  "replace": [Function],
-                  "target": [Function],
-                  "to": [Function],
-                },
-                "render": [Function],
-              }
-            }
-            disabled={false}
-            to="/retroactive-certification/certify/2020-02-15"
-            type="submit"
-            variant="secondary"
-          >
+          <DaysSickQuestion
+            helpText="You must report the numbers of days that you could not work during this week. Unemployment benefits are paid according to the number of days you are able to work this week."
+            onChange={[Function]}
+            questionText="If Yes, enter the number of days (1 - 7) you were unable to work."
+          />
+        </YesNoQuestion>
+        <YesNoQuestion
+          helpText={
             <Trans
-              i18nKey="retrocerts-certification.button-next"
+              i18nKey="retrocerts-certification.questions.ui-full-time.help-couldNotAcceptWork"
               t={[Function]}
-              values={
+            />
+          }
+          inputName="couldNotAcceptWork"
+          key="0couldNotAcceptWork"
+          onChange={[Function]}
+          questionNumber={2}
+          questionText={
+            <Trans
+              i18nKey="retrocerts-certification.questions.ui-full-time.couldNotAcceptWork"
+              t={[Function]}
+            />
+          }
+        />
+        <YesNoQuestion
+          helpText={
+            <Trans
+              i18nKey="retrocerts-certification.questions.ui-full-time.help-didYouLook"
+              t={[Function]}
+            />
+          }
+          inputName="didYouLook"
+          key="0didYouLook"
+          onChange={[Function]}
+          questionNumber={3}
+          questionText={
+            <Trans
+              i18nKey="retrocerts-certification.questions.ui-full-time.didYouLook"
+              t={[Function]}
+            />
+          }
+        />
+        <YesNoQuestion
+          helpText={
+            <Trans
+              i18nKey="retrocerts-certification.questions.ui-full-time.help-refuseWork"
+              t={[Function]}
+            />
+          }
+          inputName="refuseWork"
+          key="0refuseWork"
+          onChange={[Function]}
+          questionNumber={4}
+          questionText={
+            <Trans
+              i18nKey="retrocerts-certification.questions.ui-full-time.refuseWork"
+              t={[Function]}
+            />
+          }
+        />
+        <YesNoQuestion
+          helpText={
+            <Trans
+              i18nKey="retrocerts-certification.questions.ui-full-time.help-schoolOrTraining"
+              t={[Function]}
+            />
+          }
+          inputName="schoolOrTraining"
+          key="0schoolOrTraining"
+          onChange={[Function]}
+          questionNumber={5}
+          questionText={
+            <Trans
+              i18nKey="retrocerts-certification.questions.ui-full-time.schoolOrTraining"
+              t={[Function]}
+            />
+          }
+        />
+        <YesNoQuestion
+          helpText="Look at the date each week begins and ends. If you performed any work during this week, all earnings must be reported regardless if payment has been received."
+          inputName="workOrEarn"
+          key="0workOrEarn"
+          onChange={[Function]}
+          questionNumber={6}
+          questionText="Did you work or earn any money, whether you were paid or not?"
+        >
+          <EmployersQuestions
+            onChange={[Function]}
+          />
+        </YesNoQuestion>
+        <FormRow>
+          <Col>
+            <Button
+              active={false}
+              as={
                 Object {
-                  "nextWeekForUser": 2,
+                  "$$typeof": Symbol(react.forward_ref),
+                  "displayName": "Link",
+                  "propTypes": Object {
+                    "innerRef": [Function],
+                    "onClick": [Function],
+                    "replace": [Function],
+                    "target": [Function],
+                    "to": [Function],
+                  },
+                  "render": [Function],
                 }
               }
-            />
-          </Button>
-        </Col>
-      </Row>
+              className="text-dark bg-light"
+              disabled={false}
+              to="/retroactive-certification/weeks-to-certify"
+              type="button"
+              variant="outline-secondary"
+            >
+              Back
+            </Button>
+          </Col>
+          <Col
+            style={
+              Object {
+                "textAlign": "end",
+              }
+            }
+          >
+            <Button
+              active={false}
+              disabled={false}
+              type="submit"
+              variant="secondary"
+            >
+              <Trans
+                i18nKey="retrocerts-certification.button-next"
+                t={[Function]}
+                values={
+                  Object {
+                    "nextWeekForUser": 2,
+                  }
+                }
+              />
+            </Button>
+          </Col>
+        </FormRow>
+      </Form>
     </div>
   </main>
   <Footer />

--- a/src/client/pages/RetroCertsCertificationPage/index.js
+++ b/src/client/pages/RetroCertsCertificationPage/index.js
@@ -1,9 +1,9 @@
 import Button from "react-bootstrap/Button";
+import Form from "react-bootstrap/Form";
 import Col from "react-bootstrap/Col";
-import Row from "react-bootstrap/Row";
 import { Redirect, useHistory, Link } from "react-router-dom";
 import PropTypes from "prop-types";
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
 import { userDataPropType, setUserDataPropType } from "../../commonPropTypes";
 import {
@@ -24,6 +24,7 @@ import EmployersQuestions from "../../components/EmployersQuestions";
 function RetroCertsCertificationPage(props) {
   const { t } = useTranslation();
   const history = useHistory();
+  const [validated, setValidated] = useState(false);
 
   const { userData, setUserData, routeComputedMatch } = props;
   const numberOfWeeks = userData.weeksToCertify.length;
@@ -39,19 +40,38 @@ function RetroCertsCertificationPage(props) {
     return <Redirect to={routes.retroCertsWeeksToCertify} />;
   }
 
-  // When the user transitions to a new week, return to the top
-  // of the form.
-  if (weekIndexRef.current !== weekIndex) {
-    weekIndexRef.current = weekIndex;
-    window.scroll({
-      top: headingElement.current.offsetTop,
-      left: 0,
-      behavior: "smooth",
-    });
-  }
-
   const formDataArray = userData.formData || [];
   const formData = formDataArray[weekForUser - 1] || { weekIndex };
+
+  // If we're missing data from a previous week (e.g., the user pressed
+  // reload), go back to the first week since we lost their previous
+  // answers.
+  if (weekForUser > 1 && formDataArray.length < weekForUser - 1) {
+    return (
+      <Redirect
+        to={
+          routes.retroCertsCertify +
+          "/" +
+          fromIndexToPathString(userData.weeksToCertify[0])
+        }
+      />
+    );
+  }
+
+  // When the user transitions to a new week, return to the top
+  // of the form and reset the form.
+  if (weekIndexRef.current !== weekIndex) {
+    weekIndexRef.current = weekIndex;
+
+    setValidated(false);
+    if (headingElement.current) {
+      window.scroll({
+        top: headingElement.current.offsetTop,
+        left: 0,
+        behavior: "smooth",
+      });
+    }
+  }
 
   const weekSeekWorkPlan =
     userData.seekWorkPlan[userData.weeksToCertify.indexOf(weekIndex)];
@@ -91,7 +111,29 @@ function RetroCertsCertificationPage(props) {
     }
   }
 
-  function handleSubmit() {
+  const handleSubmit = (event) => {
+    const form = event.currentTarget;
+    const isValid = form.checkValidity();
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    setValidated(true);
+
+    if (!isValid) return;
+
+    if (weekForUser !== numberOfWeeks) {
+      history.push(
+        routes.retroCertsCertify +
+          "/" +
+          fromIndexToPathString(userData.weeksToCertify[weekForUser])
+      );
+    } else if (weekForUser === numberOfWeeks) {
+      postUserDataToServer();
+    }
+  };
+
+  function postUserDataToServer() {
     fetch(AUTH_STRINGS.apiPath.save, {
       method: "POST",
       headers: {
@@ -141,105 +183,85 @@ function RetroCertsCertificationPage(props) {
               values={{ weekForUser, weekString: toWeekString(weekIndex) }}
             />
           </h3>
-          <Row>
-            <Col>
-              <YesNoQuestion
-                key={weekIndex + "tooSick"}
-                questionNumber={1}
-                questionText={t(questionText("tooSick"))}
-                helpText={t(questionText("help-tooSick"))}
-                ifYes={formData.tooSick}
+          <Form noValidate validated={validated} onSubmit={handleSubmit}>
+            <YesNoQuestion
+              key={weekIndex + "tooSick"}
+              questionNumber={1}
+              questionText={t(questionText("tooSick"))}
+              helpText={t(questionText("help-tooSick"))}
+              ifYes={formData.tooSick}
+              onChange={(e) => handleFormDataChange(e)}
+              inputName="tooSick"
+            >
+              <DaysSickQuestion
+                numDays={formData.tooSickNumberOfDays}
                 onChange={(e) => handleFormDataChange(e)}
-                inputName="tooSick"
-              >
-                <DaysSickQuestion
-                  numDays={formData.tooSickNumberOfDays}
-                  onChange={(e) => handleFormDataChange(e)}
-                  questionText={t(questionText("tooSickNumberOfDays"))}
-                  helpText={t(questionText("help-tooSickNumberOfDays"))}
-                />
-              </YesNoQuestion>
-            </Col>
-          </Row>
-          {questionsTwoThroughFive.map((name, index) => (
-            <Row key={weekIndex + name}>
-              <Col>
-                <YesNoQuestion
-                  questionNumber={index + 2}
-                  questionText={<Trans t={t} i18nKey={questionText(name)} />}
-                  helpText={
-                    <Trans t={t} i18nKey={questionText(`help-${name}`)} />
-                  }
-                  ifYes={formData[name]}
-                  onChange={(e) => handleFormDataChange(e)}
-                  inputName={name}
-                />
-              </Col>
-            </Row>
-          ))}
-          <Row>
-            <Col>
+                questionText={t(questionText("tooSickNumberOfDays"))}
+                helpText={t(questionText("help-tooSickNumberOfDays"))}
+              />
+            </YesNoQuestion>
+            {questionsTwoThroughFive.map((name, index) => (
               <YesNoQuestion
-                key={weekIndex + "workOrEarn"}
-                questionNumber={6}
-                questionText={t("retrocerts-certification.q-workOrEarn")}
-                helpText={t("retrocerts-certification.qhelp-workOrEarn")}
-                ifYes={formData.workOrEarn}
-                onChange={(e) => handleFormDataChange(e)}
-                inputName="workOrEarn"
-              >
-                <EmployersQuestions
-                  employers={formData.employers}
-                  onChange={(employers) => handleEmployersChange(employers)}
-                />
-              </YesNoQuestion>
-            </Col>
-          </Row>
-          <Row>
-            <Col>
-              <Button
-                variant="outline-secondary"
-                className="text-dark bg-light"
-                as={Link}
-                to={
-                  weekForUser === 1
-                    ? routes.retroCertsWeeksToCertify
-                    : routes.retroCertsCertify +
-                      "/" +
-                      fromIndexToPathString(
-                        userData.weeksToCertify[weekForUser - 2]
-                      )
+                key={weekIndex + name}
+                questionNumber={index + 2}
+                questionText={<Trans t={t} i18nKey={questionText(name)} />}
+                helpText={
+                  <Trans t={t} i18nKey={questionText(`help-${name}`)} />
                 }
-              >
-                {t("retrocerts-certification.button-back")}
-              </Button>
-            </Col>
-            <Col style={{ textAlign: "end" }}>
-              {weekForUser === numberOfWeeks && (
-                <Button variant="secondary" onClick={handleSubmit}>
-                  {t("retrocerts-certification.button-submit")}
-                </Button>
-              )}
-              {weekForUser !== numberOfWeeks && (
+                ifYes={formData[name]}
+                onChange={(e) => handleFormDataChange(e)}
+                inputName={name}
+              />
+            ))}
+            <YesNoQuestion
+              key={weekIndex + "workOrEarn"}
+              questionNumber={6}
+              questionText={t("retrocerts-certification.q-workOrEarn")}
+              helpText={t("retrocerts-certification.qhelp-workOrEarn")}
+              ifYes={formData.workOrEarn}
+              onChange={(e) => handleFormDataChange(e)}
+              inputName="workOrEarn"
+            >
+              <EmployersQuestions
+                employers={formData.employers}
+                onChange={(employers) => handleEmployersChange(employers)}
+              />
+            </YesNoQuestion>
+
+            <Form.Row>
+              <Col>
                 <Button
-                  variant="secondary"
+                  variant="outline-secondary"
+                  className="text-dark bg-light"
                   as={Link}
-                  type="submit"
                   to={
-                    routes.retroCertsCertify +
-                    "/" +
-                    fromIndexToPathString(userData.weeksToCertify[weekForUser])
+                    weekForUser === 1
+                      ? routes.retroCertsWeeksToCertify
+                      : routes.retroCertsCertify +
+                        "/" +
+                        fromIndexToPathString(
+                          userData.weeksToCertify[weekForUser - 2]
+                        )
                   }
                 >
-                  <Trans
-                    t={t}
-                    i18nKey="retrocerts-certification.button-next"
-                    values={{ nextWeekForUser: weekForUser + 1 }}
-                  />
+                  {t("retrocerts-certification.button-back")}
                 </Button>
-              )}
-            </Col>
-          </Row>
+              </Col>
+              <Col style={{ textAlign: "end" }}>
+                <Button variant="secondary" type="submit">
+                  {weekForUser === numberOfWeeks &&
+                    t("retrocerts-certification.button-submit")}
+                  {weekForUser !== numberOfWeeks && (
+                    <Trans
+                      t={t}
+                      i18nKey="retrocerts-certification.button-next"
+                      values={{ nextWeekForUser: weekForUser + 1 }}
+                    />
+                  )}
+                </Button>
+              </Col>
+            </Form.Row>
+          </Form>
         </div>
       </main>
       <Footer />


### PR DESCRIPTION
Makes most inputs required and add some patterns
for things that should be numbers.

The styling needs some work, but I'll wait until we
get the designs for it.

We're still submitting the fake data though
(can be fixed in a separate change).

===

- [X] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made

![screencapture-localhost-3000-retroactive-certification-certify-2020-02-08-2020-06-19-13_58_02](https://user-images.githubusercontent.com/175378/85179118-f19f1680-b234-11ea-83fd-17b44779cec5.png)
