### PR TITLE
Back button bug

### DIFF
--- a/src/client/components/RetroCertsRoute/__snapshots__/index.test.js.snap
+++ b/src/client/components/RetroCertsRoute/__snapshots__/index.test.js.snap
@@ -31,21 +31,9 @@ exports[`<RetroCertsRoute /> route needing auth with user data 1`] = `
   computedMatch={Object {}}
   path="/path"
 >
-  <AuthorizedPageWrapper
-    computedMatch={Object {}}
-    pageComponent={[Function]}
-    pageProps={
-      Object {
-        "setUserData": [Function],
-        "userData": Object {
-          "weeksToCertify": Array [
-            0,
-          ],
-        },
-      }
-    }
-    path="/path"
-    requiresAuthentication={true}
+  <Redirect
+    push={true}
+    to="/retroactive-certification"
   />
 </Route>
 `;

--- a/src/client/components/RetroCertsRoute/index.js
+++ b/src/client/components/RetroCertsRoute/index.js
@@ -7,7 +7,11 @@ import routes from "../../../data/routes";
 import PageNotFound from "../../pages/PageNotFound";
 import SessionTimer from "../../components/SessionTimer";
 
-function userIsAuthenticated(userData) {
+function userIsAuthenticated() {
+  return !!sessionStorage.getItem(AUTH_STRINGS.authToken);
+}
+
+function userDataIsSet(userData) {
   return !!userData.weeksToCertify;
 }
 
@@ -57,7 +61,7 @@ function RetroCertsRoute(props) {
     routeChild = <PageNotFound />;
   } else if (!requiresAuthentication) {
     routeChild = <Component {...pageProps} />;
-  } else if (userIsAuthenticated(pageProps.userData)) {
+  } else if (userIsAuthenticated() && userDataIsSet(pageProps.userData)) {
     routeChild = <AuthorizedPageWrapper {...props} />;
   } else {
     // This page requires authentication and the user is not authenticated.


### PR DESCRIPTION
Previously, a user could be on the confirmation page, hit the browser back button, and see their form again. This PR updates the auth logic so that the form doesn't display unless we've confirmed the user has a session variable set.

===

Resolves #XXX

- [x] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
