### PR TITLE
Fix npm start.

### DIFF
--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -22,7 +22,7 @@ module.exports = merge(common, {
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
     new I18NextHMRPlugin({
-      localesDir: path.resolve(__dirname, "public/locales"),
+      localesDir: path.resolve(__dirname, "src/data/locales"),
     }),
   ],
   stats: "errors-warnings",


### PR DESCRIPTION
The dev build was still looking for translations.json
in public/locales.

===

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
