### PR TITLE
Fix the height of the Guide language button.

### DIFF
--- a/src/client/components/Subheader/__snapshots__/index.test.js.snap
+++ b/src/client/components/Subheader/__snapshots__/index.test.js.snap
@@ -28,7 +28,9 @@ exports[`<Subheader /> renders vertical navigation bar 1`] = `
       >
         <BPOButton />
       </div>
-      <LanguageSelector />
+      <div>
+        <LanguageSelector />
+      </div>
     </div>
   </div>
 </div>

--- a/src/client/components/Subheader/index.js
+++ b/src/client/components/Subheader/index.js
@@ -17,7 +17,9 @@ function Subheader() {
           <div className="mr-4 mb-4">
             <BPOButton />
           </div>
-          <LanguageSelector />
+          <div>
+            <LanguageSelector />
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
It was too tall. This makes it the same height
as the button next to it.

===

- [X] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made

![Annotation 2020-06-26 144529](https://user-images.githubusercontent.com/175378/85903827-26264b80-b7bc-11ea-84d3-c1e1bb1004a1.png)
