### PR TITLE
Scroll to top when transitioning pages.

### DIFF
--- a/src/client/components/RetroCertsRoute/index.js
+++ b/src/client/components/RetroCertsRoute/index.js
@@ -5,7 +5,8 @@ import { userDataPropType, setUserDataPropType } from "../../commonPropTypes";
 import AUTH_STRINGS from "../../../data/authStrings";
 import routes from "../../../data/routes";
 import PageNotFound from "../../pages/PageNotFound";
-import SessionTimer, { clearAuthToken } from "../../components/SessionTimer";
+import SessionTimer, { clearAuthToken } from "../SessionTimer";
+import ScrollToTop from "../ScrollToTop";
 
 function userIsAuthenticated() {
   return !!sessionStorage.getItem(AUTH_STRINGS.authToken);
@@ -29,6 +30,7 @@ function AuthorizedPageWrapper(props) {
 
   return (
     <React.Fragment>
+      <ScrollToTop />
       <Component routeComputedMatch={computedMatch} {...pageProps} />
       <SessionTimer
         action="startOrUpdate"

--- a/src/client/components/ScrollToTop/index.js
+++ b/src/client/components/ScrollToTop/index.js
@@ -1,0 +1,13 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+// From https://reacttraining.com/react-router/web/guides/scroll-restoration
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}

--- a/src/client/pages/RetroCertsCertificationPage/index.js
+++ b/src/client/pages/RetroCertsCertificationPage/index.js
@@ -67,19 +67,11 @@ function RetroCertsCertificationPage(props) {
     );
   }
 
-  // When the user transitions to a new week, return to the top
-  // of the form and reset the form.
+  // When the user transitions to a new week, reset the form.
   if (weekIndexRef.current !== weekIndex) {
     weekIndexRef.current = weekIndex;
 
     setValidated(false);
-    if (headingElement.current) {
-      autoScroll({
-        y: headingElement.current.offsetTop,
-        x: 0,
-        behavior: BEHAVIOR.smooth,
-      });
-    }
   }
 
   // Most (99.99%) users have the same programPlan for all weeks in


### PR DESCRIPTION
Only for the retro certs pages, when changing locations,
always scroll to the top. This isn't my favorite behavior
since it applies to pressing the back button (instead,
it should use the scroll offset from before), but
it's better than not scrolling to the top at all.

===

Resolves #415

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [X] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
