### PR TITLE
Update partition key for cosmosdb containers

### DIFF
--- a/src/data/cosmosConfig.js
+++ b/src/data/cosmosConfig.js
@@ -4,7 +4,7 @@ const COSMOS_CONFIG = {
   databaseName: "retrocert",
   formsContainerName: "forms",
   usersContainerName: "users",
-  partitionKey: { kind: "Hash", paths: ["/category"] },
+  partitionKey: { kind: "Hash", paths: ["/id"] },
 };
 
 function getRetrocertDbKey() {


### PR DESCRIPTION
This PR updates the partition key to /id to match prod, now that we've been able to have unique ids on prod.