### PR TITLE
Jlechowicz/issue 333

### DIFF
--- a/src/client/App.scss
+++ b/src/client/App.scss
@@ -124,3 +124,9 @@ footer {
 .was-validated .unchecked .invalid-feedback {
   display: block;
 }
+
+// For help text on pages and components
+.help-text {
+  font-size: 20px;
+  color: #595959;
+}

--- a/src/client/App.scss
+++ b/src/client/App.scss
@@ -130,3 +130,10 @@ footer {
   font-size: 20px;
   color: #595959;
 }
+
+// This helps keep the certification pages from becoming too wide
+#certification-page {
+  .container {
+    max-width: 800px !important;
+  }
+}

--- a/src/client/components/DaysSickQuestion/__snapshots__/index.test.js.snap
+++ b/src/client/components/DaysSickQuestion/__snapshots__/index.test.js.snap
@@ -11,7 +11,7 @@ exports[`<DaysSickQuestion /> renders the component 1`] = `
     If Yes, enter the number of days (1 - 7) you were unable to work.
   </FormLabel>
   <FormText
-    muted={true}
+    className="help-text"
   >
     You must report the numbers of days that you could not work during this week.
   </FormText>

--- a/src/client/components/DaysSickQuestion/index.js
+++ b/src/client/components/DaysSickQuestion/index.js
@@ -25,7 +25,7 @@ function DaysSickQuestion(props) {
   return (
     <Form.Group controlId="days-sick">
       <Form.Label>{props.questionText}</Form.Label>
-      <Form.Text muted>{props.helpText}</Form.Text>
+      <Form.Text className="help-text">{props.helpText}</Form.Text>
       <Form.Control
         style={{ width: "6rem" }}
         type="text"

--- a/src/client/components/EmployersQuestions/index.js
+++ b/src/client/components/EmployersQuestions/index.js
@@ -62,7 +62,7 @@ function EmployerQuestions(props) {
     return (
       <Form.Group controlId={props.employerData.id + name}>
         <Form.Label>{t(tk(name))}</Form.Label>
-        <Form.Text muted>{t(tk(`help-${name}`))}</Form.Text>
+        <Form.Text className="help-text">{t(tk(`help-${name}`))}</Form.Text>
         <Form.Control
           className={options.className}
           type="text"
@@ -106,7 +106,7 @@ function EmployerQuestions(props) {
         <Col md={8}>{renderTextInput("city")}</Col>
         <Form.Group controlId={props.employerData.id + "state-select"} as={Col}>
           <Form.Label>{t(tk("state"))}</Form.Label>
-          <Form.Text muted>{t(tk("help-state"))}</Form.Text>
+          <Form.Text className="help-text">{t(tk("help-state"))}</Form.Text>
           <Form.Control
             as="select"
             value={stateFuncs.state.get}
@@ -129,7 +129,7 @@ function EmployerQuestions(props) {
       })}
 
       <p>{t(tk("lastDateWorked"))}</p>
-      <small className="text-muted">{t(tk("help-lastDateWorked"))}</small>
+      <small className="help-text">{t(tk("help-lastDateWorked"))}</small>
       <Form.Row>
         <Form.Group
           controlId={props.employerData.id + "lastDateWorked-month-question"}
@@ -197,7 +197,9 @@ function EmployerQuestions(props) {
       {stateFuncs.reason.get !== "still-working" && (
         <Form.Group controlId={props.employerData.id + "reason-details"}>
           <Form.Label>{t(tk("moreDetails"))}</Form.Label>
-          <Form.Text muted>{t(tk("help-moreDetails"))}</Form.Text>
+          <Form.Text className="help-text">
+            {t(tk("help-moreDetails"))}
+          </Form.Text>
           <Form.Control
             as="textarea"
             rows="3"

--- a/src/client/components/YesNoQuestion/index.js
+++ b/src/client/components/YesNoQuestion/index.js
@@ -44,7 +44,7 @@ function YesNoQuestion(props) {
         <Form.Label>
           {questionNumber}.&nbsp;{questionText}
         </Form.Label>
-        <Form.Text muted>{helpText}</Form.Text>
+        <Form.Text className="help-text">{helpText}</Form.Text>
 
         {["Yes", "No"].map((value) => (
           <Form.Check

--- a/src/client/pages/PageNotFound/__snapshots__/index.test.js.snap
+++ b/src/client/pages/PageNotFound/__snapshots__/index.test.js.snap
@@ -5,7 +5,9 @@ exports[`<PageNotFound /> renders a 404 page 1`] = `
   id="overflow-wrapper"
 >
   <Header />
-  <main>
+  <main
+    id="certification-page"
+  >
     <div
       className="container p-4"
     >

