### PR TITLE
Add error feedback to certification page.

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -185,6 +185,7 @@
     "Yes": "Yes",
     "No": "No"
   },
+  "required-error": "This field is required.",
   "retrocert-login": {
     "title": "Retroactive Certification for Unemployment",
     "help": "You are required to certify for Unemployment Insurance (UI) and Pandemic Unemployment Assistance (PUA) benefits from the week ending February 9, 2020, through week ending May 9, 2020.",
@@ -202,7 +203,6 @@
     "invalid-user-error": "Review and verify the information you entered is correct. If your information is correct, then you don’t need to certify.",
     "invalid-recaptcha-error": "Please check the box next to \"I'm not a robot\" to continue.",
     "session-timed-out": "We logged you out after 30 minutes of inactivity. Please provide your information again to certify your weeks.",
-    "required-error": "This field is required.",
     "show-ssn":"Show SSN",
     "hide-ssn":"Hide SSN"
   },
@@ -327,6 +327,7 @@
     "ack-list-item-3": "I declare under penalty of perjury that I am a US Citizen or National; or an Alien in satisfactory immigration status and permitted to work by the United States Citizenship and Immigration Service.",
     "ack-list-item-4": "I understand when submitting my request for benefits my submission is considered the same as my written signature.",
     "ack-label": "I agree and accept the statement above.",
+    "ack-feedback": "You must indicate your acceptance of the statement by checking the box before your certification can be submitted.",
     "submit-p1": "You are about to submit your retroactive certification(s). You will <strong>not</strong> be able to change your answers once you select Submit.",
     "submit-p2": "To complete your retroactive certification(s), select Submit.",
     "button-back": "Back",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -184,7 +184,8 @@
   "yesnoquestion": {
     "Yes": "Yes",
     "No": "No"
-  },  
+  },
+  "required-error": "This field is required.",
   "retrocert-login": {
     "title": "Retroactive Certification for Unemployment",
     "help": "You are required to certify for Unemployment Insurance (UI) and Pandemic Unemployment Assistance (PUA) benefits from the week ending February 9, 2020, through week ending May 9, 2020.",
@@ -202,7 +203,6 @@
     "invalid-user-error": "Review and verify the information you entered is correct. If your information is correct, then you don’t need to certify.",
     "invalid-recaptcha-error": "Please check the box next to \"I'm not a robot\" to continue.",
     "session-timed-out": "We logged you out after 30 minutes of inactivity. Please provide your information again to certify your weeks.",
-    "required-error": "This field is required.",
     "show-ssn":"Show SSN",
     "hide-ssn":"Hide SSN"
   },

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -327,6 +327,7 @@
     "ack-list-item-3": "I declare under penalty of perjury that I am a US Citizen or National; or an Alien in satisfactory immigration status and permitted to work by the United States Citizenship and Immigration Service.",
     "ack-list-item-4": "I understand when submitting my request for benefits my submission is considered the same as my written signature.",
     "ack-label": "I agree and accept the statement above.",
+    "ack-feedback": "You must indicate your acceptance of the statement by checking the box before your certification can be submitted.",
     "submit-p1": "You are about to submit your retroactive certification(s). You will <strong>not</strong> be able to change your answers once you select Submit.",
     "submit-p2": "To complete your retroactive certification(s), select Submit.",
     "button-back": "Back",

--- a/src/client/App.scss
+++ b/src/client/App.scss
@@ -104,9 +104,23 @@ footer {
   border-color: rgb(206, 212, 218) !important;
 }
 
+// This removes the green/red text on Yes/No radio labels.
+.form-check-input.is-valid ~ .form-check-label,
+.was-validated .form-check-input:valid ~ .form-check-label,
+.form-check-input.is-invalid ~ .form-check-label,
+.was-validated .form-check-input:invalid ~ .form-check-label {
+  color: inherit;
+}
+
 // Use grey for secondary alerts rather than our secondary color yellowish gold.
 .alert-secondary {
   color: #383d41;
   background-color: #e2e3e5;
   border-color: #d6d8db;
+}
+
+// For radio Form.Checks, we need to manually see if the
+// radio question was answered for the feedback to show.
+.was-validated .unchecked .invalid-feedback {
+  display: block;
 }

--- a/src/client/components/DaysSickQuestion/__snapshots__/index.test.js.snap
+++ b/src/client/components/DaysSickQuestion/__snapshots__/index.test.js.snap
@@ -28,5 +28,10 @@ exports[`<DaysSickQuestion /> renders the component 1`] = `
     type="text"
     value=""
   />
+  <Feedback
+    type="invalid"
+  >
+    This field is required.
+  </Feedback>
 </FormGroup>
 `;

