### PR TITLE
Create detailed confirmation page

### DIFF
--- a/src/client/App.scss
+++ b/src/client/App.scss
@@ -31,6 +31,7 @@ $font-family-sans-serif: "Source Sans Pro", sans-serif !default;
 @import "components/Footer/index";
 @import "components/TabbedContainer/index";
 @import "components/DisasterQuestion/index";
+@import "pages/RetroCertsConfirmationPage/index";
 
 h1,
 h2,

--- a/src/client/components/ListOfWeeksWithDetail/index.js
+++ b/src/client/components/ListOfWeeksWithDetail/index.js
@@ -1,127 +1,33 @@
-import Alert from "react-bootstrap/Alert";
-import PropTypes from "prop-types";
 import React from "react";
-import { Trans, useTranslation } from "react-i18next";
 import { userDataPropType } from "../../commonPropTypes";
-import { startAndEndDate, toWeekString } from "../../../utils/retroCertsWeeks";
-import programPlan from "../../../data/programPlan";
-import WeekConfirmationDetails from "../WeekConfirmationDetails";
+import WeekWithDetail from "../WeekWithDetail";
 
 function ListOfWeeksWithDetail(props) {
   const { userData } = props;
-  const { t } = useTranslation();
-
-  const baseQuestionNames = [
-    "tooSick",
-    "tooSickNumberOfDays",
-    "couldNotAcceptWork",
-    "didYouLook",
-    "refuseWork",
-  ];
-  const uiOnlyQuestionNames = ["schoolOrTraining", "workOrEarn"];
-  const puaOnlyQuestionNames = [
-    "otherBenefits",
-    "workOrEarn",
-    "recentDisaster",
-    "disasterChoice",
-  ];
-
-  // TODO(kalvin): also used in RCCertificationPage, refactor to common place
-  function getQuestionKey(transKey, weekProgramPlan) {
-    if (weekProgramPlan === programPlan.uiPartTime) {
-      return "retrocerts-certification.questions.ui-part-time." + transKey;
-    }
-    if (weekProgramPlan === programPlan.uiFullTime) {
-      return "retrocerts-certification.questions.ui-full-time." + transKey;
-    }
-    if (weekProgramPlan === programPlan.puaFullTime) {
-      return "retrocerts-certification.questions.pua-full-time." + transKey;
-    }
-  }
-
-  function getSubmittedAnswer(questionName, weekData) {
-    const answer = weekData[questionName];
-    if (answer === undefined) {
-      // The only case where the answer should be undefined is for
-      // the "number of days you were sick" question, and then only
-      // if the answer to "were you sick" was yes
-      if (questionName !== "tooSickNumberOfDays" || weekData.tooSick) {
-        // TODO turn this into an error we log
-        console.log("missing answer", questionName, weekData);
-      }
-      return "N/A";
-    }
-
-    // disasterChoice answers are stored in the format "choice-3 TEXT OF Q..."
-    if (questionName === "disasterChoice") {
-      return answer.substring(answer.indexOf(" ") + 1);
-    }
-
-    if (answer === true) {
-      return t("yesnoquestion.Yes");
-    } else if (answer === false) {
-      return t("yesnoquestion.No");
-    }
-    return answer;
-  }
 
   return userData.weeksToCertify.map((weekIndex, index) => {
     const weekForUser = index + 1;
-    const dates = startAndEndDate(weekIndex);
     const weekData = userData.formData[index];
-    const weekHasEmployers = weekData.workOrEarn;
-    if (weekHasEmployers && !weekData.employers) {
-      // TODO turn this into an error we log
-      console.log("missing employer(s)");
-    }
 
     // TODO(kalvin): also used in RCCertificationPage, refactor to common place
     const programPlanIndex =
       userData.programPlan.length === 1 ? 0 : weekForUser - 1;
     const weekProgramPlan = userData.programPlan[programPlanIndex];
 
-    let questionNames;
-    if (weekProgramPlan === programPlan.puaFullTime) {
-      questionNames = baseQuestionNames.concat(puaOnlyQuestionNames);
-    } else {
-      questionNames = baseQuestionNames.concat(uiOnlyQuestionNames);
-    }
-
-    const questionKeys = questionNames.map((questionName) => {
-      return getQuestionKey(questionName, weekProgramPlan);
-    });
-
-    const questionAnswers = questionNames.map((questionName) => {
-      return getSubmittedAnswer(questionName, weekData);
-    });
-
     return (
-      <Alert
-        key={`weekToCertify${weekIndex}`}
-        variant="secondary"
-        className="d-flex"
-      >
-        <div className="flex-fill">
-          <Trans
-            t={t}
-            i18nKey="retrocerts-week-list-item"
-            values={{ ...dates, weekForUser }}
-          />
-          <WeekConfirmationDetails
-            employers={weekHasEmployers ? weekData.employers : undefined}
-            questionAnswers={questionAnswers}
-            questionKeys={questionKeys}
-            weekString={toWeekString(weekIndex)}
-          />
-        </div>
-      </Alert>
+      <WeekWithDetail
+        index={index}
+        key={index}
+        weekData={weekData}
+        weekIndex={weekIndex}
+        weekProgramPlan={weekProgramPlan}
+      />
     );
   });
 }
 
 ListOfWeeksWithDetail.propTypes = {
   userData: userDataPropType,
-  showChecks: PropTypes.bool,
 };
 
 export default ListOfWeeksWithDetail;

--- a/src/client/components/ListOfWeeksWithDetail/index.js
+++ b/src/client/components/ListOfWeeksWithDetail/index.js
@@ -95,7 +95,6 @@ function ListOfWeeksWithDetail(props) {
       return getSubmittedAnswer(questionName, weekData);
     });
 
