### PR TITLE
Updated header and footer links to use a new tab

### DIFF
--- a/src/client/components/Footer/__snapshots__/index.test.js.snap
+++ b/src/client/components/Footer/__snapshots__/index.test.js.snap
@@ -39,6 +39,8 @@ exports[`<Footer /> renders the component 1`] = `
         }
         disabled={false}
         href="https://edd.ca.gov/about_edd/"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         About EDD
       </NavLink>
@@ -52,6 +54,8 @@ exports[`<Footer /> renders the component 1`] = `
         }
         disabled={false}
         href="https://edd.ca.gov/about_edd/contact_edd.htm"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         Contact EDD
       </NavLink>
@@ -65,6 +69,8 @@ exports[`<Footer /> renders the component 1`] = `
         }
         disabled={false}
         href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         Conditions of Use
       </NavLink>
@@ -78,6 +84,8 @@ exports[`<Footer /> renders the component 1`] = `
         }
         disabled={false}
         href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         Privacy Policy
       </NavLink>
@@ -91,6 +99,8 @@ exports[`<Footer /> renders the component 1`] = `
         }
         disabled={false}
         href="https://edd.ca.gov/about_edd/accessibility.htm"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         Accessibility
       </NavLink>
@@ -104,6 +114,8 @@ exports[`<Footer /> renders the component 1`] = `
         }
         disabled={false}
         href="https://edd.ca.gov/sitemap.htm"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         Site Map
       </NavLink>
@@ -123,6 +135,8 @@ exports[`<Footer /> renders the component 1`] = `
         }
         disabled={false}
         href="https://www.facebook.com/californiaedd/"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         <img
           alt="Facebook icon"
@@ -142,6 +156,8 @@ exports[`<Footer /> renders the component 1`] = `
         }
         disabled={false}
         href="https://twitter.com/CA_EDD"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         <img
           alt="Twitter icon"
@@ -161,6 +177,8 @@ exports[`<Footer /> renders the component 1`] = `
         }
         disabled={false}
         href="https://www.linkedin.com/company/californiaedd/"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         <img
           alt="LinkedIn icon"
@@ -180,6 +198,8 @@ exports[`<Footer /> renders the component 1`] = `
         }
         disabled={false}
         href="https://www.instagram.com/ca_edd/"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         <img
           alt="Instagram icon"
@@ -199,6 +219,8 @@ exports[`<Footer /> renders the component 1`] = `
         }
         disabled={false}
         href="https://www.youtube.com/user/CaliforniaEDDD"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         <img
           alt="YouTube icon"

--- a/src/client/components/Footer/index.js
+++ b/src/client/components/Footer/index.js
@@ -12,27 +12,55 @@ function Footer() {
       <Navbar className="justify-content-between" variant="custom" bg="dark">
         <Nav className="flex-wrap">
           <Nav.Link href="#back-to-top">{t("footer.toTop")}</Nav.Link>
-          <Nav.Link href="https://edd.ca.gov/about_edd/">
+          <Nav.Link
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://edd.ca.gov/about_edd/"
+          >
             {t("footer.about")}
           </Nav.Link>
-          <Nav.Link href="https://edd.ca.gov/about_edd/contact_edd.htm">
+          <Nav.Link
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://edd.ca.gov/about_edd/contact_edd.htm"
+          >
             {t("footer.contact")}
           </Nav.Link>
-          <Nav.Link href="https://edd.ca.gov/about_edd/conditions_of_use.htm">
+          <Nav.Link
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+          >
             {t("footer.conditionsOfUse")}
           </Nav.Link>
-          <Nav.Link href="https://edd.ca.gov/about_edd/privacy_policy.htm">
+          <Nav.Link
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+          >
             {t("footer.privacyPolicy")}
           </Nav.Link>
-          <Nav.Link href="https://edd.ca.gov/about_edd/accessibility.htm">
+          <Nav.Link
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://edd.ca.gov/about_edd/accessibility.htm"
+          >
             {t("footer.accessibility")}
           </Nav.Link>
-          <Nav.Link href="https://edd.ca.gov/sitemap.htm">
+          <Nav.Link
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://edd.ca.gov/sitemap.htm"
+          >
             {t("footer.siteMap")}
           </Nav.Link>
         </Nav>
         <Nav className="flex-wrap">
-          <Nav.Link href="https://www.facebook.com/californiaedd/">
+          <Nav.Link
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://www.facebook.com/californiaedd/"
+          >
             <img
               src="images/facebook.svg"
               width="15"
@@ -40,7 +68,11 @@ function Footer() {
               alt={t("iconAltText.facebook")}
             />{" "}
           </Nav.Link>
-          <Nav.Link href="https://twitter.com/CA_EDD">
+          <Nav.Link
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://twitter.com/CA_EDD"
+          >
             <img
               src="images/twitter.svg"
               width="15"
@@ -48,7 +80,11 @@ function Footer() {
               alt={t("iconAltText.twitter")}
             />{" "}
           </Nav.Link>
-          <Nav.Link href="https://www.linkedin.com/company/californiaedd/">
+          <Nav.Link
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://www.linkedin.com/company/californiaedd/"
+          >
             <img
               src="images/linkedin.svg"
               width="15"
@@ -56,7 +92,11 @@ function Footer() {
               alt={t("iconAltText.linkedIn")}
             />{" "}
           </Nav.Link>
-          <Nav.Link href="https://www.instagram.com/ca_edd/">
+          <Nav.Link
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://www.instagram.com/ca_edd/"
+          >
             <img
               src="images/instagram.svg"
               width="15"
@@ -64,7 +104,11 @@ function Footer() {
               alt={t("iconAltText.instagram")}
             />{" "}
           </Nav.Link>
-          <Nav.Link href="https://www.youtube.com/user/CaliforniaEDDD">
+          <Nav.Link
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://www.youtube.com/user/CaliforniaEDDD"
+          >
             <img
               src="images/youtube.svg"
               width="15"

--- a/src/client/components/Header/__snapshots__/index.test.js.snap
+++ b/src/client/components/Header/__snapshots__/index.test.js.snap
@@ -13,6 +13,8 @@ exports[`<Header /> renders the component 1`] = `
   >
     <NavbarBrand
       href="https://ca.gov"
