### PR TITLE
Differentiate PUA / UI questions

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -233,29 +233,45 @@
         "tooSick": "Were you too sick or injured to work?",
         "help-tooSick": "You must be well enough to work everyday of the week to receive full benefits. Check ‘yes’ if a workday was missed due to being sick or injured.",
         "tooSickNumberOfDays": "If Yes, enter the number of days (1 - 7) you were unable to work.",
-        "help-tooSickNumberOfDays": "You must report the numbers of days that you could not work during this week. Unemployment benefits are paid according to the number of days you are able to work this week."
+        "help-tooSickNumberOfDays": "You must report the numbers of days that you could not work during this week. Unemployment benefits are paid according to the number of days you are able to work this week.",
+        "couldNotAcceptWork": "Was there any reason (other than sickness or injury) that you could not have accepted full-time work <strong>each workday</strong>?",
+        "help-couldNotAcceptWork": "You must be available for work to receive unemployment benefits. Available means you are ready and willing to accept work that matches your occupational skills and educational background. If part-time work was refused for any reason other than being sick or injured check ‘yes’.",
+        "didYouLook": "Did you look for work?",
+        "help-didYouLook": "The work search requirements on your Notice of Unemployment Insurance Award must be followed. Work searches may be in-person, mail, telephone, or Internet contacts with employers.",
+        "refuseWork": "Did you refuse any work?",
+        "help-refuseWork": "If work was refused, a determination will be scheduled. Union members answer ‘yes’ if a union referral to a job was refused.",
+        "schoolOrTraining": "Did you <strong>begin</strong> attending any kind of school or training?",
+        "help-schoolOrTraining": "Answer ‘yes’ only if school or training <strong>began</strong> during this work week."
       },
       "ui-part-time": {
         "tooSick": "Were you too sick or injured to work?",
         "help-tooSick": "You must be well enough to work everyday of the week to receive full benefits. Check ‘yes’ if a workday was missed due to being sick or injured.",
         "tooSickNumberOfDays": "If Yes, enter the number of days (1 - 7) you were unable to work.",
-        "help-tooSickNumberOfDays": "You must report the numbers of days that you could not work during this week. Unemployment benefits are paid according to the number of days you are able to work this week."
-      },
+        "help-tooSickNumberOfDays": "You must report the numbers of days that you could not work during this week. Unemployment benefits are paid according to the number of days you are able to work this week.",
+        "couldNotAcceptWork": "Was there any reason (other than sickness or injury) that you could not have accepted part-time work, <strong>as instructed by EDD</strong>?",
+        "help-couldNotAcceptWork": "You must be available for work to receive unemployment benefits. Available means you are ready and willing to accept work that matches your occupational skills and educational background. Check 'yes' if you refused fulltime work for any reason other than being sick or injured.",
+        "didYouLook": "Did you look for work?",
+        "help-didYouLook": "The work search requirements on your Notice of Unemployment Insurance Award must be followed. Work searches may include in-person, mail, telephone, or Internet contacts with employers.",
+        "refuseWork": "Did you refuse any work?",
+        "help-refuseWork": "If work was refused, a determination will be scheduled. Union members answer ‘yes’ if a union referral to a job was refused.",
+        "schoolOrTraining": "Did you <strong>begin</strong> attending any kind of school or training?",
+        "help-schoolOrTraining": "Answer ‘yes’ only if school or training <strong>began</strong> during this work week."
+       },
       "pua-full-time": {
         "tooSick": "Were you too sick or injured to work for reasons other than disaster?",
         "help-tooSick": "You must be well enough to receive full benefits. Other than disaster, was a workday missed due to sickness or injury?",
         "tooSickNumberOfDays": "If Yes, enter the number of days (1 - 7) you were unable to work.",
-        "help-tooSickNumberOfDays": "You must report the number of days that work was missed."
-      }
+        "help-tooSickNumberOfDays": "You must report the number of days that work was missed.",
+        "couldNotAcceptWork": "Was there any reason (other than sickness, injury or the disaster) that you could not have accepted full-time work, each workday?",
+        "help-couldNotAcceptWork": "Other than being sick, injured or disaster, could full-time work have been accepted?",
+        "didYouLook": "Did you look for work or contact your last employer, or, if self employed, did you attempt to resume self- employment?",
+        "help-didYouLook": "The work search requirements on your notice of Unemployment Insurance Award must be followed. Work Searches may include in-person, mail, telephone, or Internet contacts with employers. Was there any attempt to look for work or resume work?",
+        "refuseWork": "Did you refuse any work?",
+        "help-refuseWork": "If work was refused, a determination will be scheduled. Union members answer ‘yes’ if a union referral to a job was refused.",
+        "otherBenefits": "Did you receive disability, private income insurance, or supplemental unemployment benefits?",
+        "help-otherBenefits": "Disability Insurance, Private Income Insurance and Supplemental Unemployment Benefits are considered into the final amount of unemployment benefits."
+       }
     },
