### PR TITLE
Update logic for reading user data from db

### DIFF
--- a/scripts/create_test_users.py
+++ b/scripts/create_test_users.py
@@ -44,7 +44,7 @@ def generate_test_users():
   for user in TEST_USERS:
       users.append({
           'id': get_hash(*user[:3]),
-          'seekWorkPlan': user[3],
+          'seekWorkPlan': [user[3]],
           'weeksToCertify': user[4],
           'source': SOURCE,
       })
@@ -66,7 +66,7 @@ def generate_batch_users(num_users=30):
 
         users.append({
             'id': get_hash(name, dob, ssn),
-            'seekWorkPlan': WORK_PLANS[i % 3],
+            'seekWorkPlan': [WORK_PLANS[i % 3]],
             'weeksToCertify': weeks_to_certify,
             'source': 'batch' + SOURCE
         })

--- a/src/client/pages/RetroCertsCertificationPage/index.js
+++ b/src/client/pages/RetroCertsCertificationPage/index.js
@@ -75,8 +75,14 @@ function RetroCertsCertificationPage(props) {
     }
   }
 
-  const weekSeekWorkPlan =
-    userData.seekWorkPlan[userData.weeksToCertify.indexOf(weekIndex)];
+  // Most (99.99%) users have the same seekWorkPlan for all weeks in ,
+  // weeksToCertify in which case their seekWorkPlan is a one element array.
+  // The rest have an array whose length matches the weeksToCertify length.
+  const seekWorkPlanIndex =
+    userData.seekWorkPlan.length === 1
+      ? 0
+      : userData.weeksToCertify.indexOf(weekIndex);
+  const weekSeekWorkPlan = userData.seekWorkPlan[seekWorkPlanIndex];
 
   const handleFormDataChange = (event) => {
     const { value, name } = event;

--- a/src/client/pages/RetroCertsCertificationPage/index.js
+++ b/src/client/pages/RetroCertsCertificationPage/index.js
@@ -79,9 +79,7 @@ function RetroCertsCertificationPage(props) {
   // weeksToCertify, in which case their seekWorkPlan is a one element array.
   // The rest have an array whose length matches the weeksToCertify length.
   const seekWorkPlanIndex =
-    userData.seekWorkPlan.length === 1
-      ? 0
-      : userData.weeksToCertify.indexOf(weekIndex);
+    userData.seekWorkPlan.length === 1 ? 0 : weekForUser - 1;
   const weekSeekWorkPlan = userData.seekWorkPlan[seekWorkPlanIndex];
 
   const handleFormDataChange = (event) => {

--- a/src/client/pages/RetroCertsCertificationPage/index.js
+++ b/src/client/pages/RetroCertsCertificationPage/index.js
@@ -75,8 +75,8 @@ function RetroCertsCertificationPage(props) {
     }
   }
 
-  // Most (99.99%) users have the same seekWorkPlan for all weeks in ,
-  // weeksToCertify in which case their seekWorkPlan is a one element array.
+  // Most (99.99%) users have the same seekWorkPlan for all weeks in
+  // weeksToCertify, in which case their seekWorkPlan is a one element array.
   // The rest have an array whose length matches the weeksToCertify length.
   const seekWorkPlanIndex =
     userData.seekWorkPlan.length === 1

--- a/src/routes/retro-certs.test.js
+++ b/src/routes/retro-certs.test.js
@@ -186,6 +186,21 @@ describe("Router: API tests", () => {
       [
         { authToken: "valid uuid" },
         { id: "hash", authToken: "auth token" },
+        {
+          id: "hash",
+          weeksToCertify: [0, 1],
+          seekWorkPlan: ["UI full time"],
+        },
+        200,
+        {
+          status: AUTH_STRINGS.statusCode.ok,
+          weeksToCertify: [0, 1],
+          seekWorkPlan: ["UI full time"],
+        },
+      ],
+      [
+        { authToken: "valid uuid" },
+        { id: "hash", authToken: "auth token" },
         { id: "hash", weeksToCertify: [2], seekWorkPlan: ["PUA full time"] },
         200,
         {


### PR DESCRIPTION
This PR updates the logic for reading from the db to account for the following:

Most (99.99%) users have the same seekWorkPlan for all weeks in weeksToCertify, in which case their seekWorkPlan is a one element array. The rest have an array whose length matches the weeksToCertify length.

Note that this logic should continue to work with all existing test data created under the prior assumption that all seekWorkPlan arrays would be the same length as the weeksToCertify array for that row.

===

Resolves #329

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
