### PR TITLE
Add timeout & retry logic to reCaptcha validation

### DIFF
--- a/src/services/reCaptcha.js
+++ b/src/services/reCaptcha.js
@@ -14,11 +14,25 @@ class ReCaptcha {
 
   async askGoogle() {
     const postUrl = `${this.url}?secret=${this.secret}&response=${this.userToken}`;
+    const postData = {};
+    // The 99th percentile of requests takes 128ms. 2s should be plenty of time.
+    const timeoutMs = 2 * 1000;
+    const numAttempts = 3;
+    const config = {
+      timeout: timeoutMs,
+    };
 
-    // TODO: Add error handling
-    const response = await axios.post(postUrl, {});
-
-    return response;
+    let axiosError = null;
+    for (let i = 0; i < numAttempts; ++i) {
+      try {
+        const response = await axios.post(postUrl, postData, config);
+        return response;
+      } catch (e) {
+        // There was a timeout or some other error. Try again.
+        axiosError = e;
+      }
+    }
+    throw axiosError;
   }
 }
 

--- a/src/services/reCaptcha.test.js
+++ b/src/services/reCaptcha.test.js
@@ -3,11 +3,72 @@
  */
 
 const ReCaptcha = require("./reCaptcha");
+const axios = require("axios");
 
 describe("ReCaptcha", () => {
   it("validates user", async () => {
     const reCaptcha = new ReCaptcha("userToken");
     const isUserValid = await reCaptcha.validateUser();
     expect(isUserValid).toBe(true);
+  });
+
+  it("Test 1 timeout", async () => {
+    const axiosPostMock = jest.spyOn(axios, "post");
+    let numFuncCalls = 0;
+    axiosPostMock.mockImplementation(
+      jest.fn(async () => {
+        ++numFuncCalls;
+        if (numFuncCalls % 2 === 0) {
+          return { data: { success: true } };
+        } else {
+          throw Error("mock timeout");
+        }
+      })
+    );
+
+    const reCaptcha = new ReCaptcha("userToken");
+    const isUserValid = await reCaptcha.validateUser();
+    expect(isUserValid).toBe(true);
+    expect(numFuncCalls).toBe(2);
+
+    axiosPostMock.mockRestore();
+  });
+
+  it("Test 2 timeouts", async () => {
+    const axiosPostMock = jest.spyOn(axios, "post");
+    let numFuncCalls = 0;
+    axiosPostMock.mockImplementation(
+      jest.fn(async () => {
+        ++numFuncCalls;
+        if (numFuncCalls % 3 === 0) {
+          return { data: { success: true } };
+        } else {
+          throw Error("mock timeout");
+        }
+      })
+    );
+
+    const reCaptcha = new ReCaptcha("userToken");
+    const isUserValid = await reCaptcha.validateUser();
+    expect(isUserValid).toBe(true);
+    expect(numFuncCalls).toBe(3);
+
+    axiosPostMock.mockRestore();
+  });
+
+  it("Test 3 timeouts", async () => {
+    const axiosPostMock = jest.spyOn(axios, "post");
+    let numFuncCalls = 0;
+    axiosPostMock.mockImplementation(
+      jest.fn(async () => {
+        ++numFuncCalls;
+        throw Error("mock timeout");
+      })
+    );
+
+    const reCaptcha = new ReCaptcha("userToken");
+    await expect(reCaptcha.validateUser()).rejects.toThrow("mock timeout");
+    expect(numFuncCalls).toBe(3);
+    axiosPostMock.mockRestore();
   });
 });


### PR DESCRIPTION
We see a few requests to reCaptcha timeout after 60s.
Use a 5s timeout (most requests take < 250ms) and
allow up to 3 attempts to reach reCaptcha before
timing giving up.

===

Resolves #XXX

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [X] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