-    "q-fullTime": "Was there any reason (other than sickness or injury) that you could not have accepted full-time work each workday?",
-    "qhelp-fullTime": "Available means you are ready and willing to accept work that matches your occupational skills and educational background.",
-    "q-didYouLook": "Did you look for work?",
-    "qhelp-didYouLook": "You must look for work, according to your Notice of Unemployment Insurance Award. Work searches may include in-person, mail, telephone, or Internet contacts with employers.",
-    "q-refuseWork": "Did you refuse any work?",
-    "qhelp-refuseWork": "You will not be penalized for however you answer this question, due to COVID-19.",
-    "q-schoolOrTraining": "Did you begin attending any kind of school or training?",
-    "qhelp-schoolOrTraining": "Answer ‘yes’ only if school or training began during this week.",
     "q-workOrEarn": "Did you work or earn any money, whether you were paid or not?",
     "qhelp-workOrEarn": "Look at the date each week begins and ends. If you performed any work during this week, all earnings must be reported regardless if payment has been received.",
     "employers": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -228,9 +228,26 @@
     "title":"Retroactive Unemployment Certification",
     "p1-multiple": "You are on Week {{weekForUser}} of {{numberOfWeeks}} to certify.",
     "form-header": "Week {{weekForUser}}: {{weekString}}",
-    "q-tooSick": "Were you too sick or injured to work?",
-    "qhelp-tooSick": "You must be well enough to work every day of the week to receive full benefits.",
-    "q-tooSickNumberOfDays": "Enter the number of days (1 through 7) you were unable to work.",
+    "questions": {
+      "ui-full-time": {
+        "tooSick": "Were you too sick or injured to work?",
+        "help-tooSick": "You must be well enough to work everyday of the week to receive full benefits. Check ‘yes’ if a workday was missed due to being sick or injured.",
+        "tooSickNumberOfDays": "If Yes, enter the number of days (1 - 7) you were unable to work.",
+        "help-tooSickNumberOfDays": "You must report the numbers of days that you could not work during this week. Unemployment benefits are paid according to the number of days you are able to work this week."
+      },
+      "ui-part-time": {
+        "tooSick": "Were you too sick or injured to work?",
+        "help-tooSick": "You must be well enough to work everyday of the week to receive full benefits. Check ‘yes’ if a workday was missed due to being sick or injured.",
+        "tooSickNumberOfDays": "If Yes, enter the number of days (1 - 7) you were unable to work.",
+        "help-tooSickNumberOfDays": "You must report the numbers of days that you could not work during this week. Unemployment benefits are paid according to the number of days you are able to work this week."
+      },
+      "pua-full-time": {
+        "tooSick": "Were you too sick or injured to work for reasons other than disaster?",
+        "help-tooSick": "You must be well enough to receive full benefits. Other than disaster, was a workday missed due to sickness or injury?",
+        "tooSickNumberOfDays": "If Yes, enter the number of days (1 - 7) you were unable to work.",
+        "help-tooSickNumberOfDays": "You must report the number of days that work was missed."
+      }
+    },
     "q-fullTime": "Was there any reason (other than sickness or injury) that you could not have accepted full-time work each workday?",
     "qhelp-fullTime": "Available means you are ready and willing to accept work that matches your occupational skills and educational background.",
     "q-didYouLook": "Did you look for work?",