+      rel="noopener noreferrer"
+      target="_blank"
     >
       <img
         alt="California gov logo"
@@ -35,6 +37,8 @@ exports[`<Header /> renders the component 1`] = `
         }
         disabled={false}
         href="https://edd.ca.gov"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         <img
           alt="home icon"
@@ -60,6 +64,8 @@ exports[`<Header /> renders the component 1`] = `
         }
         disabled={false}
         href="https://edd.ca.gov/login.htm"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         <span>
           <img
@@ -86,6 +92,8 @@ exports[`<Header /> renders the component 1`] = `
   >
     <NavbarBrand
       href="https://edd.ca.gov"
+      rel="noopener noreferrer"
+      target="_blank"
     >
       <img
         alt="California gov logo"
@@ -112,6 +120,8 @@ exports[`<Header /> renders the component 1`] = `
         }
         disabled={false}
         href="https://edd.ca.gov/jobs.htm"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         <span>
           Jobs
@@ -127,6 +137,8 @@ exports[`<Header /> renders the component 1`] = `
         }
         disabled={false}
         href="https://edd.ca.gov/claims.htm"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         <span>
           Claims
@@ -142,6 +154,8 @@ exports[`<Header /> renders the component 1`] = `
         }
         disabled={false}
         href="https://edd.ca.gov/employers.htm"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         <span>
           Employers
@@ -157,6 +171,8 @@ exports[`<Header /> renders the component 1`] = `
         }
         disabled={false}
         href="https://edd.ca.gov/newsroom.htm"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         <span>
           Newsroom
@@ -172,6 +188,8 @@ exports[`<Header /> renders the component 1`] = `
         }
         disabled={false}
         href="https://edd.ca.gov/serp.html?q="
+        rel="noopener noreferrer"
+        target="_blank"
       >
         <span>
           Search

--- a/src/client/components/Header/index.js
+++ b/src/client/components/Header/index.js
@@ -9,7 +9,11 @@ function Header() {
   return (
     <header className="header border-bottom border-secondary">
       <Navbar className="justify-content-between" variant="custom" bg="primary">
-        <Navbar.Brand href="https://ca.gov">
+        <Navbar.Brand
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://ca.gov"
+        >
           <img
             src="images/Ca-Gov-Logo-Gold.svg"
             width="30"
@@ -18,7 +22,11 @@ function Header() {
           />
         </Navbar.Brand>
         <Nav>
-          <Nav.Link href="https://edd.ca.gov">
+          <Nav.Link
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://edd.ca.gov"
+          >
             <img
               className="icon"
               src="images/home.svg"
@@ -28,7 +36,11 @@ function Header() {
             />{" "}
             <span className="text">{t("header.home")}</span>
           </Nav.Link>
-          <Nav.Link href="https://edd.ca.gov/login.htm">
+          <Nav.Link
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://edd.ca.gov/login.htm"
+          >
             <span>
               <img
                 className="icon"
@@ -43,7 +55,11 @@ function Header() {
         </Nav>
       </Navbar>
       <Navbar collapseOnSelect expand="md" variant="light">
-        <Navbar.Brand href="https://edd.ca.gov">
+        <Navbar.Brand
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://edd.ca.gov"
+        >
           <img
             src="images/edd-logo-2-Color.svg"
             height="50"
@@ -54,19 +70,39 @@ function Header() {
         </Navbar.Brand>
         <Navbar.Toggle aria-controls="responsive-navbar-nav" />
         <Navbar.Collapse className="justify-content-between ml-5 mr-5 pl-5">
-          <Nav.Link href="https://edd.ca.gov/jobs.htm">
+          <Nav.Link
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://edd.ca.gov/jobs.htm"
+          >
             <span>{t("header.jobs")}</span>
           </Nav.Link>
-          <Nav.Link href="https://edd.ca.gov/claims.htm">
+          <Nav.Link
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://edd.ca.gov/claims.htm"
+          >
             <span>{t("header.claims")}</span>
           </Nav.Link>
-          <Nav.Link href="https://edd.ca.gov/employers.htm">
+          <Nav.Link
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://edd.ca.gov/employers.htm"
+          >
             <span>{t("header.employers")}</span>
           </Nav.Link>
-          <Nav.Link href="https://edd.ca.gov/newsroom.htm">
+          <Nav.Link
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://edd.ca.gov/newsroom.htm"
+          >
             <span>{t("header.newsroom")}</span>
           </Nav.Link>
-          <Nav.Link href="https://edd.ca.gov/serp.html?q=">
+          <Nav.Link
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://edd.ca.gov/serp.html?q="
+          >
             <span>{t("header.search")}</span>
           </Nav.Link>
         </Navbar.Collapse>


### PR DESCRIPTION
Updated header and footer links to open in a new tab

===

Resolves #369 

- [X] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
