### PR TITLE
Enable the frontend in prod.

### DIFF
--- a/src/client/App.js
+++ b/src/client/App.js
@@ -1,6 +1,5 @@
 import React, { Suspense, useState, useRef } from "react";
 import { Switch, Route, Redirect, useHistory } from "react-router-dom";
-import PropTypes from "prop-types";
 import RetroCertsRoute from "./components/RetroCertsRoute";
 import GuidePage from "./pages/GuidePage";
 import PageNotFound from "./pages/PageNotFound";
@@ -12,9 +11,7 @@ import AUTH_STRINGS from "../data/authStrings";
 import routes from "../data/routes";
 import { logPage } from "./utils.js";
 
-export default function App(props) {
-  const hostname = props.hostname || window.location.hostname;
-  const isProduction = hostname === "unemployment.edd.ca.gov";
+export default function App() {
   const history = useHistory();
   const initialPageLoad = useRef(true);
 
@@ -41,7 +38,6 @@ export default function App(props) {
         <Route path="/guide" component={GuidePage} />
         <RetroCertsRoute
           path={routes.retroCertsWeeksToCertify}
-          isProduction={isProduction}
           pageComponent={RetroCertsWeeksToCertifyPage}
           pageProps={{
             userData: retroCertsUserData,
@@ -51,7 +47,6 @@ export default function App(props) {
         />
         <RetroCertsRoute
           path={routes.retroCertsCertify + "/:week"}
-          isProduction={isProduction}
           pageComponent={RetroCertsCertificationPage}
           pageProps={{
             userData: retroCertsUserData,
@@ -61,7 +56,6 @@ export default function App(props) {
         />
         <RetroCertsRoute
           path={routes.retroCertsConfirmation}
-          isProduction={isProduction}
           pageComponent={RetroCertsConfirmationPage}
           pageProps={{
             userData: retroCertsUserData,
@@ -71,7 +65,6 @@ export default function App(props) {
         />
         <RetroCertsRoute
           path={routes.retroCertsAuth}
-          isProduction={isProduction}
           pageComponent={RetroCertsAuthPage}
           pageProps={{
             userData: retroCertsUserData,
@@ -85,7 +78,3 @@ export default function App(props) {
     </Suspense>
   );
 }
-
-App.propTypes = {
-  hostname: PropTypes.string,
-};

--- a/src/client/__snapshots__/App.test.js.snap
+++ b/src/client/__snapshots__/App.test.js.snap
@@ -18,7 +18,6 @@ exports[`<App /> renders application with retro-certs 1`] = `
       path="/guide"
     />
     <RetroCertsRoute
-      isProduction={false}
       pageComponent={[Function]}
       pageProps={
         Object {
@@ -32,7 +31,6 @@ exports[`<App /> renders application with retro-certs 1`] = `
       requiresAuthentication={true}
     />
     <RetroCertsRoute
-      isProduction={false}
       pageComponent={[Function]}
       pageProps={
         Object {
@@ -46,7 +44,6 @@ exports[`<App /> renders application with retro-certs 1`] = `
       requiresAuthentication={true}
     />
     <RetroCertsRoute
-      isProduction={false}
       pageComponent={[Function]}
       pageProps={
         Object {
@@ -60,7 +57,6 @@ exports[`<App /> renders application with retro-certs 1`] = `
       requiresAuthentication={true}
     />
     <RetroCertsRoute
-      isProduction={false}
       pageComponent={[Function]}
       pageProps={
         Object {
@@ -97,7 +93,6 @@ exports[`<App /> renders application without retro-certs 1`] = `
       path="/guide"
     />
     <RetroCertsRoute
-      isProduction={true}
       pageComponent={[Function]}
       pageProps={
         Object {
@@ -111,7 +106,6 @@ exports[`<App /> renders application without retro-certs 1`] = `
       requiresAuthentication={true}
     />
     <RetroCertsRoute
-      isProduction={true}
       pageComponent={[Function]}
       pageProps={
         Object {
@@ -125,7 +119,6 @@ exports[`<App /> renders application without retro-certs 1`] = `
       requiresAuthentication={true}
     />
     <RetroCertsRoute
-      isProduction={true}
       pageComponent={[Function]}
       pageProps={
         Object {
@@ -139,7 +132,6 @@ exports[`<App /> renders application without retro-certs 1`] = `
       requiresAuthentication={true}
     />
     <RetroCertsRoute
-      isProduction={true}
       pageComponent={[Function]}
       pageProps={
         Object {

--- a/src/client/components/RetroCertsRoute/__snapshots__/index.test.js.snap
+++ b/src/client/components/RetroCertsRoute/__snapshots__/index.test.js.snap
@@ -10,9 +10,10 @@ exports[`<RetroCertsRoute /> basic route 1`] = `
 
 exports[`<RetroCertsRoute /> route in production (should be PageNotFound) 1`] = `
 <Route
+  isProduction={true}
   path="/path"
 >
-  <PageNotFound />
+  <TestComponent />
 </Route>
 `;
 

--- a/src/client/components/RetroCertsRoute/index.js
+++ b/src/client/components/RetroCertsRoute/index.js
@@ -4,7 +4,6 @@ import React from "react";
 import { userDataPropType, setUserDataPropType } from "../../commonPropTypes";
 import AUTH_STRINGS from "../../../data/authStrings";
 import routes from "../../../data/routes";
-import PageNotFound from "../../pages/PageNotFound";
 import SessionTimer, { clearAuthToken } from "../SessionTimer";
 import ScrollToTop from "../ScrollToTop";
 
@@ -52,16 +51,13 @@ AuthorizedPageWrapper.propTypes = {
 function RetroCertsRoute(props) {
   const {
     pageComponent: Component,
-    isProduction,
     pageProps,
     requiresAuthentication,
     ...routeProps
   } = props;
 
   let routeChild = <div>Loading...</div>;
-  if (isProduction) {
-    routeChild = <PageNotFound />;
-  } else if (!requiresAuthentication) {
+  if (!requiresAuthentication) {
     routeChild = <Component {...pageProps} />;
   } else if (userIsAuthenticated() && userDataIsSet(pageProps.userData)) {
     routeChild = <AuthorizedPageWrapper {...props} />;
@@ -98,7 +94,6 @@ function RetroCertsRoute(props) {
 
 RetroCertsRoute.propTypes = {
   exact: PropTypes.bool,
-  isProduction: PropTypes.bool,
   pageComponent: PropTypes.func.isRequired,
   pageProps: PropTypes.shape({
     userData: userDataPropType,


### PR DESCRIPTION
Removes the domain check from the javascript.

===

- [X] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