--- a/src/client/commonPropTypes.js
+++ b/src/client/commonPropTypes.js
@@ -4,6 +4,7 @@ export const userDataPropType = PropTypes.shape({
   status: PropTypes.string,
   lastName: PropTypes.string,
   weeksToCertify: PropTypes.arrayOf(PropTypes.number),
+  seekWorkPlan: PropTypes.arrayOf(PropTypes.string),
   confirmationNumber: PropTypes.string,
 });
 

--- a/src/client/components/DaysSickQuestion/__snapshots__/index.test.js.snap
+++ b/src/client/components/DaysSickQuestion/__snapshots__/index.test.js.snap
@@ -8,9 +8,10 @@ exports[`<DaysSickQuestion /> renders the component 1`] = `
     <FormLabel
       column={false}
       srOnly={false}
-    >
-      Enter the number of days (1 through 7) you were unable to work.
-    </FormLabel>
+    />
+    <FormText
+      muted={true}
+    />
     <FormControl
       maxLength={1}
       onChange={[Function]}

--- a/src/client/components/DaysSickQuestion/__snapshots__/index.test.js.snap
+++ b/src/client/components/DaysSickQuestion/__snapshots__/index.test.js.snap
@@ -8,10 +8,14 @@ exports[`<DaysSickQuestion /> renders the component 1`] = `
     <FormLabel
       column={false}
       srOnly={false}
-    />
+    >
+      If Yes, enter the number of days (1 - 7) you were unable to work.
+    </FormLabel>
     <FormText
       muted={true}
-    />
+    >
+      You must report the numbers of days that you could not work during this week.
+    </FormText>
     <FormControl
       maxLength={1}
       onChange={[Function]}

--- a/src/client/components/DaysSickQuestion/index.js
+++ b/src/client/components/DaysSickQuestion/index.js
@@ -1,11 +1,8 @@
 import Form from "react-bootstrap/Form";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
