### PR TITLE
Updates to the save api.

### DIFF
--- a/src/data/cosmos.js
+++ b/src/data/cosmos.js
@@ -146,10 +146,14 @@ async function saveFormData(authToken, formData) {
     return;
   }
 
-  item.formData = formData;
-  item.confirmationNumber = uuidv4();
-  await insertItem(item, formsContainerName);
-  return item;
+  // If the user already submitted data, don't overwrite it.
+  if (!item.confirmationNumber) {
+    item.formData = formData;
+    item.confirmationNumber = uuidv4();
+    await insertItem(item, formsContainerName);
+  }
+
+  return { confirmationNumber: item.confirmationNumber };
 }
 
 module.exports = {


### PR DESCRIPTION
- If the user has already submitted
  data, don't overwrite it and return
  their existing confirmation number.
- Only return the confirmation number.
  We were returning all the meta data,
  which we probably don't want to do.

===

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
