### PR TITLE
Question page style fixes

### DIFF
--- a/src/client/App.scss
+++ b/src/client/App.scss
@@ -30,6 +30,7 @@ $font-family-sans-serif: "Source Sans Pro", sans-serif !default;
 @import "components/Header/index";
 @import "components/Footer/index";
 @import "components/TabbedContainer/index";
+@import "components/DisasterQuestion/index";
 
 h1,
 h2,

--- a/src/client/App.scss
+++ b/src/client/App.scss
@@ -48,6 +48,10 @@ h3 {
   margin-bottom: 0.8rem;
 }
 
+legend {
+  font-size: inherit;
+}
+
 a {
   text-decoration: underline;
 }

--- a/src/client/components/DisasterQuestion/__snapshots__/index.test.js.snap
+++ b/src/client/components/DisasterQuestion/__snapshots__/index.test.js.snap
@@ -1,0 +1,245 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<DisasterQuestion /> renders the component 1`] = `
+<FormGroup
+  className="disaster-question unchecked"
+  controlId="disaster-question"
+>
+  <fieldset>
+    <FormLabel
+      as="legend"
+      column={false}
+      srOnly={false}
+    />
+    <FormCheck
+      checked={false}
+      disabled={false}
+      id="disaster-question-radioYou have been diagnosed with COVID-19."
+      inline={true}
+      isInvalid={false}
+      isValid={false}
+      key="You have been diagnosed with COVID-19."
+      label="You have been diagnosed with COVID-19."
+      name="disaster-question"
+      onChange={[Function]}
+      required={true}
+      title=""
+      type="radio"
+      value="You have been diagnosed with COVID-19."
+    />
+    <FormCheck
+      checked={false}
+      disabled={false}
+      id="disaster-question-radioYou have COVID-19 symptoms and are seeking a diagnosis."
+      inline={true}
+      isInvalid={false}
+      isValid={false}
+      key="You have COVID-19 symptoms and are seeking a diagnosis."
+      label="You have COVID-19 symptoms and are seeking a diagnosis."
+      name="disaster-question"
+      onChange={[Function]}
+      required={true}
+      title=""
+      type="radio"
+      value="You have COVID-19 symptoms and are seeking a diagnosis."
+    />
+    <FormCheck
+      checked={false}
+      disabled={false}
+      id="disaster-question-radioA member of your household has COVID-19."
+      inline={true}
+      isInvalid={false}
+      isValid={false}
+      key="A member of your household has COVID-19."
+      label="A member of your household has COVID-19."
+      name="disaster-question"
+      onChange={[Function]}
+      required={true}
+      title=""
+      type="radio"
+      value="A member of your household has COVID-19."
+    />
+    <FormCheck
+      checked={false}
+      disabled={false}
+      id="disaster-question-radioYou are taking care of your family or household member who has COVID-19."
+      inline={true}
+      isInvalid={false}
+      isValid={false}
+      key="You are taking care of your family or household member who has COVID-19."
+      label="You are taking care of your family or household member who has COVID-19."
+      name="disaster-question"
+      onChange={[Function]}
+      required={true}
+      title=""
+      type="radio"
+      value="You are taking care of your family or household member who has COVID-19."
+    />
+    <FormCheck
+      checked={false}
+      disabled={false}
+      id="disaster-question-radioYou had to quit your job as a direct result of COVID-19."
+      inline={true}
+      isInvalid={false}
+      isValid={false}
+      key="You had to quit your job as a direct result of COVID-19."
+      label="You had to quit your job as a direct result of COVID-19."
+      name="disaster-question"
+      onChange={[Function]}
+      required={true}
+      title=""
+      type="radio"
+      value="You had to quit your job as a direct result of COVID-19."
+    />
+    <FormCheck
+      checked={false}
+      disabled={false}
+      id="disaster-question-radioYour place of employment is closed as a direct result of COVID-19. (This may apply if your business is open or partially re-opened but your position is not needed due to COVID-19 limitations on the business)."
+      inline={true}
+      isInvalid={false}
+      isValid={false}
+      key="Your place of employment is closed as a direct result of COVID-19. (This may apply if your business is open or partially re-opened but your position is not needed due to COVID-19 limitations on the business)."
+      label="Your place of employment is closed as a direct result of COVID-19. (This may apply if your business is open or partially re-opened but your position is not needed due to COVID-19 limitations on the business)."
+      name="disaster-question"
+      onChange={[Function]}
+      required={true}
+      title=""
+      type="radio"
+      value="Your place of employment is closed as a direct result of COVID-19. (This may apply if your business is open or partially re-opened but your position is not needed due to COVID-19 limitations on the business)."
+    />
+    <FormCheck
+      checked={false}
+      disabled={false}
+      id="disaster-question-radioYou cannot reach your workplace because of a quarantine as a direct result of COVID-19. (This may apply if you cannot reach your workplace because of a state or municipal order restricting travel to combat the spread of COVID-19, such as a stay-home or shelter-in-place order.)"
+      inline={true}
+      isInvalid={false}
+      isValid={false}
+      key="You cannot reach your workplace because of a quarantine as a direct result of COVID-19. (This may apply if you cannot reach your workplace because of a state or municipal order restricting travel to combat the spread of COVID-19, such as a stay-home or shelter-in-place order.)"
+      label="You cannot reach your workplace because of a quarantine as a direct result of COVID-19. (This may apply if you cannot reach your workplace because of a state or municipal order restricting travel to combat the spread of COVID-19, such as a stay-home or shelter-in-place order.)"
+      name="disaster-question"
+      onChange={[Function]}
+      required={true}
+      title=""
+      type="radio"
+      value="You cannot reach your workplace because of a quarantine as a direct result of COVID-19. (This may apply if you cannot reach your workplace because of a state or municipal order restricting travel to combat the spread of COVID-19, such as a stay-home or shelter-in-place order.)"
+    />
+    <FormCheck
+      checked={false}
+      disabled={false}
+      id="disaster-question-radioYou cannot reach your workplace because your health care provider advised you to quarantine due to COVID-19 concerns."
+      inline={true}
+      isInvalid={false}
+      isValid={false}
+      key="You cannot reach your workplace because your health care provider advised you to quarantine due to COVID-19 concerns."
+      label="You cannot reach your workplace because your health care provider advised you to quarantine due to COVID-19 concerns."
+      name="disaster-question"
+      onChange={[Function]}
+      required={true}
+      title=""
+      type="radio"
+      value="You cannot reach your workplace because your health care provider advised you to quarantine due to COVID-19 concerns."
+    />
+    <FormCheck
+      checked={false}
+      disabled={false}
+      id="disaster-question-radioYou cannot work because you have primary responsibility for caring for a child or another person and their school or care facility is closed as a direct result of COVID-19."
+      inline={true}
+      isInvalid={false}
+      isValid={false}
+      key="You cannot work because you have primary responsibility for caring for a child or another person and their school or care facility is closed as a direct result of COVID-19."
+      label="You cannot work because you have primary responsibility for caring for a child or another person and their school or care facility is closed as a direct result of COVID-19."
+      name="disaster-question"
+      onChange={[Function]}
+      required={true}
+      title=""
+      type="radio"
+      value="You cannot work because you have primary responsibility for caring for a child or another person and their school or care facility is closed as a direct result of COVID-19."
+    />
+    <FormCheck
+      checked={false}
+      disabled={false}
+      id="disaster-question-radioYou had a definite date to start a job that is no longer available as a direct result of COVID-19."
+      inline={true}
+      isInvalid={false}
+      isValid={false}
+      key="You had a definite date to start a job that is no longer available as a direct result of COVID-19."
+      label="You had a definite date to start a job that is no longer available as a direct result of COVID-19."
+      name="disaster-question"
+      onChange={[Function]}
+      required={true}
+      title=""
+      type="radio"
+      value="You had a definite date to start a job that is no longer available as a direct result of COVID-19."
+    />
+    <FormCheck
+      checked={false}
+      disabled={false}
+      id="disaster-question-radioYou had a definite date to start a job but cannot reach that job as a direct result of COVID-19."
+      inline={true}
+      isInvalid={false}
+      isValid={false}
+      key="You had a definite date to start a job but cannot reach that job as a direct result of COVID-19."
+      label="You had a definite date to start a job but cannot reach that job as a direct result of COVID-19."
+      name="disaster-question"
+      onChange={[Function]}
+      required={true}
+      title=""
+      type="radio"
+      value="You had a definite date to start a job but cannot reach that job as a direct result of COVID-19."
+    />
+    <FormCheck
+      checked={false}
+      disabled={false}
+      id="disaster-question-radioYou are an independent contractor with reportable income (ex. IRS Form 1099) and you are forced to stop working because COVID-19 has severely limited your ability to continue performing your customary work activities."
+      inline={true}
+      isInvalid={false}
+      isValid={false}
+      key="You are an independent contractor with reportable income (ex. IRS Form 1099) and you are forced to stop working because COVID-19 has severely limited your ability to continue performing your customary work activities."
+      label="You are an independent contractor with reportable income (ex. IRS Form 1099) and you are forced to stop working because COVID-19 has severely limited your ability to continue performing your customary work activities."
+      name="disaster-question"
+      onChange={[Function]}
+      required={true}
+      title=""
+      type="radio"
+      value="You are an independent contractor with reportable income (ex. IRS Form 1099) and you are forced to stop working because COVID-19 has severely limited your ability to continue performing your customary work activities."
+    />
+    <FormCheck
+      checked={false}
+      disabled={false}
+      id="disaster-question-radioYou became the major financial support for your household because the head of household died as a direct result of COVID-19."
+      inline={true}
+      isInvalid={false}
+      isValid={false}
+      key="You became the major financial support for your household because the head of household died as a direct result of COVID-19."
+      label="You became the major financial support for your household because the head of household died as a direct result of COVID-19."
+      name="disaster-question"
+      onChange={[Function]}
+      required={true}
+      title=""
+      type="radio"
+      value="You became the major financial support for your household because the head of household died as a direct result of COVID-19."
+    />
+    <FormCheck
+      checked={false}
+      disabled={false}
+      id="disaster-question-radioNone of these options apply to me."
+      inline={true}
+      isInvalid={false}
+      isValid={false}
+      key="None of these options apply to me."
+      label="None of these options apply to me."
+      name="disaster-question"
+      onChange={[Function]}
+      required={true}
+      title=""
+      type="radio"
+      value="None of these options apply to me."
+    />
+    <Feedback
+      type="invalid"
+    >
+      This field is required.
+    </Feedback>
+  </fieldset>
+</FormGroup>
+`;

--- a/src/client/components/DisasterQuestion/_index.scss
+++ b/src/client/components/DisasterQuestion/_index.scss
@@ -1,0 +1,4 @@
+.disaster-question .form-check-inline {
+  display: flex;
+  align-items: baseline;
+}

--- a/src/client/components/DisasterQuestion/index.js
+++ b/src/client/components/DisasterQuestion/index.js
@@ -48,7 +48,10 @@ function DisasterQuestion(props) {
   }
 
   return (
-    <Form.Group controlId="disaster-question" className={getValidationClass()}>
+    <Form.Group
+      controlId="disaster-question"
+      className={`disaster-question ${getValidationClass()}`}
+    >
       <fieldset>
         <Form.Label as="legend">{props.questionText}</Form.Label>
         {disasterRadioChoices.map((value) => (
@@ -61,6 +64,7 @@ function DisasterQuestion(props) {
             name="disaster-question"
             value={value}
             required
+            inline
             checked={isChecked(value)}
           />
         ))}

--- a/src/client/components/DisasterQuestion/index.js
+++ b/src/client/components/DisasterQuestion/index.js
@@ -49,23 +49,25 @@ function DisasterQuestion(props) {
 
   return (
     <Form.Group controlId="disaster-question" className={getValidationClass()}>
-      <Form.Label>{props.questionText}</Form.Label>
-      {disasterRadioChoices.map((value) => (
-        <Form.Check
-          key={value}
-          label={value}
-          type="radio"
-          id={`disaster-question-radio${value}`}
-          onChange={onChange}
-          name="disaster-question"
-          value={value}
-          required
-          checked={isChecked(value)}
-        />
-      ))}
-      <Form.Control.Feedback type="invalid">
-        {t("required-error")}
-      </Form.Control.Feedback>
+      <fieldset>
+        <Form.Label as="legend">{props.questionText}</Form.Label>
+        {disasterRadioChoices.map((value) => (
+          <Form.Check
+            key={value}
+            label={value}
+            type="radio"
+            id={`disaster-question-radio${value}`}
+            onChange={onChange}
+            name="disaster-question"
+            value={value}
+            required
+            checked={isChecked(value)}
+          />
+        ))}
+        <Form.Control.Feedback type="invalid">
+          {t("required-error")}
+        </Form.Control.Feedback>
+      </fieldset>
     </Form.Group>
   );
 }

--- a/src/client/components/DisasterQuestion/index.test.js
+++ b/src/client/components/DisasterQuestion/index.test.js
@@ -1,0 +1,12 @@
+import renderNonTransContent from "../../test-helpers/renderNonTransContent";
+import Component from "./index";
+
+describe("<DisasterQuestion />", () => {
+  it("renders the component", async () => {
+    const wrapper = renderNonTransContent(Component, "DisasterQuestion", {
+      onChange: () => {},
+    });
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/client/components/YesNoQuestion/index.js
+++ b/src/client/components/YesNoQuestion/index.js
@@ -41,26 +41,28 @@ function YesNoQuestion(props) {
         controlId={inputName}
         className={isYes === undefined ? "unchecked" : ""}
       >
-        <Form.Label>
-          {questionNumber}.&nbsp;{questionText}
-        </Form.Label>
-        <Form.Text className="help-text">{helpText}</Form.Text>
+        <fieldset>
+          <Form.Label as="legend">
+            {questionNumber}.&nbsp;{questionText}
+          </Form.Label>
+          <Form.Text className="help-text">{helpText}</Form.Text>
 
-        {["Yes", "No"].map((value) => (
-          <Form.Check
-            key={value}
-            inline
-            label={t(`yesnoquestion.${value}`)}
-            type="radio"
-            id={`${inputName}radio${value}`}
-            onChange={onSelectionChanged}
-            name={inputName}
-            value={value}
-            checked={isChecked(value)}
-            required
-          />
-        ))}
-        <Feedback type="invalid">{t("required-error")}</Feedback>
+          {["Yes", "No"].map((value) => (
+            <Form.Check
+              key={value}
+              inline
+              label={t(`yesnoquestion.${value}`)}
+              type="radio"
+              id={`${inputName}radio${value}`}
+              onChange={onSelectionChanged}
+              name={inputName}
+              value={value}
+              checked={isChecked(value)}
+              required
+            />
+          ))}
+          <Feedback type="invalid">{t("required-error")}</Feedback>
+        </fieldset>
       </Form.Group>
       {isYes === true && children}
     </div>

--- a/src/client/components/YesNoQuestion/index.js
+++ b/src/client/components/YesNoQuestion/index.js
@@ -36,7 +36,7 @@ function YesNoQuestion(props) {
   }
 
   return (
-    <div className="bg-light p-2 m-2">
+    <div className="bg-light p-2 mt-2 mb-2">
       <Form.Group
         controlId={inputName}
         className={isYes === undefined ? "unchecked" : ""}


### PR DESCRIPTION
- Remove the left and right margin from the background of questions. Now the edge of the background lines up with the headers.
- Fix the alignment of the radio buttons with the disaster question answers.
- Add <fieldset> and <legend> tags to radio buttons (yes/no and the disaster question) which provides hints to screen readers.

===

- [X] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [X] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made

![screencapture-localhost-3000-retroactive-certification-certify-2020-02-15-2020-06-26-16_14_27](https://user-images.githubusercontent.com/175378/85907966-2af0fc80-b7c8-11ea-8563-f0d1f5d6dfcd.png)