-import { useTranslation } from "react-i18next";
 
 function DaysSickQuestion(props) {
-  const { t } = useTranslation();
-
   const [numDays, setNumDays] = useState(
     props.numDays !== undefined ? String(props.numDays) : ""
   );
@@ -26,9 +23,8 @@ function DaysSickQuestion(props) {
   return (
     <Form>
       <Form.Group>
-        <Form.Label>
-          {t("retrocerts-certification.q-tooSickNumberOfDays")}
-        </Form.Label>
+        <Form.Label>{props.questionText}</Form.Label>
+        <Form.Text muted>{props.helpText}</Form.Text>
         <Form.Control
           style={{ width: "3rem" }}
           type="text"
@@ -44,6 +40,8 @@ function DaysSickQuestion(props) {
 DaysSickQuestion.propTypes = {
   onChange: PropTypes.func.isRequired,
   numDays: PropTypes.number,
+  questionText: PropTypes.string,
+  helpText: PropTypes.string,
 };
 
 export default DaysSickQuestion;

--- a/src/client/components/DaysSickQuestion/index.test.js
+++ b/src/client/components/DaysSickQuestion/index.test.js
@@ -5,6 +5,10 @@ describe("<DaysSickQuestion />", () => {
   it("renders the component", async () => {
     const wrapper = renderNonTransContent(Component, "DaysSickQuestion", {
       onChange: () => {},
+      questionText:
+        "If Yes, enter the number of days (1 - 7) you were unable to work.",
+      helpText:
+        "You must report the numbers of days that you could not work during this week.",
     });
 
     expect(wrapper).toMatchSnapshot();

--- a/src/client/components/YesNoQuestion/index.js
+++ b/src/client/components/YesNoQuestion/index.js
@@ -35,10 +35,12 @@ function YesNoQuestion(props) {
 
   return (
     <div className="bg-light p-2 m-2">
-      {questionNumber}.&nbsp;{questionText}
-      <p className="ml-3">{helpText}</p>
       <Form>
         <Form.Group>
+          <Form.Label>
+            {questionNumber}.&nbsp;{questionText}
+          </Form.Label>
+          <Form.Text muted>{helpText}</Form.Text>
           {["Yes", "No"].map((value) => (
             <Form.Check
               key={value}

--- a/src/client/components/YesNoQuestion/index.js
+++ b/src/client/components/YesNoQuestion/index.js
@@ -63,8 +63,10 @@ function YesNoQuestion(props) {
 
 YesNoQuestion.propTypes = {
   questionNumber: PropTypes.number.isRequired,
-  questionText: PropTypes.string.isRequired,
-  helpText: PropTypes.string.isRequired,
+  questionText: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
+    .isRequired,
+  helpText: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
+    .isRequired,
   inputName: PropTypes.string.isRequired,
   onChange: PropTypes.func,
   ifYes: PropTypes.bool,

--- a/src/client/components/YesNoQuestion/index.js
+++ b/src/client/components/YesNoQuestion/index.js
@@ -63,9 +63,9 @@ function YesNoQuestion(props) {
 
 YesNoQuestion.propTypes = {
   questionNumber: PropTypes.number.isRequired,
-  questionText: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
+  questionText: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
     .isRequired,
-  helpText: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
+  helpText: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
     .isRequired,
   inputName: PropTypes.string.isRequired,
   onChange: PropTypes.func,

--- a/src/client/pages/RetroCertsCertificationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsCertificationPage/__snapshots__/index.test.js.snap
@@ -58,17 +58,26 @@ exports[`<RetroCertsCertificationPage /> Certify for 2nd week of 2 1`] = `
         </Col>
       </Row>
       <Row
-        key="1fullTime"
+        key="1couldNotAcceptWork"
         noGutters={false}
       >
         <Col>
           <YesNoQuestion
-            helpText="Available means you are ready and willing to accept work that matches your occupational skills and educational background."
-            ifYes={false}
-            inputName="fullTime"
+            helpText={
+              <Trans
+                i18nKey="retrocerts-certification.questions.ui-part-time.help-couldNotAcceptWork"
+                t={[Function]}
+              />
+            }
+            inputName="couldNotAcceptWork"
             onChange={[Function]}
             questionNumber={2}
-            questionText="Was there any reason (other than sickness or injury) that you could not have accepted full-time work each workday?"
+            questionText={
+              <Trans
+                i18nKey="retrocerts-certification.questions.ui-part-time.couldNotAcceptWork"
+                t={[Function]}
+              />
+            }
           />
         </Col>
       </Row>
@@ -78,12 +87,22 @@ exports[`<RetroCertsCertificationPage /> Certify for 2nd week of 2 1`] = `
       >
         <Col>
           <YesNoQuestion
-            helpText="You must look for work, according to your Notice of Unemployment Insurance Award. Work searches may include in-person, mail, telephone, or Internet contacts with employers."
+            helpText={
+              <Trans
+                i18nKey="retrocerts-certification.questions.ui-part-time.help-didYouLook"
+                t={[Function]}
+              />
+            }
             ifYes={false}
             inputName="didYouLook"
             onChange={[Function]}
             questionNumber={3}
-            questionText="Did you look for work?"
+            questionText={
+              <Trans
+                i18nKey="retrocerts-certification.questions.ui-part-time.didYouLook"
+                t={[Function]}
+              />
+            }
           />
         </Col>
       </Row>
@@ -93,12 +112,22 @@ exports[`<RetroCertsCertificationPage /> Certify for 2nd week of 2 1`] = `
       >
         <Col>
           <YesNoQuestion
-            helpText="You will not be penalized for however you answer this question, due to COVID-19."
+            helpText={
+              <Trans
+                i18nKey="retrocerts-certification.questions.ui-part-time.help-refuseWork"
+                t={[Function]}
+              />
+            }
             ifYes={false}
             inputName="refuseWork"
             onChange={[Function]}
             questionNumber={4}
-            questionText="Did you refuse any work?"
+            questionText={
+              <Trans
+                i18nKey="retrocerts-certification.questions.ui-part-time.refuseWork"
+                t={[Function]}
+              />
+            }
           />
         </Col>
       </Row>
@@ -108,12 +137,22 @@ exports[`<RetroCertsCertificationPage /> Certify for 2nd week of 2 1`] = `
       >
         <Col>
           <YesNoQuestion
-            helpText="Answer ‘yes’ only if school or training began during this week."
+            helpText={
+              <Trans
+                i18nKey="retrocerts-certification.questions.ui-part-time.help-schoolOrTraining"
+                t={[Function]}
+              />
+            }
             ifYes={false}
             inputName="schoolOrTraining"
             onChange={[Function]}
             questionNumber={5}
-            questionText="Did you begin attending any kind of school or training?"
+            questionText={
+              <Trans
+                i18nKey="retrocerts-certification.questions.ui-part-time.schoolOrTraining"
+                t={[Function]}
+              />
+            }
           />
         </Col>
       </Row>
@@ -247,17 +286,26 @@ exports[`<RetroCertsCertificationPage /> Certify for one week of 2 1`] = `
         </Col>
       </Row>
       <Row
-        key="0fullTime"
+        key="0couldNotAcceptWork"
         noGutters={false}
       >
         <Col>
           <YesNoQuestion
-            helpText="Available means you are ready and willing to accept work that matches your occupational skills and educational background."
-            ifYes={true}
-            inputName="fullTime"
+            helpText={
+              <Trans
+                i18nKey="retrocerts-certification.questions.ui-full-time.help-couldNotAcceptWork"
+                t={[Function]}
+              />
+            }
+            inputName="couldNotAcceptWork"
             onChange={[Function]}
             questionNumber={2}
-            questionText="Was there any reason (other than sickness or injury) that you could not have accepted full-time work each workday?"
+            questionText={
+              <Trans
+                i18nKey="retrocerts-certification.questions.ui-full-time.couldNotAcceptWork"
+                t={[Function]}
+              />
+            }
           />
         </Col>
       </Row>
@@ -267,11 +315,21 @@ exports[`<RetroCertsCertificationPage /> Certify for one week of 2 1`] = `
       >
         <Col>
           <YesNoQuestion
-            helpText="You must look for work, according to your Notice of Unemployment Insurance Award. Work searches may include in-person, mail, telephone, or Internet contacts with employers."
+            helpText={
+              <Trans
+                i18nKey="retrocerts-certification.questions.ui-full-time.help-didYouLook"
+                t={[Function]}
+              />
+            }
             inputName="didYouLook"
             onChange={[Function]}
             questionNumber={3}
-            questionText="Did you look for work?"
+            questionText={
+              <Trans
+                i18nKey="retrocerts-certification.questions.ui-full-time.didYouLook"
+                t={[Function]}
+              />
+            }
           />
         </Col>
       </Row>
@@ -281,11 +339,21 @@ exports[`<RetroCertsCertificationPage /> Certify for one week of 2 1`] = `
       >
         <Col>
           <YesNoQuestion
-            helpText="You will not be penalized for however you answer this question, due to COVID-19."
+            helpText={
+              <Trans
+                i18nKey="retrocerts-certification.questions.ui-full-time.help-refuseWork"
+                t={[Function]}
+              />
+            }
             inputName="refuseWork"
             onChange={[Function]}
             questionNumber={4}
-            questionText="Did you refuse any work?"
+            questionText={
+              <Trans
+                i18nKey="retrocerts-certification.questions.ui-full-time.refuseWork"
+                t={[Function]}
+              />
+            }
           />
         </Col>
       </Row>
@@ -295,11 +363,21 @@ exports[`<RetroCertsCertificationPage /> Certify for one week of 2 1`] = `
       >
         <Col>
           <YesNoQuestion
-            helpText="Answer ‘yes’ only if school or training began during this week."
+            helpText={
+              <Trans
+                i18nKey="retrocerts-certification.questions.ui-full-time.help-schoolOrTraining"
+                t={[Function]}
+              />
+            }
             inputName="schoolOrTraining"
             onChange={[Function]}
             questionNumber={5}
-            questionText="Did you begin attending any kind of school or training?"
+            questionText={
+              <Trans
+                i18nKey="retrocerts-certification.questions.ui-full-time.schoolOrTraining"
+                t={[Function]}
+              />
+            }
           />
         </Col>
       </Row>

--- a/src/client/pages/RetroCertsCertificationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsCertificationPage/__snapshots__/index.test.js.snap
@@ -41,7 +41,7 @@ exports[`<RetroCertsCertificationPage /> Certify for 2nd week of 2 1`] = `
       >
         <Col>
           <YesNoQuestion
-            helpText="You must be well enough to work every day of the week to receive full benefits."
+            helpText="You must be well enough to work everyday of the week to receive full benefits. Check ‘yes’ if a workday was missed due to being sick or injured."
             ifYes={false}
             inputName="tooSick"
             key="1tooSick"
@@ -50,7 +50,9 @@ exports[`<RetroCertsCertificationPage /> Certify for 2nd week of 2 1`] = `
             questionText="Were you too sick or injured to work?"
           >
             <DaysSickQuestion
+              helpText="You must report the numbers of days that you could not work during this week. Unemployment benefits are paid according to the number of days you are able to work this week."
               onChange={[Function]}
+              questionText="If Yes, enter the number of days (1 - 7) you were unable to work."
             />
           </YesNoQuestion>
         </Col>
@@ -228,7 +230,7 @@ exports[`<RetroCertsCertificationPage /> Certify for one week of 2 1`] = `
       >
         <Col>
           <YesNoQuestion
-            helpText="You must be well enough to work every day of the week to receive full benefits."
+            helpText="You must be well enough to work everyday of the week to receive full benefits. Check ‘yes’ if a workday was missed due to being sick or injured."
             ifYes={false}
             inputName="tooSick"
             key="0tooSick"
@@ -237,7 +239,9 @@ exports[`<RetroCertsCertificationPage /> Certify for one week of 2 1`] = `
             questionText="Were you too sick or injured to work?"
           >
             <DaysSickQuestion
+              helpText="You must report the numbers of days that you could not work during this week. Unemployment benefits are paid according to the number of days you are able to work this week."
               onChange={[Function]}
+              questionText="If Yes, enter the number of days (1 - 7) you were unable to work."
             />
           </YesNoQuestion>
         </Col>

--- a/src/client/pages/RetroCertsCertificationPage/index.js
+++ b/src/client/pages/RetroCertsCertificationPage/index.js
@@ -14,6 +14,7 @@ import {
 import mockedFormData from "../../../data/mockedFormData";
 import routes from "../../../data/routes";
 import AUTH_STRINGS from "../../../data/authStrings";
+import seekWorkPlan from "../../../data/seekWorkPlan";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header";
 import YesNoQuestion from "../../components/YesNoQuestion";
@@ -52,6 +53,9 @@ function RetroCertsCertificationPage(props) {
   const formDataArray = userData.formData || [];
   const formData = formDataArray[weekForUser - 1] || { weekIndex };
 
+  const weekSeekWorkPlan =
+    userData.seekWorkPlan[userData.weeksToCertify.indexOf(weekIndex)];
+
   const handleFormDataChange = (event) => {
     const { value, name } = event;
     formDataArray[weekForUser - 1] = {
@@ -74,6 +78,18 @@ function RetroCertsCertificationPage(props) {
       formData: [...formDataArray],
     });
   };
+
+  function questionText(transKey) {
+    if (weekSeekWorkPlan === seekWorkPlan.uiPartTime) {
+      return "retrocerts-certification.questions.ui-part-time." + transKey;
+    }
+    if (weekSeekWorkPlan === seekWorkPlan.uiFullTime) {
+      return "retrocerts-certification.questions.ui-full-time." + transKey;
+    }
+    if (weekSeekWorkPlan === seekWorkPlan.puaFullTime) {
+      return "retrocerts-certification.questions.pua-full-time." + transKey;
+    }
+  }
 
   function handleSubmit() {
     fetch(AUTH_STRINGS.apiPath.save, {
@@ -125,8 +141,8 @@ function RetroCertsCertificationPage(props) {
               <YesNoQuestion
                 key={weekIndex + "tooSick"}
                 questionNumber={1}
-                questionText={t("retrocerts-certification.q-tooSick")}
-                helpText={t("retrocerts-certification.qhelp-tooSick")}
+                questionText={t(questionText("tooSick"))}
+                helpText={t(questionText("help-tooSick"))}
                 ifYes={formData.tooSick}
                 onChange={(e) => handleFormDataChange(e)}
                 inputName="tooSick"
@@ -134,6 +150,8 @@ function RetroCertsCertificationPage(props) {
                 <DaysSickQuestion
                   numDays={formData.tooSickNumberOfDays}
                   onChange={(e) => handleFormDataChange(e)}
+                  questionText={t(questionText("tooSickNumberOfDays"))}
+                  helpText={t(questionText("help-tooSickNumberOfDays"))}
                 />
               </YesNoQuestion>
             </Col>

--- a/src/client/pages/RetroCertsCertificationPage/index.js
+++ b/src/client/pages/RetroCertsCertificationPage/index.js
@@ -114,6 +114,11 @@ function RetroCertsCertificationPage(props) {
       .catch((error) => console.error(error));
   }
 
+  const questionsTwoThroughFive =
+    weekSeekWorkPlan === seekWorkPlan.puaFullTime
+      ? ["couldNotAcceptWork", "didYouLook", "refuseWork", "otherBenefits"]
+      : ["couldNotAcceptWork", "didYouLook", "refuseWork", "schoolOrTraining"];
+
   return (
     <div id="overflow-wrapper">
       <Header />
@@ -156,22 +161,22 @@ function RetroCertsCertificationPage(props) {
               </YesNoQuestion>
             </Col>
           </Row>
-          {["fullTime", "didYouLook", "refuseWork", "schoolOrTraining"].map(
-            (name, index) => (
-              <Row key={weekIndex + name}>
-                <Col>
-                  <YesNoQuestion
-                    questionNumber={index + 2}
-                    questionText={t(`retrocerts-certification.q-${name}`)}
-                    helpText={t(`retrocerts-certification.qhelp-${name}`)}
-                    ifYes={formData[name]}
-                    onChange={(e) => handleFormDataChange(e)}
-                    inputName={name}
-                  />
-                </Col>
-              </Row>
-            )
-          )}
+          {questionsTwoThroughFive.map((name, index) => (
+            <Row key={weekIndex + name}>
+              <Col>
+                <YesNoQuestion
+                  questionNumber={index + 2}
+                  questionText={<Trans t={t} i18nKey={questionText(name)} />}
+                  helpText={
+                    <Trans t={t} i18nKey={questionText(`help-${name}`)} />
+                  }
+                  ifYes={formData[name]}
+                  onChange={(e) => handleFormDataChange(e)}
+                  inputName={name}
+                />
+              </Col>
+            </Row>
+          ))}
           <Row>
             <Col>
               <YesNoQuestion

--- a/src/client/pages/RetroCertsCertificationPage/index.test.js
+++ b/src/client/pages/RetroCertsCertificationPage/index.test.js
@@ -11,6 +11,7 @@ describe("<RetroCertsCertificationPage />", () => {
         userData: {
           status: AUTH_STRINGS.statusCode.ok,
           weeksToCertify: [0, 1],
+          seekWorkPlan: ["UI full time", "UI part time"],
         },
         setUserData: () => {},
         routeComputedMatch: {
@@ -31,6 +32,7 @@ describe("<RetroCertsCertificationPage />", () => {
         userData: {
           status: AUTH_STRINGS.statusCode.ok,
           weeksToCertify: [0, 1],
+          seekWorkPlan: ["UI full time", "UI part time"],
           formData: [{ weekIndex: 0, tooSick: false, fullTime: true }],
         },
         setUserData: () => {},
@@ -53,6 +55,7 @@ describe("<RetroCertsCertificationPage />", () => {
         userData: {
           status: AUTH_STRINGS.statusCode.ok,
           weeksToCertify: [0, 1],
+          seekWorkPlan: ["UI full time", "UI part time"],
           formData: [
             {
               weekIndex: 0,

--- a/src/data/seekWorkPlan.js
+++ b/src/data/seekWorkPlan.js
@@ -1,0 +1,7 @@
+const seekWorkPlan = {
+  uiPartTime: "UI part time",
+  uiFullTime: "UI full time",
+  puaFullTime: "PUA full time",
+};
+
+export default seekWorkPlan;

--- a/src/routes/retro-certs.js
+++ b/src/routes/retro-certs.js
@@ -31,8 +31,8 @@ function createRouter() {
       );
       responseJson.status = AUTH_STRINGS.statusCode.ok;
       responseJson.authToken = formRecord.authToken;
-      responseJson.weeksToCertify = Array.from(userRecord.weeksToCertify);
-      responseJson.seekWorkPlan = Array.from(userRecord.seekWorkPlan);
+      responseJson.weeksToCertify = userRecord.weeksToCertify;
+      responseJson.seekWorkPlan = userRecord.seekWorkPlan;
       responseJson.confirmationNumber = formRecord.confirmationNumber;
     }
     return responseJson;

--- a/src/routes/retro-certs.js
+++ b/src/routes/retro-certs.js
@@ -32,6 +32,7 @@ function createRouter() {
       responseJson.status = AUTH_STRINGS.statusCode.ok;
       responseJson.authToken = formRecord.authToken;
       responseJson.weeksToCertify = Array.from(userRecord.weeksToCertify);
+      responseJson.seekWorkPlan = Array.from(userRecord.seekWorkPlan);
       responseJson.confirmationNumber = formRecord.confirmationNumber;
     }
     return responseJson;
@@ -47,6 +48,7 @@ function createRouter() {
         const userRecord = await cosmos.getUserById(formRecord.id);
         responseJson.status = AUTH_STRINGS.statusCode.ok;
         responseJson.weeksToCertify = Array.from(userRecord.weeksToCertify);
+        responseJson.seekWorkPlan = Array.from(userRecord.seekWorkPlan);
         responseJson.confirmationNumber = formRecord.confirmationNumber;
       }
     }

--- a/src/routes/retro-certs.test.js
+++ b/src/routes/retro-certs.test.js
@@ -80,20 +80,29 @@ describe("Router: API tests", () => {
       [
         { lastName: "Last", eddcan: "1234567890", ssn: "123456789" },
         true,
-        { id: "hash", weeksToCertify: [0, 1] },
+        {
+          id: "hash",
+          weeksToCertify: [0, 1],
+          seekWorkPlan: ["UI full time", "UI part time"],
+        },
         { authToken: "test auth token" },
         200,
         {
           status: AUTH_STRINGS.statusCode.ok,
           authToken: "test auth token",
           weeksToCertify: [0, 1],
+          seekWorkPlan: ["UI full time", "UI part time"],
         },
       ],
       // User has correct credentails, but recaptcha is not valid.
       [
         { lastName: "Last", eddcan: "1234567890", ssn: "123456789" },
         false,
-        { id: "hash", weeksToCertify: [0, 1] },
+        {
+          id: "hash",
+          weeksToCertify: [0, 1],
+          seekWorkPlan: ["UI full time", "UI part time"],
+        },
         { authToken: "test auth token" },
         401,
         {
@@ -168,21 +177,27 @@ describe("Router: API tests", () => {
       [
         { authToken: "valid uuid" },
         { id: "hash", authToken: "auth token" },
-        { id: "hash", weeksToCertify: [0, 1] },
+        {
+          id: "hash",
+          weeksToCertify: [0, 1],
+          seekWorkPlan: ["UI full time", "UI part time"],
+        },
         200,
         {
           status: AUTH_STRINGS.statusCode.ok,
           weeksToCertify: [0, 1],
+          seekWorkPlan: ["UI full time", "UI part time"],
         },
       ],
       [
         { authToken: "valid uuid" },
         { id: "hash", authToken: "auth token" },
-        { id: "hash", weeksToCertify: [2] },
+        { id: "hash", weeksToCertify: [2], seekWorkPlan: ["PUA full time"] },
         200,
         {
           status: AUTH_STRINGS.statusCode.ok,
           weeksToCertify: [2],
+          seekWorkPlan: ["PUA full time"],
         },
       ],
     ];


### PR DESCRIPTION
- Updates wording for questions 1-5 based on PUA/UI part time/UI full time
- Updates some styling

Still to do: 
- Update test users with new seekWorkPlan format (use JARVIS/0987654321/987654321 to test)
- Add question 7 for PUA

![pua](https://user-images.githubusercontent.com/4306128/85172792-c837b800-b23f-11ea-897d-d3b9dfb9abbe.png)
![uiPartTime](https://user-images.githubusercontent.com/4306128/85172793-c837b800-b23f-11ea-9b1d-85bc81923106.png)
![uiFullTime](https://user-images.githubusercontent.com/4306128/85172794-c8d04e80-b23f-11ea-9a02-0674fdcf59e4.png)

===

Connects #317 

- [x] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [x] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
