### PR TITLE
Restore captcha

### DIFF
--- a/src/routes/retro-certs.js
+++ b/src/routes/retro-certs.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 const { Router } = require("express");
 const AUTH_STRINGS = require("../data/authStrings");
-// const ReCaptcha = require("../services/reCaptcha");
+const ReCaptcha = require("../services/reCaptcha");
 const cosmos = require("../data/cosmos");
 
 function createRouter() {
@@ -10,11 +10,10 @@ function createRouter() {
   async function authStatus(postJson, responseJson) {
     responseJson.status = AUTH_STRINGS.statusCode.userNotFound;
 
-    // const reCaptcha = new ReCaptcha(postJson.reCaptcha);
-
+    const reCaptcha = new ReCaptcha(postJson.reCaptcha);
+    const isDev = process.env.NODE_ENV === "development";
     const [reCaptchaResponse, userRecord] = await Promise.all([
-      // reCaptcha.validateUser(),
-      true,
+      isDev || reCaptcha.validateUser(),
       cosmos.getUserByNameDobSsn(
         postJson.lastName || "",
         postJson.dob,

--- a/src/routes/retro-certs.test.js
+++ b/src/routes/retro-certs.test.js
@@ -7,7 +7,7 @@ import AUTH_STRINGS from "../data/authStrings";
 import cosmos from "../data/cosmos";
 import fflip from "fflip";
 import request from "supertest";
-// import ReCaptcha from "../services/reCaptcha";
+import ReCaptcha from "../services/reCaptcha";
 
 describe("Router: API tests", () => {
   it("retro-certs POST feature disabled", async () => {
@@ -46,106 +46,106 @@ describe("Router: API tests", () => {
     getUserByNameDobSsnMock.mockRestore();
   });
 
-  // it("retro-certs /api/login tests", async () => {
-  //   fflip.features.retroCerts.enabled = true;
-  //   const server = init();
-  //   // Format of each test case is:
-  //   //   post body,
-  //   //   recaptchaResponse,
-  //   //   getUserByNameDobSsn promise response,
-  //   //   getFormDataByUserIdWithNewAuthToken promise response,
-  //   //   expected http status,
-  //   //   expected request response
-  //   const testCases = [
-  //     [
-  //       {},
-  //       true,
-  //       null,
-  //       null,
-  //       401,
-  //       { status: AUTH_STRINGS.statusCode.userNotFound },
-  //     ],
-  //     [
-  //       {},
-  //       false,
-  //       null,
-  //       null,
-  //       401,
-  //       { status: AUTH_STRINGS.statusCode.recaptchaInvalid },
-  //     ],
-  //     // User has correct credentials.
-  //     [
-  //       { lastName: "Last", dob: "2000-01-01", ssn: "123456789" },
-  //       true,
-  //       {
-  //         id: "hash",
-  //         weeksToCertify: [0, 1],
-  //         programPlan: ["UI full time", "UI part time"],
-  //       },
-  //       { authToken: "test auth token" },
-  //       200,
-  //       {
-  //         status: AUTH_STRINGS.statusCode.ok,
-  //         authToken: "test auth token",
-  //         weeksToCertify: [0, 1],
-  //         programPlan: ["UI full time", "UI part time"],
-  //       },
-  //     ],
-  //     // User has correct credentails, but recaptcha is not valid.
-  //     [
-  //       { lastName: "Last", dob: "2000-0101", ssn: "123456789" },
-  //       false,
-  //       {
-  //         id: "hash",
-  //         weeksToCertify: [0, 1],
-  //         programPlan: ["UI full time", "UI part time"],
-  //       },
-  //       { authToken: "test auth token" },
-  //       401,
-  //       {
-  //         status: AUTH_STRINGS.statusCode.recaptchaInvalid,
-  //       },
-  //     ],
-  //   ];
+  it("retro-certs /api/login tests", async () => {
+    fflip.features.retroCerts.enabled = true;
+    const server = init();
+    // Format of each test case is:
+    //   post body,
+    //   recaptchaResponse,
+    //   getUserByNameDobSsn promise response,
+    //   getFormDataByUserIdWithNewAuthToken promise response,
+    //   expected http status,
+    //   expected request response
+    const testCases = [
+      [
+        {},
+        true,
+        null,
+        null,
+        401,
+        { status: AUTH_STRINGS.statusCode.userNotFound },
+      ],
+      [
+        {},
+        false,
+        null,
+        null,
+        401,
+        { status: AUTH_STRINGS.statusCode.recaptchaInvalid },
+      ],
+      // User has correct credentials.
+      [
+        { lastName: "Last", dob: "2000-01-01", ssn: "123456789" },
+        true,
+        {
+          id: "hash",
+          weeksToCertify: [0, 1],
+          programPlan: ["UI full time", "UI part time"],
+        },
+        { authToken: "test auth token" },
+        200,
+        {
+          status: AUTH_STRINGS.statusCode.ok,
+          authToken: "test auth token",
+          weeksToCertify: [0, 1],
+          programPlan: ["UI full time", "UI part time"],
+        },
+      ],
+      // User has correct credentails, but recaptcha is not valid.
+      [
+        { lastName: "Last", dob: "2000-0101", ssn: "123456789" },
+        false,
+        {
+          id: "hash",
+          weeksToCertify: [0, 1],
+          programPlan: ["UI full time", "UI part time"],
+        },
+        { authToken: "test auth token" },
+        401,
+        {
+          status: AUTH_STRINGS.statusCode.recaptchaInvalid,
+        },
+      ],
+    ];
 
-  //   for (const testCase of testCases) {
-  //     const [
-  //       reqJson,
-  //       recaptchaResponse,
-  //       getUserResponse,
-  //       getFormDataByUserIdWithNewAuthTokenResponse,
-  //       httpStatus,
-  //       responseJson,
-  //     ] = testCase;
-  //     const validateUserMock = jest.spyOn(ReCaptcha.prototype, "validateUser");
-  //     validateUserMock.mockImplementation(() => recaptchaResponse);
-  //     const getUserByNameDobSsnMock = jest.spyOn(cosmos, "getUserByNameDobSsn");
-  //     getUserByNameDobSsnMock.mockImplementation(
-  //       jest.fn(() => Promise.resolve(getUserResponse))
-  //     );
-  //     const getFormDataByUserIdWithNewAuthTokenMock = jest.spyOn(
-  //       cosmos,
-  //       "getFormDataByUserIdWithNewAuthToken"
-  //     );
-  //     getFormDataByUserIdWithNewAuthTokenMock.mockImplementation(
-  //       jest.fn(() =>
-  //         Promise.resolve(getFormDataByUserIdWithNewAuthTokenResponse)
-  //       )
-  //     );
+    for (const testCase of testCases) {
+      const [
+        reqJson,
+        recaptchaResponse,
+        getUserResponse,
+        getFormDataByUserIdWithNewAuthTokenResponse,
+        httpStatus,
+        responseJson,
+      ] = testCase;
+      const validateUserMock = jest.spyOn(ReCaptcha.prototype, "validateUser");
+      validateUserMock.mockImplementation(() => recaptchaResponse);
+      const getUserByNameDobSsnMock = jest.spyOn(cosmos, "getUserByNameDobSsn");
+      getUserByNameDobSsnMock.mockImplementation(
+        jest.fn(() => Promise.resolve(getUserResponse))
+      );
+      const getFormDataByUserIdWithNewAuthTokenMock = jest.spyOn(
+        cosmos,
+        "getFormDataByUserIdWithNewAuthToken"
+      );
+      getFormDataByUserIdWithNewAuthTokenMock.mockImplementation(
+        jest.fn(() =>
+          Promise.resolve(getFormDataByUserIdWithNewAuthTokenResponse)
+        )
+      );
 
-  //     const res = await request(server)
-  //       .post(AUTH_STRINGS.apiPath.login)
-  //       .send(JSON.stringify(reqJson))
-  //       .type("json");
-  //     expect(res.status).toBe(httpStatus);
-  //     expect(res.header["content-type"]).toMatch(/json/);
-  //     expect(res.body).toEqual(responseJson);
+      const res = await request(server)
+        .post(AUTH_STRINGS.apiPath.login)
+        .send(JSON.stringify(reqJson))
+        .type("json");
+      expect(res.status).toBe(httpStatus);
+      expect(res.header["content-type"]).toMatch(/json/);
+      expect(res.body).toEqual(responseJson);
 
-  //     validateUserMock.mockRestore();
-  //     getUserByNameDobSsnMock.mockRestore();
-  //     getFormDataByUserIdWithNewAuthTokenMock.mockRestore();
-  //   }
-  // });
+      validateUserMock.mockRestore();
+      getUserByNameDobSsnMock.mockRestore();
+      getFormDataByUserIdWithNewAuthTokenMock.mockRestore();
+    }
+  });
 
   it("retro-certs /api/data tests", async () => {
     fflip.features.retroCerts.enabled = true;


### PR DESCRIPTION
Reverts #386, and also disables the captcha check when developing locally (it will still appear but doesn't have to be checked to login)

`isDev || reCaptcha.validateUser()` can be updated to `true || reCaptcha.validateUser()` when we need to disable the captcha again for load testing