### PR TITLE
Fix error feedback on disaster question.

### DIFF
--- a/src/client/components/DisasterQuestion/index.js
+++ b/src/client/components/DisasterQuestion/index.js
@@ -6,11 +6,7 @@ import { useTranslation } from "react-i18next";
 function DisasterQuestion(props) {
   const { t } = useTranslation();
 
-  const [userChoice, setUserChoice] = useState(
-    props.choice !== undefined
-      ? props.choice
-      : t("retrocerts-certification.disaster-choices.choice-14")
-  );
+  const [userChoice, setUserChoice] = useState(props.choice);
 
   const [isDirty, setIsDirty] = useState(
     props.choice !== undefined || userChoice !== undefined


### PR DESCRIPTION
We were setting the default choice to the last
option rather than being unselected when shown.

===

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made

![screencapture-localhost-3000-retroactive-certification-certify-2020-02-15-2020-06-23-15_40_49](https://user-images.githubusercontent.com/175378/85473449-1b737880-b568-11ea-83eb-333ad24c24a2.png)
