### PR TITLE
Add Application Insights for front-end error logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3045,6 +3045,102 @@
         "@types/yargs": "^13.0.0"
       }
     },
+    "@microsoft/applicationinsights-analytics-js": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.5.5.tgz",
+      "integrity": "sha512-Sh2eYdVKBBAV1Wj1fSY41Vd1uZXSBq60mlhelJ63uIBGEKmd74KRHYnQH9+binMpXhAXJ4YnUN5scFBQfp03GQ==",
+      "requires": {
+        "@microsoft/applicationinsights-common": "2.5.5",
+        "@microsoft/applicationinsights-core-js": "2.5.5",
+        "@microsoft/applicationinsights-shims": "1.0.0",
+        "@microsoft/dynamicproto-js": "^0.5.2"
+      }
+    },
+    "@microsoft/applicationinsights-channel-js": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.5.5.tgz",
+      "integrity": "sha512-6gAn8q2Wi65cyE2WWQfx4SIRym6VFBPhWJH4Tgt9mxunxzEzNWw5pJWzGX5DMB+25r7WgLBVXTUtoAFwmcG6tg==",
+      "requires": {
+        "@microsoft/applicationinsights-common": "2.5.5",
+        "@microsoft/applicationinsights-core-js": "2.5.5",
+        "@microsoft/applicationinsights-shims": "1.0.0"
+      }
+    },
+    "@microsoft/applicationinsights-common": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.5.5.tgz",
+      "integrity": "sha512-SI2F0fdRfYrbQWKQqxNtpkT+BwtfqqIN6xGlAq7sxffn9ZF+YpL3HpMNxCePUg0KarFhG0ykDr/CfrHur0Q0Iw==",
+      "requires": {
+        "@microsoft/applicationinsights-core-js": "2.5.5",
+        "@microsoft/applicationinsights-shims": "1.0.0"
+      }
+    },
+    "@microsoft/applicationinsights-core-js": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.5.5.tgz",
+      "integrity": "sha512-vBV6Q0W9QZI2d1CnX2wOeAbGO4+xLGxlST6J4vvQ0gtR/fX/jjIYwr2+go+iimuvSmdtyzzhTlfO518XJ6XR+Q==",
+      "requires": {
+        "@microsoft/applicationinsights-shims": "1.0.0",
+        "@microsoft/dynamicproto-js": "^0.5.2"
+      }
+    },
+    "@microsoft/applicationinsights-dependencies-js": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.5.5.tgz",
+      "integrity": "sha512-uOmLxkF6316dbklG75OIGE6bF8Ewb2WO6nFQyUXoIhBTDGEy1vhV4jPWKEPpZc8MAqqXv6PM5+fNtSwdP5fJYA==",
+      "requires": {
+        "@microsoft/applicationinsights-common": "2.5.5",
+        "@microsoft/applicationinsights-core-js": "2.5.5",
+        "@microsoft/applicationinsights-shims": "1.0.0",
+        "@microsoft/dynamicproto-js": "^0.5.2"
+      }
+    },
+    "@microsoft/applicationinsights-properties-js": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.5.5.tgz",
+      "integrity": "sha512-o8lnv1+BL0EHxZhfUgEuImnpY+403IXZRGI28hTuyjxIucRr0X/rajuKgqb1KfW/Nb9WALgiqkLNmK/kR2esXw==",
+      "requires": {
+        "@microsoft/applicationinsights-common": "2.5.5",
+        "@microsoft/applicationinsights-core-js": "2.5.5",
+        "@microsoft/applicationinsights-shims": "1.0.0"
+      }
+    },
+    "@microsoft/applicationinsights-react-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-react-js/-/applicationinsights-react-js-3.0.0.tgz",
+      "integrity": "sha512-eTA9hujKITE7jageXZH9S1JgXIgGNeBdsJVaWk4wA1kU7xbZBsWGhtsTqZ2y0rU77XbIUNnEn2Q6ihq7CzUz/A==",
+      "requires": {
+        "@microsoft/applicationinsights-common": "^2.5.4",
+        "@microsoft/applicationinsights-core-js": "^2.5.4",
+        "@microsoft/applicationinsights-shims": "^1.0.0",
+        "history": "^4.10.1"
+      }
+    },
+    "@microsoft/applicationinsights-shims": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-1.0.0.tgz",
+      "integrity": "sha512-huUHn7LsfSohsr7TqkU+YlmXjySubGq6l9UNBtAJDaT4qSI1W7aA5htoPCnaXnUhsk1LpYybOSAAMRkEJFesPw=="
+    },
+    "@microsoft/applicationinsights-web": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-2.5.5.tgz",
+      "integrity": "sha512-k4cYJVRKTRZH70IBfDb/DN4NnbyKow4/KDBfG3XDAoG7VXnMbLvrnU1S8Jv147JFNqNEJvBb44zpIurq4I/2pw==",
+      "requires": {
+        "@microsoft/applicationinsights-analytics-js": "2.5.5",
+        "@microsoft/applicationinsights-channel-js": "2.5.5",
+        "@microsoft/applicationinsights-common": "2.5.5",
+        "@microsoft/applicationinsights-core-js": "2.5.5",
+        "@microsoft/applicationinsights-dependencies-js": "2.5.5",
+        "@microsoft/applicationinsights-properties-js": "2.5.5",
+        "@microsoft/applicationinsights-shims": "1.0.0",
+        "@microsoft/dynamicproto-js": "^0.5.2"
+      }
+    },
+    "@microsoft/dynamicproto-js": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-0.5.2.tgz",
+      "integrity": "sha512-tGwZJLtLVK96OKl5/pHeZFgi28rnKJB2DQ0V/28SVQnv9tC/OXCNOrvvvtIZM6wp1YJwqVSFnyp46w3azDjC0Q=="
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     },
     "dependencies": {
         "@azure/cosmos": "^3.7.0",
+        "@microsoft/applicationinsights-react-js": "^3.0.0",
+        "@microsoft/applicationinsights-web": "^2.5.5",
         "axios": "^0.19.2",
         "bootstrap": "^4.4.1",
         "cookie-session": "^1.3.3",

--- a/src/client/ApplicationInsights.js
+++ b/src/client/ApplicationInsights.js
@@ -1,0 +1,46 @@
+import React, { Component, Fragment } from "react";
+import { withAITracking } from "@microsoft/applicationinsights-react-js";
+import { ai } from "../services/azureApplicationInsights";
+import { withRouter } from "react-router-dom";
+import PropTypes from "prop-types";
+
+/**
+ * This Component provides telemetry with Azure App Insights
+ *
+ * NOTE: the package '@microsoft/applicationinsights-react-js' has a HOC withAITracking that requires this to be a Class Component rather than a Functional Component
+ */
+class ApplicationInsights extends Component {
+  state = {
+    initialized: false,
+  };
+
+  componentDidMount() {
+    const { history } = this.props;
+    const { initialized } = this.state;
+    const AppInsightsInstrumentationKey = this.props.instrumentationKey; // PUT YOUR KEY HERE
+    if (
+      !initialized &&
+      Boolean(AppInsightsInstrumentationKey) &&
+      Boolean(history)
+    ) {
+      ai.initialize(AppInsightsInstrumentationKey, history);
+      this.setState({ initialized: true });
+    }
+
+    this.props.after();
+  }
+
+  render() {
+    const { children } = this.props;
+    return <Fragment>{children}</Fragment>;
+  }
+}
+
+ApplicationInsights.propTypes = {
+  history: PropTypes.object,
+  after: PropTypes.func,
+  children: PropTypes.object,
+  instrumentationKey: PropTypes.string,
+};
+
+export default withRouter(withAITracking(ai.reactPlugin, ApplicationInsights));

--- a/src/client/ApplicationInsights.js
+++ b/src/client/ApplicationInsights.js
@@ -1,3 +1,4 @@
+// From: https://github.com/Azure-Samples/application-insights-react-demo/blob/master/src/telemetry-provider.jsx
 import React, { Component, Fragment } from "react";
 import { withAITracking } from "@microsoft/applicationinsights-react-js";
 import { ai } from "../services/azureApplicationInsights";

--- a/src/client/ApplicationInsights.js
+++ b/src/client/ApplicationInsights.js
@@ -18,7 +18,7 @@ class ApplicationInsights extends Component {
   componentDidMount() {
     const { history } = this.props;
     const { initialized } = this.state;
-    const AppInsightsInstrumentationKey = this.props.instrumentationKey; // PUT YOUR KEY HERE
+    const AppInsightsInstrumentationKey = this.props.instrumentationKey;
     if (
       !initialized &&
       Boolean(AppInsightsInstrumentationKey) &&

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -6,6 +6,7 @@ import App from "./App";
 import { BrowserRouter } from "react-router-dom";
 import React from "react";
 import { render } from "react-dom";
+import ApplicationInsights from "./ApplicationInsights";
 import smoothscroll from "smoothscroll-polyfill";
 
 // Enables scrolling (not just smooth scrolling) on Edge and IE
@@ -13,7 +14,12 @@ smoothscroll.polyfill();
 
 render(
   <BrowserRouter>
-    <App />
+    <ApplicationInsights
+      instrumentationKey="57ab6c1e-220e-47fa-96ab-fe49b6a9dc73"
+      after={() => {}}
+    >
+      <App />
+    </ApplicationInsights>
   </BrowserRouter>,
   document.getElementById("root")
 );

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -7,6 +7,7 @@ import { BrowserRouter } from "react-router-dom";
 import React from "react";
 import { render } from "react-dom";
 import ApplicationInsights from "./ApplicationInsights";
+import AZURE_CONFIG from "../data/azureConfig.js";
 import smoothscroll from "smoothscroll-polyfill";
 
 // Enables scrolling (not just smooth scrolling) on Edge and IE
@@ -15,7 +16,7 @@ smoothscroll.polyfill();
 render(
   <BrowserRouter>
     <ApplicationInsights
-      instrumentationKey="57ab6c1e-220e-47fa-96ab-fe49b6a9dc73"
+      instrumentationKey={AZURE_CONFIG.applicationInsightsKey}
       after={() => {}}
     >
       <App />

--- a/src/data/azureConfig.js
+++ b/src/data/azureConfig.js
@@ -1,0 +1,5 @@
+const AZURE_CONFIG = {
+  applicationInsightsKey: "57ab6c1e-220e-47fa-96ab-fe49b6a9dc73",
+};
+
+module.exports = AZURE_CONFIG;

--- a/src/services/azureApplicationInsights.js
+++ b/src/services/azureApplicationInsights.js
@@ -1,0 +1,52 @@
+// From: https://github.com/Azure-Samples/application-insights-react-demo/blob/master/src/TelemetryService.js
+import { ApplicationInsights } from "@microsoft/applicationinsights-web";
+import { ReactPlugin } from "@microsoft/applicationinsights-react-js";
+
+let reactPlugin = null;
+let appInsights = null;
+
+/**
+ * Create the App Insights Telemetry Service
+ * @returns {{reactPlugin: ReactPlugin, appInsights: object, initialize: Function}} - Object
+ */
+const createTelemetryService = () => {
+  /**
+   * Initialize the Application Insights class
+   * @param {string} instrumentationKey - Application Insights Instrumentation Key
+   * @param {object} browserHistory - client's browser history, supplied by the withRouter HOC
+   * returns {void}
+   */
+  const initialize = (instrumentationKey, browserHistory) => {
+    if (!browserHistory) {
+      throw new Error("Could not initialize Telemetry Service");
+    }
+    if (!instrumentationKey) {
+      throw new Error(
+        "Instrumentation key not provided in ApplicationInsights.js"
+      );
+    }
+
+    reactPlugin = new ReactPlugin();
+
+    appInsights = new ApplicationInsights({
+      config: {
+        instrumentationKey,
+        maxBatchInterval: 0,
+        disableFetchTracking: false,
+        extensions: [reactPlugin],
+        extensionConfig: {
+          [reactPlugin.identifier]: {
+            history: browserHistory,
+          },
+        },
+      },
+    });
+
+    appInsights.loadAppInsights();
+  };
+
+  return { reactPlugin, appInsights, initialize };
+};
+
+export const ai = createTelemetryService();
+export const getAppInsights = () => appInsights;


### PR DESCRIPTION
This PR adds Azure's Application Insights for front-end error logging

Completed: 
- [x] Verify IP addresses are not logged (verified: [IP masking is enabled by default](https://docs.microsoft.com/en-us/azure/azure-monitor/app/ip-collection), and stripped from all the data we receive)
- [x] Move instrumentation key to constants/config file (it's client-side, so doesn't need to be obscured)

Will do as part of next PR:
- [ ] Verify on staging that impact on performance is minimal
- [ ] Double check that it's not collecting request bodies, per documentation
- [ ] Manually log an error somewhere using Insights
- [ ] Ask CDT why our Application Insights key/instance is the same for both staging and prod

===

Resolves #212

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
