### PR TITLE
Add Google Analytics to retro certs.

### DIFF
--- a/setupTestFramework.js
+++ b/setupTestFramework.js
@@ -35,6 +35,7 @@ jest.mock("react-router-dom", () => {
     useHistory: () => ({
       push: jest.fn(),
       listen: jest.fn(),
+      location: {state: {isReturning: true}},
     }),
   };
 });
@@ -44,5 +45,15 @@ jest.mock("uuid", () => {
   return {
     ...actual,
     v4: () => "00000000-fake-mock-fake-123456789012",
+  };
+});
+
+// This is added by Google Analytics.
+jest.mock("./src/client/utils", () => {
+  const actual = jest.requireActual("./src/client/utils");
+  return {
+    ...actual,
+    logEvent: (a, b, c) => {},
+    logPage: (a) => {},
   };
 });

--- a/setupTestFramework.js
+++ b/setupTestFramework.js
@@ -48,7 +48,7 @@ jest.mock("uuid", () => {
   };
 });
 
-// This is added by Google Analytics.
+// window.gtag is added by Google Analytics. Mock out the calls.
 jest.mock("./src/client/utils", () => {
   const actual = jest.requireActual("./src/client/utils");
   return {

--- a/src/client/App.js
+++ b/src/client/App.js
@@ -25,7 +25,7 @@ export default function App(props) {
   if (initialPageLoad.current) {
     initialPageLoad.current = false;
 
-    // App re-mounts every time user data is changed. To have only one
+    // <App> re-mounts every time user data is changed. To have only one
     // history listener, add it during the initial page load only.
     history.listen((location) => logPage(location.pathname));
     // Log the current page.

--- a/src/client/App.js
+++ b/src/client/App.js
@@ -1,5 +1,5 @@
-import React, { Suspense, useState } from "react";
-import { Switch, Route, Redirect } from "react-router-dom";
+import React, { Suspense, useState, useRef } from "react";
+import { Switch, Route, Redirect, useHistory } from "react-router-dom";
 import PropTypes from "prop-types";
 import RetroCertsRoute from "./components/RetroCertsRoute";
 import GuidePage from "./pages/GuidePage";
@@ -10,14 +10,27 @@ import RetroCertsCertificationPage from "./pages/RetroCertsCertificationPage";
 import RetroCertsConfirmationPage from "./pages/RetroCertsConfirmationPage";
 import AUTH_STRINGS from "../data/authStrings";
 import routes from "../data/routes";
+import { logPage } from "./utils.js";
 
 export default function App(props) {
   const hostname = props.hostname || window.location.hostname;
   const isProduction = hostname === "unemployment.edd.ca.gov";
+  const history = useHistory();
+  const initialPageLoad = useRef(true);
 
   const [retroCertsUserData, setRetroCertsUserData] = useState({
     status: AUTH_STRINGS.statusCode.notLoggedIn,
   });
+
+  if (initialPageLoad.current) {
+    initialPageLoad.current = false;
+
+    // App re-mounts every time user data is changed. To have only one
+    // history listener, add it during the initial page load only.
+    history.listen((location) => logPage(location.pathname));
+    // Log the current page.
+    logPage(history.location.pathname);
+  }
 
   return (
     <Suspense fallback="Loading...">

--- a/src/client/components/BPOButton/index.js
+++ b/src/client/components/BPOButton/index.js
@@ -10,7 +10,7 @@ function BPOButton() {
     <Button
       variant="secondary"
       href={t("links.edd-bpo")}
-      onClick={() => logEvent("register-or-login")}
+      onClick={() => logEvent("Unemployment", "Navigate", "register-or-login")}
       target="_blank"
     >
       {t("subheaderButton")}

--- a/src/client/components/SessionTimer/index.js
+++ b/src/client/components/SessionTimer/index.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { setUserDataPropType } from "../../commonPropTypes";
 import AUTH_STRINGS from "../../../data/authStrings";
 import routes from "../../../data/routes";
+import { logEvent } from "../../utils";
 
 let timerId = null;
 
@@ -16,6 +17,8 @@ function SessionTimer(props) {
     timerId = setTimeout(() => {
       if (sessionStorage.getItem(AUTH_STRINGS.authToken)) {
         sessionStorage.removeItem(AUTH_STRINGS.authToken);
+        logEvent("RetroCerts", "SessionTimeout", history.location.pathname);
+
         history.push(routes.retroCertsAuth);
         setUserData({
           status: AUTH_STRINGS.statusCode.sessionTimedOut,

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -12,7 +12,6 @@ import TabPaneContent2 from "../TabPaneContent2";
 import TabPaneContent3 from "../TabPaneContent3";
 import TabPaneContent4 from "../TabPaneContent4";
 import TabPaneContent5 from "../TabPaneContent5";
-import { logPage } from "../../utils.js";
 import { useTranslation } from "react-i18next";
 
 function TabbedContainer() {
@@ -77,7 +76,6 @@ function TabbedContainer() {
   const prefix = "/guide/";
   const initialPageLoad = useRef(true);
   const history = useHistory();
-  history.listen((location) => logPage(location.pathname));
 
   // Runs when a tab content pane loads.
   function TabPaneContentOnMount({ tabIndex }) {

--- a/src/client/pages/RetroCertsAuthPage/index.js
+++ b/src/client/pages/RetroCertsAuthPage/index.js
@@ -14,6 +14,7 @@ import Footer from "../../components/Footer";
 import Header from "../../components/Header";
 import SessionTimer from "../../components/SessionTimer";
 import Inputmask from "inputmask";
+import { logEvent } from "../../utils";
 
 function RetroCertsAuthPage(props) {
   const { t } = useTranslation();
@@ -99,11 +100,12 @@ function RetroCertsAuthPage(props) {
           sessionStorage.setItem(AUTH_STRINGS.authToken, data.authToken);
           if (data.confirmationNumber) {
             // The user has already completed the retro-certs process.
-            history.push(routes.retroCertsConfirmation);
+            history.push(routes.retroCertsConfirmation, { isReturning: true });
           } else {
             history.push(routes.retroCertsWeeksToCertify);
           }
         }
+        logEvent("RetroCerts", "LoginResponse", data.status);
       })
       .catch((error) => console.error(error));
   };

--- a/src/client/pages/RetroCertsCertificationPage/index.js
+++ b/src/client/pages/RetroCertsCertificationPage/index.js
@@ -15,6 +15,7 @@ import {
 import routes from "../../../data/routes";
 import AUTH_STRINGS from "../../../data/authStrings";
 import programPlan from "../../../data/programPlan";
+import { logEvent } from "../../utils";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header";
 import YesNoQuestion from "../../components/YesNoQuestion";
@@ -153,6 +154,11 @@ function RetroCertsCertificationPage(props) {
     })
       .then((response) => response.json())
       .then((data) => {
+        logEvent(
+          "RetroCerts",
+          "CompletedCertification",
+          `weeks-${numberOfWeeks}`
+        );
         setUserData({
           ...userData,
           confirmationNumber: data.confirmationNumber,

--- a/src/client/pages/RetroCertsConfirmationPage/index.js
+++ b/src/client/pages/RetroCertsConfirmationPage/index.js
@@ -1,5 +1,5 @@
 import Button from "react-bootstrap/Button";
-import { Redirect } from "react-router-dom";
+import { Redirect, useHistory } from "react-router-dom";
 import Alert from "react-bootstrap/Alert";
 import React from "react";
 import { useTranslation, Trans } from "react-i18next";
@@ -9,10 +9,12 @@ import routes from "../../../data/routes";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header";
 import ListOfWeeks from "../../components/ListOfWeeks";
+import { logEvent } from "../../utils";
 
 function RetroCertsConfirmationPage(props) {
   const { t } = useTranslation();
   document.title = t("retrocerts-confirmation.title");
+  const history = useHistory();
   const userData = props.userData;
 
   // The user is here by accident. Send them back.
@@ -25,11 +27,16 @@ function RetroCertsConfirmationPage(props) {
   // Log out the user since they are done!
   sessionStorage.removeItem(AUTH_STRINGS.authToken);
 
-  // If the user is checking after they submitted data, formData
-  // will be empty. NOTE: if we implement partial save, we need
-  // to make sure not to return form data if the user has a
-  // confirmation number.
-  const isReturning = !userData.formData;
+  const isReturning =
+    history.location.state && history.location.state.isReturning;
+  if (isReturning) {
+    logEvent("RetroCerts", "AlreadyCompletedReturn");
+  }
+
+  function handlePrint() {
+    logEvent("RetroCerts", "PrintConfirmation");
+    window.print();
+  }
 
   return (
     <div id="overflow-wrapper">
@@ -76,7 +83,7 @@ function RetroCertsConfirmationPage(props) {
           <Button
             variant="outline-secondary"
             className="text-dark bg-light mt-5"
-            onClick={print}
+            onClick={handlePrint}
           >
             {t("retrocerts-confirmation.button-print")}
           </Button>

--- a/src/client/utils.js
+++ b/src/client/utils.js
@@ -2,9 +2,9 @@ const cagovPropertyId = "UA-3419582-2";
 const eddPropertyId = "UA-3419582-31";
 
 // log event to Google Analytics
-export function logEvent(label) {
-  window.gtag("event", "Navigate", {
-    event_category: "Unemployment",
+export function logEvent(category, action, label) {
+  window.gtag("event", action, {
+    event_category: category,
     event_label: label,
   });
 }


### PR DESCRIPTION
- Move the page transition logging to <App>.
- Add tracking of login responses.
- Add tracking of session timeouts.
- Add tracking of successful completes submits.
- Add tracking of returning users.
- Add tracking of the print button.

There is a snapshot change because I updated
how we know if it's a returning user or not (by
using the history state).

===

Resolves #296

- [X] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