--- a/src/client/components/DaysSickQuestion/index.js
+++ b/src/client/components/DaysSickQuestion/index.js
@@ -1,8 +1,10 @@
 import Form from "react-bootstrap/Form";
+import { useTranslation } from "react-i18next";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
 
 function DaysSickQuestion(props) {
+  const { t } = useTranslation();
   const [numDays, setNumDays] = useState(
     props.numDays !== undefined ? String(props.numDays) : ""
   );
@@ -33,6 +35,9 @@ function DaysSickQuestion(props) {
         required
         pattern="[1234567]"
       />
+      <Form.Control.Feedback type="invalid">
+        {t("required-error")}
+      </Form.Control.Feedback>
     </Form.Group>
   );
 }

--- a/src/client/components/EmployersQuestions/index.js
+++ b/src/client/components/EmployersQuestions/index.js
@@ -70,6 +70,9 @@ function EmployerQuestions(props) {
           required={required}
           pattern={options.pattern}
         />
+        <Form.Control.Feedback type="invalid">
+          {t("required-error")}
+        </Form.Control.Feedback>
       </Form.Group>
     );
   }
@@ -113,6 +116,9 @@ function EmployerQuestions(props) {
               <option key={code}>{code}</option>
             ))}
           </Form.Control>
+          <Form.Control.Feedback type="invalid">
+            {t("required-error")}
+          </Form.Control.Feedback>
         </Form.Group>
       </Form.Row>
       {renderTextInput("zipcode", {
@@ -136,6 +142,9 @@ function EmployerQuestions(props) {
             required
             pattern="0?[1-9]|10|11|12"
           />
+          <Form.Control.Feedback type="invalid">
+            {t("required-error")}
+          </Form.Control.Feedback>
         </Form.Group>
         <Form.Group
           controlId={props.employerData.id + "lastDateWorked-day-question"}
@@ -151,6 +160,9 @@ function EmployerQuestions(props) {
             required
             pattern="0?[1-9]|1\d|2\d|3[01]"
           />
+          <Form.Control.Feedback type="invalid">
+            {t("required-error")}
+          </Form.Control.Feedback>
         </Form.Group>
         <Form.Group as={Col} md={2}>
           <Form.Label>{t(tk("year"))}</Form.Label>

--- a/src/client/components/PerjuryCheckbox/__snapshots__/index.test.js.snap
+++ b/src/client/components/PerjuryCheckbox/__snapshots__/index.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<PerjuryCheckbox /> renders the component 1`] = `
 <FormGroup
-  className="prejury-checkbox"
+  className="unchecked"
   controlId="perjury-checkbox"
 >
   <FormText
@@ -49,6 +49,11 @@ exports[`<PerjuryCheckbox /> renders the component 1`] = `
       </FormLabel>
     </Col>
   </FormRow>
+  <Feedback
+    type="invalid"
+  >
+    You must indicate your acceptance of the statement by checking the box before your certification can be submitted.
+  </Feedback>
   <FormText
     as="p"
   >

--- a/src/client/components/PerjuryCheckbox/index.js
+++ b/src/client/components/PerjuryCheckbox/index.js
@@ -1,4 +1,5 @@
 import Col from "react-bootstrap/Col";
+import Feedback from "react-bootstrap/Feedback";
 import Form from "react-bootstrap/Form";
 import React, { useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
@@ -8,7 +9,10 @@ function PerjuryCheckbox(props) {
   const { t } = useTranslation();
 
   return (
-    <Form.Group controlId="perjury-checkbox" className="prejury-checkbox">
+    <Form.Group
+      controlId="perjury-checkbox"
+      className={isChecked ? "" : "unchecked"}
+    >
       <Form.Text as="h3">{t("retrocerts-certification.ack-header")}</Form.Text>
       <ul>
         <li>{t("retrocerts-certification.ack-list-item-1")}</li>
@@ -30,6 +34,9 @@ function PerjuryCheckbox(props) {
           <Form.Label>{t("retrocerts-certification.ack-label")}</Form.Label>
         </Col>
       </Form.Row>
+      <Feedback type="invalid">
+        {t("retrocerts-certification.ack-feedback")}
+      </Feedback>
 
       <Form.Text as="p">
         <Trans t={t} i18nKey="retrocerts-certification.submit-p1" />

--- a/src/client/components/YesNoQuestion/index.js
+++ b/src/client/components/YesNoQuestion/index.js
@@ -1,4 +1,6 @@
 import React, { useState } from "react";
+import Feedback from "react-bootstrap/Feedback";
+
 import PropTypes from "prop-types";
 import { Form } from "react-bootstrap";
 import { useTranslation } from "react-i18next";
@@ -35,7 +37,10 @@ function YesNoQuestion(props) {
 
   return (
     <div className="bg-light p-2 m-2">
-      <Form.Group controlId={inputName}>
+      <Form.Group
+        controlId={inputName}
+        className={isYes === undefined ? "unchecked" : ""}
+      >
         <Form.Label>
           {questionNumber}.&nbsp;{questionText}
         </Form.Label>
@@ -55,6 +60,7 @@ function YesNoQuestion(props) {
             required
           />
         ))}
+        <Feedback type="invalid">{t("required-error")}</Feedback>
       </Form.Group>
       {isYes === true && children}
     </div>

--- a/src/client/pages/RetroCertsAuthPage/index.js
+++ b/src/client/pages/RetroCertsAuthPage/index.js
@@ -159,7 +159,7 @@ function RetroCertsAuthPage(props) {
                   required
                 />
                 <Form.Control.Feedback type="invalid">
-                  {t("retrocert-login.required-error")}
+                  {t("required-error")}
                 </Form.Control.Feedback>
               </Form.Group>
             </Row>
@@ -181,7 +181,7 @@ function RetroCertsAuthPage(props) {
                   pattern="0?[1-9]|10|11|12"
                 />
                 <Form.Control.Feedback type="invalid">
-                  {t("retrocert-login.required-error")}
+                  {t("required-error")}
                 </Form.Control.Feedback>
               </Form.Group>
               <Form.Group controlId="formDobDay" as={Col} md={2}>
@@ -195,7 +195,7 @@ function RetroCertsAuthPage(props) {
                   pattern="0?[1-9]|1\d|2\d|3[01]"
                 />
                 <Form.Control.Feedback type="invalid">
-                  {t("retrocert-login.required-error")}
+                  {t("required-error")}
                 </Form.Control.Feedback>
               </Form.Group>
               <Form.Group controlId="formDobYear" as={Col} md={3}>
@@ -209,7 +209,7 @@ function RetroCertsAuthPage(props) {
                   pattern="[12][890]\d\d"
                 />
                 <Form.Control.Feedback type="invalid">
-                  {t("retrocert-login.required-error")}
+                  {t("required-error")}
                 </Form.Control.Feedback>
               </Form.Group>
             </Row>
@@ -223,7 +223,7 @@ function RetroCertsAuthPage(props) {
                   required
                 />
                 <Form.Control.Feedback type="invalid">
-                  {t("retrocert-login.required-error")}
+                  {t("required-error")}
                 </Form.Control.Feedback>
                 <div className="d-flex justify-content-end">
                   <Button

--- a/src/client/pages/RetroCertsCertificationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsCertificationPage/__snapshots__/index.test.js.snap
@@ -15,7 +15,7 @@ exports[`<RetroCertsCertificationPage /> Certify for 2nd week of 2 1`] = `
         Retroactively Certify and Review
       </h1>
       <h2
-        className="h3 font-weight-bold"
+        className="h3 font-weight-bold mt-5"
       >
         <Trans
           i18nKey="retrocerts-certification.form-header"
@@ -241,7 +241,7 @@ exports[`<RetroCertsCertificationPage /> Certify for one week of 2 1`] = `
         Retroactively Certify and Review
       </h1>
       <h2
-        className="h3 font-weight-bold"
+        className="h3 font-weight-bold mt-5"
       >
         <Trans
           i18nKey="retrocerts-certification.form-header"

--- a/src/client/pages/RetroCertsCertificationPage/index.js
+++ b/src/client/pages/RetroCertsCertificationPage/index.js
@@ -176,7 +176,7 @@ function RetroCertsCertificationPage(props) {
           <h1 ref={headingElement}>
             {t("retrocerts-certification.question-page-title")}
           </h1>
-          <h2 className="h3 font-weight-bold">
+          <h2 className="h3 font-weight-bold mt-5">
             <Trans
               t={t}
               i18nKey="retrocerts-certification.form-header"

--- a/src/routes/retro-certs.js
+++ b/src/routes/retro-certs.js
@@ -28,7 +28,7 @@ function createRouter() {
     }
 
     if (userRecord) {
-      console.log("login",  userRecord.id);
+      console.log("login", userRecord.id);
       const formRecord = await cosmos.getFormDataByUserIdWithNewAuthToken(
         userRecord.id
       );


### PR DESCRIPTION
Add feedback when a required field is not
entered. For Yes/No, remove the green/red
text color and add a message. For the perjury
check, add special text that they must
check the box.

===

Resolves #328

- [X] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made

![screencapture-localhost-3000-retroactive-certification-certify-2020-02-15-2020-06-23-10_41_42](https://user-images.githubusercontent.com/175378/85436860-8f992680-b53e-11ea-92d9-4171781dbdff.png)
