### PR TITLE
Script to generate test form entries for load test

### DIFF
--- a/scripts/create_test_forms.py
+++ b/scripts/create_test_forms.py
@@ -6,7 +6,7 @@ import json
 import csv
 import uuid
 
-NUM_TEST_FORMS = 100
+NUM_TEST_FORMS = 100000
 
 def get_uuid():
   return 'test' + str(uuid.uuid4())
@@ -33,9 +33,9 @@ def generate_test_form_json(test_form_data):
 def generate_test_form_csv(test_form_data):
   with open('test_forms.csv', 'w') as outfile:
       writer = csv.writer(outfile, delimiter=',', lineterminator='\n')
-      writer.writerow(['authToken', 'formData'])
+      writer.writerow(['authToken'])
       for uuid in test_form_data:
-        writer.writerow([uuid, 'updated data'])
+        writer.writerow([uuid])
 
 data = generate_test_form_data(NUM_TEST_FORMS)
 generate_test_form_json(data)

--- a/scripts/create_test_forms.py
+++ b/scripts/create_test_forms.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+'''Generate test form entries/items as JSON to use for load testing.
+'''
+
+import json
+import uuid
+
+NUM_TEST_FORMS = 100
+
+def get_uuid():
+  return 'test' + uuid.uuid4()
+
+def generate_test_forms(num_test_forms):
+  forms = []
+  for i in range(num_test_forms):
+      # 1. id must be unique because the forms container partitions on it (/id)
+      # 2. authToken must be unique because our code looks for a unique authtoken
+      forms.append({
+          'id': get_uuid(),
+          'authToken': get_uuid(),
+          'formData': "test"
+      })
+  with open('test_forms.json', 'w') as outfile:
+      outfile.write(json.dumps(sorted(forms, key=lambda d: d['id'])))
+
+generate_test_forms(NUM_TEST_FORMS)

--- a/scripts/create_test_forms.py
+++ b/scripts/create_test_forms.py
@@ -25,7 +25,7 @@ def generate_test_form_json(test_form_data):
       forms.append({
           'id': uuid,
           'authToken': uuid,
-          'formData': "test"
+          'formData': "initial data"
       })
   with open('test_forms.json', 'w') as outfile:
       outfile.write(json.dumps(sorted(forms, key=lambda d: d['id'])))
@@ -33,9 +33,9 @@ def generate_test_form_json(test_form_data):
 def generate_test_form_csv(test_form_data):
   with open('test_forms.csv', 'w') as outfile:
       writer = csv.writer(outfile, delimiter=',', lineterminator='\n')
-      writer.writerow(['authToken'])
+      writer.writerow(['authToken', 'formData'])
       for uuid in test_form_data:
-        writer.writerow([uuid])
+        writer.writerow([uuid, 'updated data'])
 
 data = generate_test_form_data(NUM_TEST_FORMS)
 generate_test_form_json(data)

--- a/scripts/create_test_forms.py
+++ b/scripts/create_test_forms.py
@@ -3,24 +3,40 @@
 '''
 
 import json
+import csv
 import uuid
 
 NUM_TEST_FORMS = 100
 
 def get_uuid():
-  return 'test' + uuid.uuid4()
+  return 'test' + str(uuid.uuid4())
 
-def generate_test_forms(num_test_forms):
-  forms = []
+def generate_test_form_data(num_test_forms):
+  uuids = []
   for i in range(num_test_forms):
+    uuids.append(get_uuid())
+  return uuids
+
+def generate_test_form_json(test_form_data):
+  forms = []
+  for uuid in test_form_data:
       # 1. id must be unique because the forms container partitions on it (/id)
       # 2. authToken must be unique because our code looks for a unique authtoken
       forms.append({
-          'id': get_uuid(),
-          'authToken': get_uuid(),
+          'id': uuid,
+          'authToken': uuid,
           'formData': "test"
       })
   with open('test_forms.json', 'w') as outfile:
       outfile.write(json.dumps(sorted(forms, key=lambda d: d['id'])))
 
-generate_test_forms(NUM_TEST_FORMS)
+def generate_test_form_csv(test_form_data):
+  with open('test_forms.csv', 'w') as outfile:
+      writer = csv.writer(outfile, delimiter=',', lineterminator='\n')
+      writer.writerow(['authToken'])
+      for uuid in test_form_data:
+        writer.writerow([uuid])
+
+data = generate_test_form_data(NUM_TEST_FORMS)
+generate_test_form_json(data)
+generate_test_form_csv(data)


### PR DESCRIPTION
This PR is a script to generate test form entries for the load test

===

Resolves #338

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
