### PR TITLE
Fix bug where non-submits were considered complete

### DIFF
--- a/src/client/App.scss
+++ b/src/client/App.scss
@@ -62,8 +62,7 @@ a {
   text-decoration: none;
 }
 
-input[type="radio"]
-{
+input[type="radio"] {
   -ms-transform: scale(1.01); /* IE */
   -moz-transform: scale(1.01); /* FF */
   -webkit-transform: scale(1.01); /* Safari and Chrome */
@@ -138,7 +137,7 @@ footer {
 // radio question was answered for the feedback to show.
 .was-validated .unchecked .invalid-feedback {
   display: block;
-  color:  #CC2435;
+  color: #cc2435;
 }
 
 // For help text on pages and components
@@ -162,13 +161,13 @@ footer {
 }
 
 input[name="disaster-question"].form-check-input {
-  margin-right: .5rem;
+  margin-right: 0.5rem;
 }
 
 #certification-page {
-
   // This resets the language toggle button to not inherit the changes we made to the form questions background
-  button.bg-light, .bg-light.btn {
+  button.bg-light,
+  .bg-light.btn {
     padding: 6px 12px !important;
     background-color: #f8f9fa !important;
   }

--- a/src/client/pages/RetroCertsCertificationPage/index.js
+++ b/src/client/pages/RetroCertsCertificationPage/index.js
@@ -212,7 +212,9 @@ function RetroCertsCertificationPage(props) {
           </h1>
           <LanguageSelector className="mt-3 mb-4" />
           {history.location.state && history.location.state.returningUser && (
-            <Alert variant="success">{t("retrocerts-certification.alert-found-save")}</Alert>
+            <Alert variant="success">
+              {t("retrocerts-certification.alert-found-save")}
+            </Alert>
           )}
           {showGenericValidationError && validated && genericValidationError}
           <h2 className="h3 font-weight-bold mt-5">

--- a/src/client/pages/RetroCertsCertificationPage/index.js
+++ b/src/client/pages/RetroCertsCertificationPage/index.js
@@ -149,6 +149,7 @@ function RetroCertsCertificationPage(props) {
     let body = JSON.stringify({
       formData: userData.formData,
       authToken: sessionStorage.getItem(AUTH_STRINGS.authToken),
+      completed: weekForUser === numberOfWeeks,
     });
     // The server rejects < followed by non-whitespace,
     // so change the input from the form to add a space.

--- a/src/routes/retro-certs.js
+++ b/src/routes/retro-certs.js
@@ -83,13 +83,18 @@ function createRouter() {
           formRecord.formData = postJson.formData;
           if (
             userRecord.weeksToCertify.length ===
-            weeksCompleted(formRecord.formData, userRecord.programPlan)
+              weeksCompleted(formRecord.formData, userRecord.programPlan) &&
+            postJson.completed === true
           ) {
             formRecord.confirmationNumber = uuidv4();
             responseJson.confirmationNumber = formRecord.confirmationNumber;
           }
           await cosmos.upsertFormData(formRecord);
-          console.log("saved data", postJson.authToken, responseJson.confirmationNumber || "");
+          console.log(
+            "saved data",
+            postJson.authToken,
+            responseJson.confirmationNumber || ""
+          );
         }
       } else {
         console.log("save with invalid token", postJson.authToken);
@@ -134,7 +139,6 @@ function createRouter() {
     }
 
     try {
-
       const responseJson = await saveFormData(req.body, {});
       const httpStatus =
         responseJson.status === AUTH_STRINGS.statusCode.ok ? 200 : 401;

--- a/src/routes/retro-certs.test.js
+++ b/src/routes/retro-certs.test.js
@@ -280,6 +280,7 @@ describe("Router: API tests", () => {
         {
           authToken: "TOKEN",
           formData: [weekOfAnswers],
+          completed: false,
         },
         { id: "ID" },
         { programPlan: [programPlan.uiFullTime], weeksToCertify: [0, 1] },
@@ -291,6 +292,7 @@ describe("Router: API tests", () => {
         {
           authToken: "TOKEN",
           formData: [weekOfAnswers, weekOfAnswers],
+          completed: true,
         },
         { id: "ID" },
         { programPlan: [programPlan.uiFullTime], weeksToCertify: [0, 1] },
@@ -300,11 +302,26 @@ describe("Router: API tests", () => {
           confirmationNumber: "00000000-fake-mock-fake-123456789012",
         },
       ],
+      // Save 2 weeks of 2, but not submitting the final page (user went back to week 1, then forward).
+      [
+        {
+          authToken: "TOKEN",
+          formData: [weekOfAnswers, weekOfAnswers],
+          completed: false,
+        },
+        { id: "ID" },
+        { programPlan: [programPlan.uiFullTime], weeksToCertify: [0, 1] },
+        200,
+        {
+          status: "ok",
+        },
+      ],
       // Already have a confirmation number.
       [
         {
           authToken: "TOKEN",
           formData: [weekOfAnswers, weekOfAnswers],
+          completed: true,
         },
         { id: "ID", confirmationNumber: "alreadyExists" },
         { programPlan: [programPlan.uiFullTime], weeksToCertify: [0, 1] },


### PR DESCRIPTION
The bug was if you had completed the last week to
certify, gone back a week, then gone forward, we
would treat that as the user submitting because
all the necessary data was there.

Instead, add an extra "completed" field for when
the user is on the last page. Only assign a
confirmation number if that field is true.

===

Resolves #XXX

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [X] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