--- a/src/client/pages/PageNotFound/index.js
+++ b/src/client/pages/PageNotFound/index.js
@@ -9,7 +9,7 @@ function PageNotFound() {
   return (
     <div id="overflow-wrapper">
       <Header />
-      <main>
+      <main id="certification-page">
         <div className="container p-4">
           <h1>{t("page-not-found-header")}</h1>
           <p>{t("page-not-found-text")}</p>

--- a/src/client/pages/RetroCertsAuthPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsAuthPage/__snapshots__/index.test.js.snap
@@ -5,7 +5,9 @@ exports[`<RetroCertsAuthPage /> retro certs auth page 1`] = `
   id="overflow-wrapper"
 >
   <Header />
-  <main>
+  <main
+    id="certification-page"
+  >
     <div
       className="container p-4"
     >
@@ -253,7 +255,9 @@ exports[`<RetroCertsAuthPage /> retro certs auth page with captcha timeout error
   id="overflow-wrapper"
 >
   <Header />
-  <main>
+  <main
+    id="certification-page"
+  >
     <div
       className="container p-4"
     >
@@ -530,7 +534,9 @@ exports[`<RetroCertsAuthPage /> retro certs auth page with session timeout 1`] =
   id="overflow-wrapper"
 >
   <Header />
-  <main>
+  <main
+    id="certification-page"
+  >
     <div
       className="container p-4"
     >
@@ -807,7 +813,9 @@ exports[`<RetroCertsAuthPage /> retro certs auth page with user not found error 
   id="overflow-wrapper"
 >
   <Header />
-  <main>
+  <main
+    id="certification-page"
+  >
     <div
       className="container p-4"
     >

--- a/src/client/pages/RetroCertsAuthPage/index.js
+++ b/src/client/pages/RetroCertsAuthPage/index.js
@@ -165,7 +165,7 @@ function RetroCertsAuthPage(props) {
   return (
     <div id="overflow-wrapper">
       <Header />
-      <main>
+      <main id="certification-page">
         <div className="container p-4">
           <h1>{t("retrocert-login.title")}</h1>
           <LanguageSelector className="mt-3 mb-4" />

--- a/src/client/pages/RetroCertsCertificationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsCertificationPage/__snapshots__/index.test.js.snap
@@ -7,6 +7,7 @@ exports[`<RetroCertsCertificationPage /> Certify for 2nd week of 2 1`] = `
   <Header />
   <main
     className="pb-5"
+    id="certification-page"
   >
     <div
       className="container p-4"
@@ -243,6 +244,7 @@ exports[`<RetroCertsCertificationPage /> Certify for one week of 2 1`] = `
   <Header />
   <main
     className="pb-5"
+    id="certification-page"
   >
     <div
       className="container p-4"

--- a/src/client/pages/RetroCertsCertificationPage/index.js
+++ b/src/client/pages/RetroCertsCertificationPage/index.js
@@ -206,7 +206,7 @@ function RetroCertsCertificationPage(props) {
   return (
     <div id="overflow-wrapper">
       <Header />
-      <main className="pb-5">
+      <main id="certification-page" className="pb-5">
         <div className="container p-4">
           <h1 ref={headingElement}>
             {t("retrocerts-certification.question-page-title")}

--- a/src/client/pages/RetroCertsConfirmationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsConfirmationPage/__snapshots__/index.test.js.snap
@@ -11,7 +11,9 @@ exports[`<RetroCertsConfirmationPage /> with confirmation number 1`] = `
   id="overflow-wrapper"
 >
   <Header />
-  <main>
+  <main
+    id="certification-page"
+  >
     <div
       className="container p-4"
     >

--- a/src/client/pages/RetroCertsConfirmationPage/index.js
+++ b/src/client/pages/RetroCertsConfirmationPage/index.js
@@ -42,7 +42,7 @@ function RetroCertsConfirmationPage(props) {
   return (
     <div id="overflow-wrapper">
       <Header />
-      <main>
+      <main id="certification-page">
         <div className="container p-4">
           <h1>{t("retrocerts-confirmation.title")}</h1>
           <LanguageSelector className="mt-3 mb-4" />

--- a/src/client/pages/RetroCertsWeeksToCertifyPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsWeeksToCertifyPage/__snapshots__/index.test.js.snap
@@ -7,6 +7,7 @@ exports[`<RetroCertsWeeksToCertifyPage /> has user data 1`] = `
   <Header />
   <main
     className="pb-5"
+    id="certification-page"
   >
     <div
       className="container p-4"

--- a/src/client/pages/RetroCertsWeeksToCertifyPage/index.js
+++ b/src/client/pages/RetroCertsWeeksToCertifyPage/index.js
@@ -20,7 +20,7 @@ function RetroCertsWeeksToCertifyPage(props) {
   return (
     <div id="overflow-wrapper">
       <Header />
-      <main className="pb-5">
+      <main id="certification-page" className="pb-5">
         <div className="container p-4">
           <h1>{t("retrocerts-weeks.title")}</h1>
           <LanguageSelector className="mt-3 mb-4" />


### PR DESCRIPTION
Updated styling for help text to increase the contrast ratio.
Updates certification pages to have a max width of 800px.

===

Resolves #333 

- [X] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
