### PR TITLE
Reject form data that contains < + a character.

### DIFF
--- a/src/client/pages/RetroCertsCertificationPage/index.js
+++ b/src/client/pages/RetroCertsCertificationPage/index.js
@@ -155,15 +155,20 @@ function RetroCertsCertificationPage(props) {
   };
 
   function postUserDataToServer() {
+    let body = JSON.stringify({
+      formData: userData.formData,
+      authToken: sessionStorage.getItem(AUTH_STRINGS.authToken),
+    });
+    // The server rejects < followed by non-whitespace,
+    // so change the input from the form to add a space.
+    body = body.replace(/</g, "< ");
+
     fetch(AUTH_STRINGS.apiPath.save, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({
-        formData: userData.formData,
-        authToken: sessionStorage.getItem(AUTH_STRINGS.authToken),
-      }),
+      body,
     })
       .then((response) => response.json())
       .then((data) => {

--- a/src/routes/retro-certs.js
+++ b/src/routes/retro-certs.js
@@ -91,6 +91,14 @@ function createRouter() {
 
   router.post(AUTH_STRINGS.apiPath.save, async (req, res) => {
     try {
+      const formDataAsString = JSON.stringify(req.body.formData || {});
+      // Reject inputs that might be trying to inject malicious scripts.
+      if (formDataAsString.match(/<[^ ]/)) {
+        console.log("rejected input", req.body.authToken);
+        res.status(400).type("json").send();
+        return;
+      }
+
       const responseJson = await cosmos.saveFormData(
         req.body.authToken,
         req.body.formData


### PR DESCRIPTION
During security review, they asked we avoid letting
malicious be saved to the database, where it may
get rendered incorrectly later.

This returns a 400 error when the input contains
< followed by a non-space character.

On the client side, add a space after each < so
the input never gets rejected if you're using
the frontend.

===

Resolves #397

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made

![Annotation 2020-06-26 080241](https://user-images.githubusercontent.com/175378/85871581-7503bf00-b783-11ea-82ea-42b8ccfdb3b0.png)