-    console.log(weekData);
     return (
       <Alert
         key={`weekToCertify${weekIndex}`}

--- a/src/client/components/ListOfWeeksWithDetail/index.js
+++ b/src/client/components/ListOfWeeksWithDetail/index.js
@@ -61,15 +61,19 @@ function ListOfWeeksWithDetail(props) {
       return "Yes";
     } else if (answer === false) {
       return "No";
-    } else {
-      return answer;
     }
+    return answer;
   }
 
   return userData.weeksToCertify.map((weekIndex, index) => {
     const weekForUser = index + 1;
     const dates = startAndEndDate(weekIndex);
     const weekData = userData.formData[index];
+    const weekHasEmployers = weekData.workOrEarn;
+    if (weekHasEmployers && !weekData.employers) {
+      // TODO turn this into an error we log
+      console.log("missing employer(s)");
+    }
 
     // TODO(kalvin): also used in RCCertificationPage, refactor to common place
     const programPlanIndex =
@@ -91,6 +95,7 @@ function ListOfWeeksWithDetail(props) {
       return getSubmittedAnswer(questionName, weekData);
     });
 
+    console.log(weekData);
     return (
       <Alert
         key={`weekToCertify${weekIndex}`}
@@ -104,6 +109,7 @@ function ListOfWeeksWithDetail(props) {
             values={{ ...dates, weekForUser }}
           />
           <WeekConfirmationDetails
+            employers={weekHasEmployers ? weekData.employers : undefined}
             questionAnswers={questionAnswers}
             questionKeys={questionKeys}
             weekString={toWeekString(weekIndex)}

--- a/src/client/components/ListOfWeeksWithDetail/index.js
+++ b/src/client/components/ListOfWeeksWithDetail/index.js
@@ -58,9 +58,9 @@ function ListOfWeeksWithDetail(props) {
     }
 
     if (answer === true) {
-      return "Yes";
+      return t("yesnoquestion.Yes");
     } else if (answer === false) {
-      return "No";
+      return t("yesnoquestion.No");
     }
     return answer;
   }

--- a/src/client/components/ListOfWeeksWithDetail/index.js
+++ b/src/client/components/ListOfWeeksWithDetail/index.js
@@ -1,0 +1,122 @@
+import Alert from "react-bootstrap/Alert";
+import PropTypes from "prop-types";
+import React from "react";
+import { Trans, useTranslation } from "react-i18next";
+import { userDataPropType } from "../../commonPropTypes";
+import { startAndEndDate, toWeekString } from "../../../utils/retroCertsWeeks";
+import programPlan from "../../../data/programPlan";
+import WeekConfirmationDetails from "../WeekConfirmationDetails";
+
+function ListOfWeeksWithDetail(props) {
+  const { userData } = props;
+  const { t } = useTranslation();
+
+  const baseQuestionNames = [
+    "tooSick",
+    "tooSickNumberOfDays",
+    "couldNotAcceptWork",
+    "didYouLook",
+    "refuseWork",
+  ];
+  const uiOnlyQuestionNames = ["schoolOrTraining", "workOrEarn"];
+  const puaOnlyQuestionNames = [
+    "otherBenefits",
+    "workOrEarn",
+    "recentDisaster",
+    "disasterChoice",
+  ];
+
+  // TODO(kalvin): also used in RCCertificationPage, refactor to common place
+  function getQuestionKey(transKey, weekProgramPlan) {
+    if (weekProgramPlan === programPlan.uiPartTime) {
+      return "retrocerts-certification.questions.ui-part-time." + transKey;
+    }
+    if (weekProgramPlan === programPlan.uiFullTime) {
+      return "retrocerts-certification.questions.ui-full-time." + transKey;
+    }
+    if (weekProgramPlan === programPlan.puaFullTime) {
+      return "retrocerts-certification.questions.pua-full-time." + transKey;
+    }
+  }
+
+  function getSubmittedAnswer(questionName, weekData) {
+    const answer = weekData[questionName];
+    if (answer === undefined) {
+      // The only case where the answer should be undefined is for
+      // the "number of days you were sick" question, and then only
+      // if the answer to "were you sick" was yes
+      if (questionName !== "tooSickNumberOfDays" || weekData.tooSick) {
+        // TODO turn this into an error we log
+        console.log("missing answer", questionName, weekData);
+      }
+      return "N/A";
+    }
+
+    // disasterChoice answers are stored in the format "choice-3 TEXT OF Q..."
+    if (questionName === "disasterChoice") {
+      return answer.substring(answer.indexOf(" ") + 1);
+    }
+
+    if (answer === true) {
+      return "Yes";
+    } else if (answer === false) {
+      return "No";
+    } else {
+      return answer;
+    }
+  }
+
+  return userData.weeksToCertify.map((weekIndex, index) => {
+    const weekForUser = index + 1;
+    const dates = startAndEndDate(weekIndex);
+    const weekData = userData.formData[index];
+
+    // TODO(kalvin): also used in RCCertificationPage, refactor to common place
+    const programPlanIndex =
+      userData.programPlan.length === 1 ? 0 : weekForUser - 1;
+    const weekProgramPlan = userData.programPlan[programPlanIndex];
+
+    let questionNames;
+    if (weekProgramPlan === programPlan.puaFullTime) {
+      questionNames = baseQuestionNames.concat(puaOnlyQuestionNames);
+    } else {
+      questionNames = baseQuestionNames.concat(uiOnlyQuestionNames);
+    }
+
+    const questionKeys = questionNames.map((questionName) => {
+      return getQuestionKey(questionName, weekProgramPlan);
+    });
+
+    const questionAnswers = questionNames.map((questionName) => {
+      return getSubmittedAnswer(questionName, weekData);
+    });
+
+    return (
+      <Alert
+        key={`weekToCertify${weekIndex}`}
+        variant="secondary"
+        className="d-flex"
+      >
+        <div className="flex-fill">
+          <Trans
+            t={t}
+            i18nKey="retrocerts-week-list-item"
+            values={{ ...dates, weekForUser }}
+          />
+          <WeekConfirmationDetails
+            questionAnswers={questionAnswers}
+            questionKeys={questionKeys}
+            weekString={toWeekString(weekIndex)}
+          />
+        </div>
+      </Alert>
+    );
+  });
+}
+
+ListOfWeeksWithDetail.propTypes = {
+  userData: userDataPropType,
+  showChecks: PropTypes.bool,
+};
+
+export default ListOfWeeksWithDetail;

--- a/src/client/components/SessionTimer/index.js
+++ b/src/client/components/SessionTimer/index.js
@@ -9,7 +9,7 @@ let timerId = null;
 const TIMEOUT_KEY = "timeout";
 
 function SessionTimer(props) {
-  const TIMEOUT_MS = 30 * 60 * 1000;
+  const TIMEOUT_MS = 3000 * 60 * 1000;
   const history = useHistory();
   const { action, setUserData } = props;
 

--- a/src/client/components/SessionTimer/index.js
+++ b/src/client/components/SessionTimer/index.js
@@ -9,7 +9,7 @@ let timerId = null;
 const TIMEOUT_KEY = "timeout";
 
 function SessionTimer(props) {
-  const TIMEOUT_MS = 3000 * 60 * 1000;
+  const TIMEOUT_MS = 30 * 60 * 1000;
   const history = useHistory();
   const { action, setUserData } = props;
 

--- a/src/client/components/WeekConfirmationDetails/index.js
+++ b/src/client/components/WeekConfirmationDetails/index.js
@@ -1,0 +1,68 @@
+import PropTypes from "prop-types";
+import React from "react";
+import { Trans, useTranslation } from "react-i18next";
+
+function WeekConfirmationDetails(props) {
+	const { questionAnswers, questionKeys, weekString } = props;
+	const { t } = useTranslation();
+
+	const employerAddressNames = [
+		"employerName",
+		"address1",
+		"address2",
+		"city",
+		"state",
+		"zipcode",
+	];
+
+	const employerQuestionNames = [
+		"heading",
+		"lastDateWorked",
+		"totalHoursWorked",
+		"grossEarnings",
+		"help-moreDetails",
+		"moreDetails",
+	];
+
+	const employerQuestionKeys = employerQuestionNames.map(
+		(name) => "retrocerts-certification.employers." + name
+	);
+
+	function Employers(props) {
+		return employerQuestionKeys.map((questionKey, index) => {
+			const question = t(questionKey);
+			return (
+				<React.Fragment key={index}>
+					<p>{question}</p>
+				</React.Fragment>
+			);
+		});
+	}
+
+	return questionKeys.map((questionKey, index) => {
+		const questionNumber = index + 1;
+		const answer = questionAnswers[index];
+		const showEmployers =
+			questionKey.endsWith("workOrEarn") && answer === "Yes";
+
+		return (
+			<React.Fragment key={index}>
+				<p>
+					{questionNumber}.{" "}
+					<Trans t={t} i18nKey={questionKey} values={{ weekString }} />
+				</p>
+				<p>
+					<strong>{answer}</strong>
+				</p>
+				{showEmployers && <Employers />}
+			</React.Fragment>
+		);
+	});
+}
+WeekConfirmationDetails.propTypes = {
+	questionAnswers: PropTypes.array,
+	questionKeys: PropTypes.arrayOf(PropTypes.string),
+	weekString: PropTypes.string,
+};
+
+export default WeekConfirmationDetails;

--- a/src/client/components/WeekConfirmationDetails/index.js
+++ b/src/client/components/WeekConfirmationDetails/index.js
@@ -3,66 +3,147 @@ import React from "react";
 import { Trans, useTranslation } from "react-i18next";
 
 function WeekConfirmationDetails(props) {
-	const { questionAnswers, questionKeys, weekString } = props;
-	const { t } = useTranslation();
+  const { employers, questionAnswers, questionKeys, weekString } = props;
+  const { t } = useTranslation();
 
-	const employerAddressNames = [
-		"employerName",
-		"address1",
-		"address2",
-		"city",
-		"state",
-		"zipcode",
-	];
+  const employerAddressFieldNames = [
+    "employerName",
+    "address1",
+    "address2",
+    "city",
+    "state",
+    "zipcode",
+  ];
 
-	const employerQuestionNames = [
-		"heading",
-		"lastDateWorked",
-		"totalHoursWorked",
-		"grossEarnings",
-		"help-moreDetails",
-		"moreDetails",
-	];
+  const employerLast5QuestionNames = [
+    "lastDateWorked",
+    "totalHoursWorked",
+    "grossEarnings",
+    "reason",
+    "moreDetails",
+  ];
 
-	const employerQuestionKeys = employerQuestionNames.map(
-		(name) => "retrocerts-certification.employers." + name
-	);
+  const employerLast5QuestionKeys = employerLast5QuestionNames.map((name) =>
+    prefix(name)
+  );
 
-	function Employers(props) {
-		return employerQuestionKeys.map((questionKey, index) => {
-			const question = t(questionKey);
-			return (
-				<React.Fragment key={index}>
-					<p>{question}</p>
-				</React.Fragment>
-			);
-		});
-	}
+  function prefix(key) {
+    return "retrocerts-certification.employers." + key;
+  }
 
-	return questionKeys.map((questionKey, index) => {
-		const questionNumber = index + 1;
-		const answer = questionAnswers[index];
-		const showEmployers =
-			questionKey.endsWith("workOrEarn") && answer === "Yes";
+  function ListOfEmployers(props) {
+    return employers.map((employer, index) => {
+      return <Employer key={index} employerIndex={index} />;
+    });
+  }
 
-		return (
-			<React.Fragment key={index}>
-				<p>
-					{questionNumber}.{" "}
-					<Trans t={t} i18nKey={questionKey} values={{ weekString }} />
-				</p>
-				<p>
-					<strong>{answer}</strong>
-				</p>
-				{showEmployers && <Employers />}
-			</React.Fragment>
-		);
-	});
+  function Employer(props) {
+    const { employerIndex } = props;
+    return (
+      <React.Fragment>
+        <p>{t(prefix("heading"), { incomeNumber: employerIndex + 1 })}</p>
+        <p>
+          <strong>
+            <EmployerAddress employerIndex={employerIndex} />
+          </strong>
+        </p>
+        <EmployerLast5Items employerIndex={employerIndex} />
+      </React.Fragment>
+    );
+  }
+  Employer.propTypes = {
+    employerIndex: PropTypes.number,
+  };
+
+  function EmployerAddress(props) {
+    const { employerIndex } = props;
+    const employer = employers[employerIndex];
+    return employerAddressFieldNames.map((field, index) => {
+      return (
+        <React.Fragment key={index}>
+          {employer[field]}
+          <br />
+        </React.Fragment>
+      );
+    });
+  }
+  EmployerAddress.propTypes = {
+    employerIndex: PropTypes.number,
+  };
+
+  function EmployerLast5Items(props) {
+    const { employerIndex } = props;
+
+    return employerLast5QuestionKeys.map((questionKey, index) => {
+      const question = t(questionKey);
+      const employer = employers[employerIndex];
+      const questionName = employerLast5QuestionNames[index];
+      const answer = getSubmittedAnswer(questionName, employer);
+
+      return (
+        <React.Fragment key={index}>
+          <p>{question}</p>
+          <p>
+            <strong>{answer}</strong>
+          </p>
+        </React.Fragment>
+      );
+    });
+  }
+  EmployerLast5Items.propTypes = {
+    employerIndex: PropTypes.number,
+  };
+
+  function getSubmittedAnswer(questionName, employer) {
+    const answer = employer[questionName];
+    if (answer === "") {
+      // The only case where the answer should be undefined is for
+      // the "number of days you were sick" question, and then only
+      // if the answer to "were you sick" was yes
+      // if (questionName !== "tooSickNumberOfDays" || weekData.tooSick) {
+      //   // TODO turn this into an error we log
+      //   console.log("missing answer", questionName, weekData);
+      // }
+      return "N/A";
+    }
+    if (answer === undefined) {
+      // TODO turn this into an error we log
+      console.log("missing answer", questionName, employer);
+    }
+
+    if (questionName === "reason") {
+      return t(prefix("reason-" + answer));
+    } else if (questionName === "grossEarnings") {
+      return "$" + answer;
+    }
+
+    return answer;
+  }
+
+  return questionKeys.map((questionKey, index) => {
+    const questionNumber = index + 1;
+    const answer = questionAnswers[index];
+    const showEmployers = questionKey.endsWith("workOrEarn") && employers;
+
+    return (
+      <React.Fragment key={index}>
+        <p>
+          {questionNumber}.{" "}
+          <Trans t={t} i18nKey={questionKey} values={{ weekString }} />
+        </p>
+        <p>
+          <strong>{answer}</strong>
+        </p>
+        {showEmployers && <ListOfEmployers />}
+      </React.Fragment>
+    );
+  });
 }
 WeekConfirmationDetails.propTypes = {
-	questionAnswers: PropTypes.array,
-	questionKeys: PropTypes.arrayOf(PropTypes.string),
-	weekString: PropTypes.string,
+  employers: PropTypes.arrayOf(PropTypes.object),
+  questionAnswers: PropTypes.array,
+  questionKeys: PropTypes.arrayOf(PropTypes.string),
+  weekString: PropTypes.string,
 };
 
 export default WeekConfirmationDetails;

--- a/src/client/components/WeekConfirmationDetails/index.js
+++ b/src/client/components/WeekConfirmationDetails/index.js
@@ -113,7 +113,7 @@ function WeekConfirmationDetails(props) {
     if (questionName === "reason") {
       return t(prefix("reason-" + answer));
     } else if (questionName === "grossEarnings") {
-      return "$" + answer;
+      return answer.startsWith("$") ? answer : "$" + answer;
     }
 
     return answer;

--- a/src/client/components/WeekConfirmationDetails/index.js
+++ b/src/client/components/WeekConfirmationDetails/index.js
@@ -47,7 +47,7 @@ function WeekConfirmationDetails(props) {
             <EmployerAddress employerIndex={employerIndex} />
           </strong>
         </p>
-        <EmployerLast5Items employerIndex={employerIndex} />
+        <EmployerDetails employerIndex={employerIndex} />
       </React.Fragment>
     );
   }
@@ -71,7 +71,7 @@ function WeekConfirmationDetails(props) {
     employerIndex: PropTypes.number,
   };
 
-  function EmployerLast5Items(props) {
+  function EmployerDetails(props) {
     const { employerIndex } = props;
 
     return employerDetailsFieldKeys.map((questionKey, index) => {
@@ -90,7 +90,7 @@ function WeekConfirmationDetails(props) {
       );
     });
   }
-  EmployerLast5Items.propTypes = {
+  EmployerDetails.propTypes = {
     employerIndex: PropTypes.number,
   };
 

--- a/src/client/components/WeekConfirmationDetails/index.js
+++ b/src/client/components/WeekConfirmationDetails/index.js
@@ -79,14 +79,17 @@ function WeekConfirmationDetails(props) {
       const employer = employers[employerIndex];
       const questionName = employerDetailsFieldNames[index];
       const answer = getSubmittedAnswer(questionName, employer);
+      const showQuestion = answer !== false;
 
       return (
-        <React.Fragment key={index}>
-          <p>{question}</p>
-          <p>
-            <strong>{answer}</strong>
-          </p>
-        </React.Fragment>
+        showQuestion && (
+          <React.Fragment key={index}>
+            <p>{question}</p>
+            <p>
+              <strong>{answer}</strong>
+            </p>
+          </React.Fragment>
+        )
       );
     });
   }
@@ -100,14 +103,13 @@ function WeekConfirmationDetails(props) {
       // The only case where the answer should be an empty string is for
       // the "provide more details" question, and then only
       // if the answer to "reason you're not working" was "still working PT"
-      return "N/A";
+      return false;
     }
     if (
       answer === undefined ||
       (answer === "" && employer.reason !== "still-working")
     ) {
-      // TODO turn this into an error we log
-      console.log("missing answer", questionName, employer);
+      // TODO(kalvin): log this "missing answer" error in Azure
     }
 
     if (questionName === "reason") {
@@ -120,21 +122,32 @@ function WeekConfirmationDetails(props) {
   }
 
   return questionKeys.map((questionKey, index) => {
-    const questionNumber = index + 1;
+    // Ugly hack to avoid prefixing the second question (a subquestion) with a number
+    const questionNumber = index === 0 ? 1 : index;
     const answer = questionAnswers[index];
+    const showQuestion = answer !== false;
+    // Don't prefix sub-questions with numbers, in order to match actual application
+    const showQuestionNumber = !(
+      questionKey.endsWith("tooSickNumberOfDays") ||
+      questionKey.endsWith("disasterChoice")
+    );
     const showEmployers = questionKey.endsWith("workOrEarn") && employers;
+    const isNotLastItem = index !== questionKeys.length - 1;
 
     return (
-      <React.Fragment key={index}>
-        <p>
-          {questionNumber}.{" "}
-          <Trans t={t} i18nKey={questionKey} values={{ weekString }} />
-        </p>
-        <p>
-          <strong>{answer}</strong>
-        </p>
-        {showEmployers && <ListOfEmployers />}
-      </React.Fragment>
+      showQuestion && (
+        <React.Fragment key={index}>
+          <p>
+            {showQuestionNumber && questionNumber + ". "}
+            <Trans t={t} i18nKey={questionKey} values={{ weekString }} />
+          </p>
+          <p>
+            <strong>{answer}</strong>
+          </p>
+          {showEmployers && <ListOfEmployers />}
+          {isNotLastItem && <hr />}
+        </React.Fragment>
+      )
     );
   });
 }

--- a/src/client/components/WeekConfirmationDetails/index.js
+++ b/src/client/components/WeekConfirmationDetails/index.js
@@ -15,7 +15,7 @@ function WeekConfirmationDetails(props) {
     "zipcode",
   ];
 
-  const employerLast5QuestionNames = [
+  const employerDetailsFieldNames = [
     "lastDateWorked",
     "totalHoursWorked",
     "grossEarnings",
@@ -23,7 +23,7 @@ function WeekConfirmationDetails(props) {
     "moreDetails",
   ];
 
-  const employerLast5QuestionKeys = employerLast5QuestionNames.map((name) =>
+  const employerDetailsFieldKeys = employerDetailsFieldNames.map((name) =>
     prefix(name)
   );
 
@@ -74,10 +74,10 @@ function WeekConfirmationDetails(props) {
   function EmployerLast5Items(props) {
     const { employerIndex } = props;
 
-    return employerLast5QuestionKeys.map((questionKey, index) => {
+    return employerDetailsFieldKeys.map((questionKey, index) => {
       const question = t(questionKey);
       const employer = employers[employerIndex];
-      const questionName = employerLast5QuestionNames[index];
+      const questionName = employerDetailsFieldNames[index];
       const answer = getSubmittedAnswer(questionName, employer);
 
       return (
@@ -97,16 +97,15 @@ function WeekConfirmationDetails(props) {
   function getSubmittedAnswer(questionName, employer) {
     const answer = employer[questionName];
     if (answer === "") {
-      // The only case where the answer should be undefined is for
-      // the "number of days you were sick" question, and then only
-      // if the answer to "were you sick" was yes
-      // if (questionName !== "tooSickNumberOfDays" || weekData.tooSick) {
-      //   // TODO turn this into an error we log
-      //   console.log("missing answer", questionName, weekData);
-      // }
+      // The only case where the answer should be an empty string is for
+      // the "provide more details" question, and then only
+      // if the answer to "reason you're not working" was "still working PT"
       return "N/A";
     }
-    if (answer === undefined) {
+    if (
+      answer === undefined ||
+      (answer === "" && employer.reason !== "still-working")
+    ) {
       // TODO turn this into an error we log
       console.log("missing answer", questionName, employer);
     }

--- a/src/client/components/WeekWithDetail/index.js
+++ b/src/client/components/WeekWithDetail/index.js
@@ -1,0 +1,116 @@
+import Alert from "react-bootstrap/Alert";
+import PropTypes from "prop-types";
+import React from "react";
+import { Trans, useTranslation } from "react-i18next";
+import { startAndEndDate, toWeekString } from "../../../utils/retroCertsWeeks";
+import programPlan from "../../../data/programPlan";
+import WeekConfirmationDetails from "../WeekConfirmationDetails";
+
+function WeekWithDetail(props) {
+  const { index, weekData, weekIndex, weekProgramPlan } = props;
+  const { t } = useTranslation();
+
+  const baseQuestionNames = [
+    "tooSick",
+    "tooSickNumberOfDays",
+    "couldNotAcceptWork",
+    "didYouLook",
+    "refuseWork",
+  ];
+  const uiOnlyQuestionNames = ["schoolOrTraining", "workOrEarn"];
+  const puaOnlyQuestionNames = [
+    "otherBenefits",
+    "workOrEarn",
+    "recentDisaster",
+    "disasterChoice",
+  ];
+
+  // TODO(kalvin): also used in RCCertificationPage, refactor to common place
+  function getQuestionKey(transKey, weekProgramPlan) {
+    if (weekProgramPlan === programPlan.uiPartTime) {
+      return "retrocerts-certification.questions.ui-part-time." + transKey;
+    }
+    if (weekProgramPlan === programPlan.uiFullTime) {
+      return "retrocerts-certification.questions.ui-full-time." + transKey;
+    }
+    if (weekProgramPlan === programPlan.puaFullTime) {
+      return "retrocerts-certification.questions.pua-full-time." + transKey;
+    }
+  }
+
+  function getSubmittedAnswer(questionName, weekData) {
+    const answer = weekData[questionName];
+    if (answer === undefined) {
+      // The only case where the answer should be undefined is for
+      // the "number of days you were sick" question, and then only
+      // if the answer to "were you sick" was yes
+      if (questionName !== "tooSickNumberOfDays" || weekData.tooSick) {
+        // TODO turn this into an error we log
+        console.log("missing answer", questionName, weekData);
+      }
+      return "N/A";
+    }
+
+    // disasterChoice answers are stored in the format "choice-3 TEXT OF Q..."
+    if (questionName === "disasterChoice") {
+      return answer.substring(answer.indexOf(" ") + 1);
+    }
+
+    if (answer === true) {
+      return t("yesnoquestion.Yes");
+    } else if (answer === false) {
+      return t("yesnoquestion.No");
+    }
+    return answer;
+  }
+
+  const weekForUser = index + 1;
+  const dates = startAndEndDate(weekIndex);
+  const weekHasEmployers = weekData.workOrEarn;
+  if (weekHasEmployers && !weekData.employers) {
+    // TODO turn this into an error we log
+    console.log("missing employer(s)");
+  }
+
+  let questionNames;
+  if (weekProgramPlan === programPlan.puaFullTime) {
+    questionNames = baseQuestionNames.concat(puaOnlyQuestionNames);
+  } else {
+    questionNames = baseQuestionNames.concat(uiOnlyQuestionNames);
+  }
+
+  const questionKeys = questionNames.map((questionName) => {
+    return getQuestionKey(questionName, weekProgramPlan);
+  });
+
+  const questionAnswers = questionNames.map((questionName) => {
+    return getSubmittedAnswer(questionName, weekData);
+  });
+
+  return (
+    <Alert variant="secondary" className="d-flex">
+      <div className="flex-fill">
+        <Trans
+          t={t}
+          i18nKey="retrocerts-week-list-item"
+          values={{ ...dates, weekForUser }}
+        />
+        <WeekConfirmationDetails
+          employers={weekHasEmployers ? weekData.employers : undefined}
+          questionAnswers={questionAnswers}
+          questionKeys={questionKeys}
+          weekString={toWeekString(weekIndex)}
+        />
+      </div>
+    </Alert>
+  );
+}
+
+WeekWithDetail.propTypes = {
+  index: PropTypes.number,
+  weekData: PropTypes.object,
+  weekIndex: PropTypes.number,
+  weekProgramPlan: PropTypes.string,
+};
+
+export default WeekWithDetail;

--- a/src/client/pages/RetroCertsCertificationPage/index.js
+++ b/src/client/pages/RetroCertsCertificationPage/index.js
@@ -298,7 +298,7 @@ function RetroCertsCertificationPage(props) {
                 inputName="recentDisaster"
               >
                 <DisasterQuestion
-                  questionText={t(questionText("recentDisasterChoice"))}
+                  questionText={t(questionText("disasterChoice"))}
                   choice={formData.disasterChoice}
                   onChange={(e) => handleFormDataChange(e)}
                 />

--- a/src/client/pages/RetroCertsConfirmationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsConfirmationPage/__snapshots__/index.test.js.snap
@@ -78,18 +78,62 @@ exports[`<RetroCertsConfirmationPage /> with confirmation number 1`] = `
       >
         Retroactive Certification Weeks
       </h2>
-      <ListOfWeeks
-        showChecks={true}
-        weeksToCertify={
-          Array [
-            0,
-            1,
-            2,
-            5,
-            6,
-          ]
+      <ListOfWeeksWithDetail
+        userData={
+          Object {
+            "confirmationNumber": "CONFIRMATION_NUMBER",
+            "programPlan": Array [
+              "PUA full time",
+            ],
+            "status": "ok",
+            "weeksToCertify": Array [
+              0,
+              1,
+              2,
+              5,
+              6,
+            ],
+          }
         }
       />
+      <Alert
+        className="d-flex"
+        closeLabel="Close alert"
+        show={true}
+        transition={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "defaultProps": Object {
+              "appear": false,
+              "in": false,
+              "mountOnEnter": false,
+              "timeout": 300,
+              "unmountOnExit": false,
+            },
+            "displayName": "Fade",
+            "render": [Function],
+          }
+        }
+        variant="secondary"
+      >
+        <div
+          className="flex-fill"
+        >
+          <button
+            className="toggleAccordion"
+            onClick={[Function]}
+          >
+            <span
+              className="toggleCharacter"
+            >
+              +
+            </span>
+            <strong>
+              Acknowledgement
+            </strong>
+          </button>
+        </div>
+      </Alert>
       <h2
         className="mt-5"
       >

--- a/src/client/pages/RetroCertsConfirmationPage/_index.scss
+++ b/src/client/pages/RetroCertsConfirmationPage/_index.scss
@@ -1,5 +1,5 @@
 .toggleAccordion {
-  border-width: 0px;
+  border-width: 0;
   background-color: inherit;
 }
 

--- a/src/client/pages/RetroCertsConfirmationPage/_index.scss
+++ b/src/client/pages/RetroCertsConfirmationPage/_index.scss
@@ -1,0 +1,26 @@
+.toggleAccordion {
+  border-width: 0px;
+  background-color: inherit;
+}
+
+.toggleCharacter {
+  padding-right: 20px;
+  font-weight: bold;
+}
+
+.detail {
+  padding: 20px;
+  border: 1px solid #d6d8db;
+  margin-top: -20px;
+  margin-bottom: 20px;
+}
+
+.detail ul {
+  padding-left: 20px;
+}
+
+input[type="checkbox"] {
+  margin-right: 10px;
+  height: 15px;
+  width: 15px;
+}

--- a/src/client/pages/RetroCertsConfirmationPage/index.js
+++ b/src/client/pages/RetroCertsConfirmationPage/index.js
@@ -38,7 +38,7 @@ function RetroCertsConfirmationPage(props) {
     .toUpperCase();
 
   // Log out the user since they are done!
-  // clearAuthToken();
+  clearAuthToken();
 
   const isReturning =
     history.location.state && history.location.state.isReturning;

--- a/src/client/pages/RetroCertsConfirmationPage/index.js
+++ b/src/client/pages/RetroCertsConfirmationPage/index.js
@@ -8,7 +8,7 @@ import routes from "../../../data/routes";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header";
 import LanguageSelector from "../../components/LanguageSelector";
-import ListOfWeeks from "../../components/ListOfWeeks";
+import ListOfWeeksWithDetail from "../../components/ListOfWeeksWithDetail";
 import { logEvent } from "../../utils";
 import { clearAuthToken } from "../../components/SessionTimer";
 
@@ -34,7 +34,7 @@ function RetroCertsConfirmationPage(props) {
     .toUpperCase();
 
   // Log out the user since they are done!
-  clearAuthToken();
+  // clearAuthToken();
 
   const isReturning =
     history.location.state && history.location.state.isReturning;
@@ -77,7 +77,7 @@ function RetroCertsConfirmationPage(props) {
           <p>{t("retrocerts-confirmation.p1a")}</p>
           <p>{t("retrocerts-confirmation.p1b")}</p>
           <h2 className="mt-5">{t("retrocerts-confirmation.header2")}</h2>
-          <ListOfWeeks weeksToCertify={userData.weeksToCertify} showChecks />
+          <ListOfWeeksWithDetail userData={userData} />
 
           <h2 className="mt-5">{t("retrocerts-confirmation.header3")}</h2>
           <p>

--- a/src/client/pages/RetroCertsConfirmationPage/index.js
+++ b/src/client/pages/RetroCertsConfirmationPage/index.js
@@ -1,7 +1,7 @@
 import Button from "react-bootstrap/Button";
 import { Redirect, useHistory } from "react-router-dom";
 import Alert from "react-bootstrap/Alert";
-import React from "react";
+import React, { useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
 import { userDataPropType } from "../../commonPropTypes";
 import routes from "../../../data/routes";
@@ -11,12 +11,16 @@ import LanguageSelector from "../../components/LanguageSelector";
 import ListOfWeeksWithDetail from "../../components/ListOfWeeksWithDetail";
 import { logEvent } from "../../utils";
 import { clearAuthToken } from "../../components/SessionTimer";
+import programPlan from "../../../data/programPlan";
 
 function RetroCertsConfirmationPage(props) {
   const { t } = useTranslation();
   document.title = t("retrocerts-confirmation.title");
   const history = useHistory();
   const userData = props.userData;
+  const isAnyWeekPua = userData.programPlan.includes(programPlan.puaFullTime);
+
+  const [showDetail, setShowDetail] = useState(false);
 
   // The user is here by accident. Send them back.
   if (!userData.confirmationNumber) {
@@ -47,6 +51,30 @@ function RetroCertsConfirmationPage(props) {
     window.print();
   }
 
+  function AcknowledgementDetail(props) {
+    return (
+      <div className="detail">
+        {isAnyWeekPua ? (
+          <ul>
+            <li>{t("retrocerts-certification.ack-list-pua-item-1")}</li>
+            <li>{t("retrocerts-certification.ack-list-pua-item-2")}</li>
+            <li>{t("retrocerts-certification.ack-list-pua-item-3")}</li>
+          </ul>
+        ) : (
+          <ul>
+            <li>{t("retrocerts-certification.ack-list-item-1")}</li>
+            <li>{t("retrocerts-certification.ack-list-item-2")}</li>
+            <li>{t("retrocerts-certification.ack-list-item-3")}</li>
+            <li>{t("retrocerts-certification.ack-list-item-4")}</li>
+          </ul>
+        )}
+        <input type="checkbox" checked disabled />
+        {t("retrocerts-certification.ack-label")}
+      </div>
+    );
+  }
+
+  const EN_DASH = "–";
   return (
     <div id="overflow-wrapper">
       <Header />
@@ -78,6 +106,20 @@ function RetroCertsConfirmationPage(props) {
           <p>{t("retrocerts-confirmation.p1b")}</p>
           <h2 className="mt-5">{t("retrocerts-confirmation.header2")}</h2>
           <ListOfWeeksWithDetail userData={userData} />
+          <Alert variant="secondary" className="d-flex">
+            <div className="flex-fill">
+              <button
+                className="toggleAccordion"
+                onClick={() => setShowDetail(!showDetail)}
+              >
+                <span className="toggleCharacter">
+                  {showDetail ? EN_DASH : "+"}
+                </span>
+                <strong>{t("retrocerts-certification.ack-header")}</strong>
+              </button>
+            </div>
+          </Alert>
+          {showDetail && <AcknowledgementDetail className="detail" />}
 
           <h2 className="mt-5">{t("retrocerts-confirmation.header3")}</h2>
           <p>

--- a/src/client/pages/RetroCertsConfirmationPage/index.test.js
+++ b/src/client/pages/RetroCertsConfirmationPage/index.test.js
@@ -12,6 +12,7 @@ describe("<RetroCertsConfirmationPage />", () => {
           status: AUTH_STRINGS.statusCode.ok,
           weeksToCertify: [0, 1, 2, 5, 6],
           confirmationNumber: "CONFIRMATION_NUMBER",
+          programPlan: ["PUA full time"],
         },
         setUserData: () => {},
       }
@@ -28,6 +29,7 @@ describe("<RetroCertsConfirmationPage />", () => {
         userData: {
           status: AUTH_STRINGS.statusCode.ok,
           weeksToCertify: [0, 1, 2, 5, 6],
+          programPlan: ["UI full time"],
         },
         setUserData: () => {},
       }

--- a/src/data/locales/en/translation.json
+++ b/src/data/locales/en/translation.json
@@ -277,8 +277,7 @@
         "workOrEarn": "Did you work or earn money, <strong>whether you were paid or not</strong>? If self-employed, report earnings during the week you receive the money.",
         "help-workOrEarn": "Look at the date each week begins and ends. If you performed any work during this week, the earnings must be reported regardless if you received payment or not. This does not include self-employment.",
         "recentDisaster": "Are you unemployed as a direct result of a recent disaster (for example: COVID-19, earthquake, flood, mudslide, or fire) in California?",
-        "disasterChoice": "Select the option for how you were impacted by the COVID-19 pandemic.",
-        "recentDisasterChoice": "Select the option for how you were impacted by the COVID-19 pandemic."
+        "disasterChoice": "Select the option for how you were impacted by the COVID-19 pandemic."
       }
     },
     "q-workOrEarn": "Did you work or earn any money, whether you were paid or not?",

--- a/src/data/locales/en/translation.json
+++ b/src/data/locales/en/translation.json
@@ -277,6 +277,7 @@
         "workOrEarn": "Did you work or earn money, <strong>whether you were paid or not</strong>? If self-employed, report earnings during the week you receive the money.",
         "help-workOrEarn": "Look at the date each week begins and ends. If you performed any work during this week, the earnings must be reported regardless if you received payment or not. This does not include self-employment.",
         "recentDisaster": "Are you unemployed as a direct result of a recent disaster (for example: COVID-19, earthquake, flood, mudslide, or fire) in California?",
+        "disasterChoice": "Select the option for how you were impacted by the COVID-19 pandemic.",
         "recentDisasterChoice": "Select the option for how you were impacted by the COVID-19 pandemic."
       }
     },

--- a/src/data/locales/es/translation.json
+++ b/src/data/locales/es/translation.json
@@ -277,8 +277,7 @@
         "workOrEarn": "¿Trabajó o ganó algún dinero, sin importar si le pagaron o no? Si trabaja por cuenta propia, reporte sus ingresos durante la semana en que recibe el dinero.",
         "help-workOrEarn": "Revise la fecha en que comienza y termina cada semana. Si realizó algún trabajo durante esta semana, los ingresos deben reportarse independientemente si recibió paga o no. Esto no incluye empleo por cuenta propia.",
         "recentDisaster": "¿Está usted desempleado(a) como resultado directo de un desastre reciente (por ejemplo: COVID-19, terremoto, inundación, deslizamiento de tierra, incendio, etc.) que haya ocurrido en California?",
-        "disasterChoice": "Seleccione la opción de cómo se vio afectado por la pandemia de COVID-19.",
-        "recentDisasterChoice": "Seleccione la opción de cómo se vio afectado por la pandemia de COVID-19."
+        "disasterChoice": "Seleccione la opción de cómo se vio afectado por la pandemia de COVID-19."
       }
     },
     "employers": {

--- a/src/data/locales/es/translation.json
+++ b/src/data/locales/es/translation.json
@@ -277,6 +277,7 @@
         "workOrEarn": "¿Trabajó o ganó algún dinero, sin importar si le pagaron o no? Si trabaja por cuenta propia, reporte sus ingresos durante la semana en que recibe el dinero.",
         "help-workOrEarn": "Revise la fecha en que comienza y termina cada semana. Si realizó algún trabajo durante esta semana, los ingresos deben reportarse independientemente si recibió paga o no. Esto no incluye empleo por cuenta propia.",
         "recentDisaster": "¿Está usted desempleado(a) como resultado directo de un desastre reciente (por ejemplo: COVID-19, terremoto, inundación, deslizamiento de tierra, incendio, etc.) que haya ocurrido en California?",
+        "disasterChoice": "Seleccione la opción de cómo se vio afectado por la pandemia de COVID-19.",
         "recentDisasterChoice": "Seleccione la opción de cómo se vio afectado por la pandemia de COVID-19."
       }
     },


### PR DESCRIPTION
This PR creates the new detailed confirmation page.

I merged #487 into this branch so the screenshot below is the same as that one

![095 - Retroactive Certification for Unemployment - localhost](https://user-images.githubusercontent.com/82277/87833608-43e44f00-c856-11ea-8c54-4db0ecdf7178.jpg)

===

Resolves #344

- [x] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [x] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [x] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
