### PR TITLE
Add the perjury checkbox.

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -325,6 +325,9 @@
       "choice-13": "You became the major financial support for your household because the head of household died as a direct result of COVID-19.",
       "choice-14": "None of these options apply to me."
     },
+    "ack-header": "Acknowledgement",
+    "ack-p": "I understand the questions I answered through this automated system. I know the law provides penalties if I make false statements or  withhold facts to receive benefits; and my answers are true and correct. I declare under penalty of perjury that I am a US Citizen or National; or an Alien in satisfactory immigration status and permitted to work by the United States Citizenship and Immigration Service. I understand when submitting my request for benefits my submission is considered the same as my written signature.",
+    "ack-label": "You must indicate your acceptance of the statement by checking the box before your certification can be submitted.",
     "button-back": "Back",
     "button-next": "Next, certify Week {{nextWeekForUser}}",
     "button-submit": "Submit your certification"

--- a/src/client/components/PerjuryCheckbox/__snapshots__/index.test.js.snap
+++ b/src/client/components/PerjuryCheckbox/__snapshots__/index.test.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<PerjuryCheckbox /> renders the component 1`] = `
+<FormGroup
+  className="prejury-checkbox"
+>
+  <FormText
+    as="h3"
+  >
+    Acknowledgement
+  </FormText>
+  <FormText
+    as="p"
+  >
+    I understand the questions I answered through this automated system. I know the law provides penalties if I make false statements or  withhold facts to receive benefits; and my answers are true and correct. I declare under penalty of perjury that I am a US Citizen or National; or an Alien in satisfactory immigration status and permitted to work by the United States Citizenship and Immigration Service. I understand when submitting my request for benefits my submission is considered the same as my written signature.
+  </FormText>
+  <FormRow>
+    <Col
+      md="auto"
+    >
+      <FormCheck
+        checked={false}
+        disabled={false}
+        inline={false}
+        isInvalid={false}
+        isValid={false}
+        onChange={[Function]}
+        required={true}
+        title=""
+        type="checkbox"
+      />
+    </Col>
+    <Col>
+      <FormLabel
+        column={false}
+        srOnly={false}
+      >
+        You must indicate your acceptance of the statement by checking the box before your certification can be submitted.
+      </FormLabel>
+    </Col>
+  </FormRow>
+</FormGroup>
+`;

--- a/src/client/components/PerjuryCheckbox/index.js
+++ b/src/client/components/PerjuryCheckbox/index.js
@@ -1,0 +1,32 @@
+import Col from "react-bootstrap/Col";
+import Form from "react-bootstrap/Form";
+import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+function PerjuryCheckbox(props) {
+  const [isChecked, setIsChecked] = useState(false);
+  const { t } = useTranslation();
+
+  return (
+    <Form.Group className="prejury-checkbox">
+      <Form.Text as="h3">{t("retrocerts-certification.ack-header")}</Form.Text>
+      <Form.Text as="p">{t("retrocerts-certification.ack-p")}</Form.Text>
+
+      <Form.Row>
+        <Col md="auto">
+          <Form.Check
+            type="checkbox"
+            checked={isChecked}
+            onChange={(e) => setIsChecked(e.target.checked)}
+            required
+          />
+        </Col>
+        <Col>
+          <Form.Label>{t("retrocerts-certification.ack-label")}</Form.Label>
+        </Col>
+      </Form.Row>
+    </Form.Group>
+  );
+}
+
+export default PerjuryCheckbox;

--- a/src/client/components/PerjuryCheckbox/index.test.js
+++ b/src/client/components/PerjuryCheckbox/index.test.js
@@ -1,0 +1,10 @@
+import renderNonTransContent from "../../test-helpers/renderNonTransContent";
+import Component from "./index";
+
+describe("<PerjuryCheckbox />", () => {
+  it("renders the component", async () => {
+    const wrapper = renderNonTransContent(Component, "PerjuryCheckbox");
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/client/pages/RetroCertsCertificationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsCertificationPage/__snapshots__/index.test.js.snap
@@ -170,6 +170,7 @@ exports[`<RetroCertsCertificationPage /> Certify for 2nd week of 2 1`] = `
             onChange={[Function]}
           />
         </YesNoQuestion>
+        <PerjuryCheckbox />
         <FormRow>
           <Col>
             <Button

--- a/src/client/pages/RetroCertsCertificationPage/index.js
+++ b/src/client/pages/RetroCertsCertificationPage/index.js
@@ -21,6 +21,7 @@ import YesNoQuestion from "../../components/YesNoQuestion";
 import DaysSickQuestion from "../../components/DaysSickQuestion";
 import EmployersQuestions from "../../components/EmployersQuestions";
 import DisasterQuestion from "../../components/DisasterQuestion";
+import PerjuryCheckbox from "../../components/PerjuryCheckbox";
 
 function RetroCertsCertificationPage(props) {
   const { t } = useTranslation();
@@ -252,6 +253,8 @@ function RetroCertsCertificationPage(props) {
                 />
               </YesNoQuestion>
             )}
+            {weekForUser === numberOfWeeks && <PerjuryCheckbox />}
+
             <Form.Row>
               <Col>
                 <Button


### PR DESCRIPTION
On the last page of the form, add a
checkbox that must be set to submit.

There's some styling that needs to be
done, especially when the box isn't
checked.

===

Resolves #320

- [X] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [X] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made

![screencapture-localhost-3000-retroactive-certification-certify-2020-05-02-2020-06-19-15_54_11](https://user-images.githubusercontent.com/175378/85184683-890c6580-b245-11ea-84a0-4dc83adb0747.png)
