### PR TITLE
Always show checkmarks on the confirmation page.

### DIFF
--- a/src/client/pages/RetroCertsConfirmationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsConfirmationPage/__snapshots__/index.test.js.snap
@@ -12,6 +12,7 @@ exports[`<RetroCertsConfirmationPage /> with confirmation number 1`] = `
 >
   <Header />
   <main
+    className="pb-5"
     id="certification-page"
   >
     <div
@@ -78,7 +79,7 @@ exports[`<RetroCertsConfirmationPage /> with confirmation number 1`] = `
         Retroactive Certification Weeks
       </h2>
       <ListOfWeeks
-        showChecks={false}
+        showChecks={true}
         weeksToCertify={
           Array [
             0,

--- a/src/client/pages/RetroCertsConfirmationPage/index.js
+++ b/src/client/pages/RetroCertsConfirmationPage/index.js
@@ -42,7 +42,7 @@ function RetroCertsConfirmationPage(props) {
   return (
     <div id="overflow-wrapper">
       <Header />
-      <main id="certification-page">
+      <main id="certification-page" className="pb-5">
         <div className="container p-4">
           <h1>{t("retrocerts-confirmation.title")}</h1>
           <LanguageSelector className="mt-3 mb-4" />
@@ -71,7 +71,7 @@ function RetroCertsConfirmationPage(props) {
           <h2 className="mt-5">{t("retrocerts-confirmation.header2")}</h2>
           <ListOfWeeks
             weeksToCertify={userData.weeksToCertify}
-            showChecks={!isReturning}
+            showChecks
           />
 
           <h2 className="mt-5">{t("retrocerts-confirmation.header3")}</h2>


### PR DESCRIPTION
For both returning users and users who just completed
certifying, show the checkmarks.

Also add some bottom padding after the print button.

===

- [X] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made

![screencapture-localhost-3000-retroactive-certification-confirmation-2020-06-26-15_57_34](https://user-images.githubusercontent.com/175378/85907361-0d229800-b7c6-11ea-8562-8c31c472604a.png)
