### PR TITLE
Save Q7 answer when switching language.

### DIFF
--- a/src/client/components/DisasterQuestion/__snapshots__/index.test.js.snap
+++ b/src/client/components/DisasterQuestion/__snapshots__/index.test.js.snap
@@ -25,7 +25,7 @@ exports[`<DisasterQuestion /> renders the component 1`] = `
       required={true}
       title=""
       type="radio"
-      value="You have been diagnosed with COVID-19."
+      value="choice-1"
     />
     <FormCheck
       checked={false}
@@ -41,7 +41,7 @@ exports[`<DisasterQuestion /> renders the component 1`] = `
       required={true}
       title=""
       type="radio"
-      value="You have COVID-19 symptoms and are seeking a diagnosis."
+      value="choice-2"
     />
     <FormCheck
       checked={false}
@@ -57,7 +57,7 @@ exports[`<DisasterQuestion /> renders the component 1`] = `
       required={true}
       title=""
       type="radio"
-      value="A member of your household has COVID-19."
+      value="choice-3"
     />
     <FormCheck
       checked={false}
@@ -73,7 +73,7 @@ exports[`<DisasterQuestion /> renders the component 1`] = `
       required={true}
       title=""
       type="radio"
-      value="You are taking care of your family or household member who has COVID-19."
+      value="choice-4"
     />
     <FormCheck
       checked={false}
@@ -89,7 +89,7 @@ exports[`<DisasterQuestion /> renders the component 1`] = `
       required={true}
       title=""
       type="radio"
-      value="You had to quit your job as a direct result of COVID-19."
+      value="choice-5"
     />
     <FormCheck
       checked={false}
@@ -105,7 +105,7 @@ exports[`<DisasterQuestion /> renders the component 1`] = `
       required={true}
       title=""
       type="radio"
-      value="Your place of employment is closed as a direct result of COVID-19. (This may apply if your business is open or partially re-opened but your position is not needed due to COVID-19 limitations on the business)."
+      value="choice-6"
     />
     <FormCheck
       checked={false}
@@ -121,7 +121,7 @@ exports[`<DisasterQuestion /> renders the component 1`] = `
       required={true}
       title=""
       type="radio"
-      value="You cannot reach your workplace because of a quarantine as a direct result of COVID-19. (This may apply if you cannot reach your workplace because of a state or municipal order restricting travel to combat the spread of COVID-19, such as a stay-home or shelter-in-place order.)"
+      value="choice-7"
     />
     <FormCheck
       checked={false}
@@ -137,7 +137,7 @@ exports[`<DisasterQuestion /> renders the component 1`] = `
       required={true}
       title=""
       type="radio"
-      value="You cannot reach your workplace because your health care provider advised you to quarantine due to COVID-19 concerns."
+      value="choice-8"
     />
     <FormCheck
       checked={false}
@@ -153,7 +153,7 @@ exports[`<DisasterQuestion /> renders the component 1`] = `
       required={true}
       title=""
       type="radio"
-      value="You cannot work because you have primary responsibility for caring for a child or another person and their school or care facility is closed as a direct result of COVID-19."
+      value="choice-9"
     />
     <FormCheck
       checked={false}
@@ -169,7 +169,7 @@ exports[`<DisasterQuestion /> renders the component 1`] = `
       required={true}
       title=""
       type="radio"
-      value="You had a definite date to start a job that is no longer available as a direct result of COVID-19."
+      value="choice-10"
     />
     <FormCheck
       checked={false}
@@ -185,7 +185,7 @@ exports[`<DisasterQuestion /> renders the component 1`] = `
       required={true}
       title=""
       type="radio"
-      value="You had a definite date to start a job but cannot reach that job as a direct result of COVID-19."
+      value="choice-11"
     />
     <FormCheck
       checked={false}
@@ -201,7 +201,7 @@ exports[`<DisasterQuestion /> renders the component 1`] = `
       required={true}
       title=""
       type="radio"
-      value="You are an independent contractor with reportable income (ex. IRS Form 1099) and you are forced to stop working because COVID-19 has severely limited your ability to continue performing your customary work activities."
+      value="choice-12"
     />
     <FormCheck
       checked={false}
@@ -217,7 +217,7 @@ exports[`<DisasterQuestion /> renders the component 1`] = `
       required={true}
       title=""
       type="radio"
-      value="You became the major financial support for your household because the head of household died as a direct result of COVID-19."
+      value="choice-13"
     />
     <FormCheck
       checked={false}
@@ -233,7 +233,7 @@ exports[`<DisasterQuestion /> renders the component 1`] = `
       required={true}
       title=""
       type="radio"
-      value="None of these options apply to me."
+      value="choice-14"
     />
     <Feedback
       type="invalid"

--- a/src/client/components/DisasterQuestion/index.js
+++ b/src/client/components/DisasterQuestion/index.js
@@ -54,7 +54,7 @@ function DisasterQuestion(props) {
     >
       <fieldset>
         <Form.Label as="legend">{props.questionText}</Form.Label>
-        {disasterRadioChoices.map((value) => (
+        {disasterRadioChoices.map((value, index) => (
           <Form.Check
             key={value}
             label={value}
@@ -62,10 +62,10 @@ function DisasterQuestion(props) {
             id={`disaster-question-radio${value}`}
             onChange={onChange}
             name="disaster-question"
-            value={value}
+            value={`choice-${index + 1}`}
             required
             inline
-            checked={isChecked(value)}
+            checked={isChecked(`choice-${index + 1}`)}
           />
         ))}
         <Form.Control.Feedback type="invalid">

--- a/src/client/components/DisasterQuestion/index.js
+++ b/src/client/components/DisasterQuestion/index.js
@@ -6,19 +6,25 @@ import { useTranslation } from "react-i18next";
 function DisasterQuestion(props) {
   const { t } = useTranslation();
 
-  const [userChoice, setUserChoice] = useState(props.choice);
+  const propsValue = props.choice && props.choice.split(" ")[0];
+
+  // userChoice is a value from choice-1 to choice-14.
+  const [userChoice, setUserChoice] = useState(propsValue);
 
   const [isDirty, setIsDirty] = useState(
     props.choice !== undefined || userChoice !== undefined
   );
 
   function onChange(event) {
-    setUserChoice(event.target.value);
+    const value = event.target.value;
+    setUserChoice(value);
     setIsDirty(true);
 
     props.onChange({
       name: "disasterChoice",
-      value: event.target.value,
+      value: `${value} ${t(
+        "retrocerts-certification.disaster-choices." + value
+      )}`,
     });
   }
 


### PR DESCRIPTION
The value was the localized text. Instead, use
choice-# as the value we save in the backend.

Write a description of the changes proposed in this pull request. Include images/GIFs if relevant for reviewers. Try Fireshot (Chrome, Firefox) for full-page screenshots and LICEcap (macOS) for GIFs.

Before submitting the PR for review, consider the checklist below and check off any completed items

===

Resolves #426

- [X] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [X] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
