### PR TITLE
Style detailed confirmation page

### DIFF
--- a/src/client/App.scss
+++ b/src/client/App.scss
@@ -32,7 +32,6 @@ $font-family-sans-serif: "Source Sans Pro", sans-serif !default;
 @import "components/TabbedContainer/index";
 @import "components/DisasterQuestion/index";
 @import "pages/RetroCertsConfirmationPage/index";
-@import "components/WeekWithDetail/index";
 
 h1,
 h2,

--- a/src/client/App.scss
+++ b/src/client/App.scss
@@ -31,6 +31,8 @@ $font-family-sans-serif: "Source Sans Pro", sans-serif !default;
 @import "components/Footer/index";
 @import "components/TabbedContainer/index";
 @import "components/DisasterQuestion/index";
+@import "pages/RetroCertsConfirmationPage/index";
+@import "components/WeekWithDetail/index";
 
 h1,
 h2,

--- a/src/client/components/WeekConfirmationDetails/index.js
+++ b/src/client/components/WeekConfirmationDetails/index.js
@@ -109,8 +109,7 @@ function WeekConfirmationDetails(props) {
       answer === undefined ||
       (answer === "" && employer.reason !== "still-working")
     ) {
-      // TODO turn this into an error we log
-      console.log("missing answer", questionName, employer);
+      // TODO(kalvin): log this "missing answer" error in Azure
     }
 
     if (questionName === "reason") {

--- a/src/client/components/WeekConfirmationDetails/index.js
+++ b/src/client/components/WeekConfirmationDetails/index.js
@@ -122,13 +122,18 @@ function WeekConfirmationDetails(props) {
   return questionKeys.map((questionKey, index) => {
     const questionNumber = index + 1;
     const answer = questionAnswers[index];
+    // Don't prefix sub-questions with numbers, in order to match actual application
+    const showQuestionNumber = !(
+      questionKey.endsWith("tooSickNumberOfDays") ||
+      questionKey.endsWith("disasterChoice")
+    );
     const showEmployers = questionKey.endsWith("workOrEarn") && employers;
     const isNotLastItem = index !== questionKeys.length - 1;
 
     return (
       <React.Fragment key={index}>
         <p>
-          {questionNumber}.{" "}
+          {showQuestionNumber && questionNumber + ". "}
           <Trans t={t} i18nKey={questionKey} values={{ weekString }} />
         </p>
         <p>

--- a/src/client/components/WeekConfirmationDetails/index.js
+++ b/src/client/components/WeekConfirmationDetails/index.js
@@ -123,6 +123,7 @@ function WeekConfirmationDetails(props) {
     const questionNumber = index + 1;
     const answer = questionAnswers[index];
     const showEmployers = questionKey.endsWith("workOrEarn") && employers;
+    const isNotLastItem = index !== questionKeys.length - 1;
 
     return (
       <React.Fragment key={index}>
@@ -134,6 +135,7 @@ function WeekConfirmationDetails(props) {
           <strong>{answer}</strong>
         </p>
         {showEmployers && <ListOfEmployers />}
+        {isNotLastItem && <hr />}
       </React.Fragment>
     );
   });

--- a/src/client/components/WeekConfirmationDetails/index.js
+++ b/src/client/components/WeekConfirmationDetails/index.js
@@ -79,14 +79,17 @@ function WeekConfirmationDetails(props) {
       const employer = employers[employerIndex];
       const questionName = employerDetailsFieldNames[index];
       const answer = getSubmittedAnswer(questionName, employer);
+      const showQuestion = answer !== false;
 
       return (
-        <React.Fragment key={index}>
-          <p>{question}</p>
-          <p>
-            <strong>{answer}</strong>
-          </p>
-        </React.Fragment>
+        showQuestion && (
+          <React.Fragment key={index}>
+            <p>{question}</p>
+            <p>
+              <strong>{answer}</strong>
+            </p>
+          </React.Fragment>
+        )
       );
     });
   }
@@ -100,7 +103,7 @@ function WeekConfirmationDetails(props) {
       // The only case where the answer should be an empty string is for
       // the "provide more details" question, and then only
       // if the answer to "reason you're not working" was "still working PT"
-      return "N/A";
+      return false;
     }
     if (
       answer === undefined ||
@@ -120,8 +123,10 @@ function WeekConfirmationDetails(props) {
   }
 
   return questionKeys.map((questionKey, index) => {
-    const questionNumber = index + 1;
+    // Ugly hack to avoid prefixing the second question (a subquestion) with a number
+    const questionNumber = index === 0 ? 1 : index;
     const answer = questionAnswers[index];
+    const showQuestion = answer !== false;
     // Don't prefix sub-questions with numbers, in order to match actual application
     const showQuestionNumber = !(
       questionKey.endsWith("tooSickNumberOfDays") ||
@@ -131,17 +136,19 @@ function WeekConfirmationDetails(props) {
     const isNotLastItem = index !== questionKeys.length - 1;
 
     return (
-      <React.Fragment key={index}>
-        <p>
-          {showQuestionNumber && questionNumber + ". "}
-          <Trans t={t} i18nKey={questionKey} values={{ weekString }} />
-        </p>
-        <p>
-          <strong>{answer}</strong>
-        </p>
-        {showEmployers && <ListOfEmployers />}
-        {isNotLastItem && <hr />}
-      </React.Fragment>
+      showQuestion && (
+        <React.Fragment key={index}>
+          <p>
+            {showQuestionNumber && questionNumber + ". "}
+            <Trans t={t} i18nKey={questionKey} values={{ weekString }} />
+          </p>
+          <p>
+            <strong>{answer}</strong>
+          </p>
+          {showEmployers && <ListOfEmployers />}
+          {isNotLastItem && <hr />}
+        </React.Fragment>
+      )
     );
   });
 }

--- a/src/client/components/WeekWithDetail/_index.scss
+++ b/src/client/components/WeekWithDetail/_index.scss
@@ -1,0 +1,4 @@
+.toggleAccordion {
+	border-width: 0px;
+	background-color: inherit;
+}

--- a/src/client/components/WeekWithDetail/_index.scss
+++ b/src/client/components/WeekWithDetail/_index.scss
@@ -1,4 +1,0 @@
-.toggleAccordion {
-	border-width: 0px;
-	background-color: inherit;
-}

--- a/src/client/components/WeekWithDetail/index.js
+++ b/src/client/components/WeekWithDetail/index.js
@@ -89,27 +89,40 @@ function WeekWithDetail(props) {
     return getSubmittedAnswer(questionName, weekData);
   });
 
+  // TODO(kalvin): refactor collapsible accordion item from here and Acknowledgement
+  // in RetroCertsConfirmationPage out to common file
+  const EN_DASH = "–";
   return (
-    <Alert variant="secondary" className="d-flex">
-      <div className="flex-fill">
-        <button onClick={() => setShowDetail(!showDetail)}>
-          {showDetail ? "-" : "+"}
-        </button>
-        <Trans
-          t={t}
-          i18nKey="retrocerts-week-list-item"
-          values={{ ...dates, weekForUser }}
-        />
-        {showDetail && (
+    <React.Fragment>
+      <Alert variant="secondary" className="d-flex">
+        <div className="flex-fill">
+          <button
+            className="toggleAccordion"
+            onClick={() => setShowDetail(!showDetail)}
+          >
+            <span className="toggleCharacter">
+              {showDetail ? EN_DASH : "+"}
+            </span>
+            <Trans
+              t={t}
+              i18nKey="retrocerts-week-list-item"
+              values={{ ...dates, weekForUser }}
+            />
+          </button>
+        </div>
+      </Alert>
+
+      {showDetail && (
+        <div className="detail">
           <WeekConfirmationDetails
             employers={weekHasEmployers ? weekData.employers : undefined}
             questionAnswers={questionAnswers}
             questionKeys={questionKeys}
             weekString={toWeekString(weekIndex)}
           />
-        )}
-      </div>
-    </Alert>
+        </div>
+      )}
+    </React.Fragment>
   );
 }
 

--- a/src/client/components/WeekWithDetail/index.js
+++ b/src/client/components/WeekWithDetail/index.js
@@ -47,8 +47,7 @@ function WeekWithDetail(props) {
       // the "number of days you were sick" question, and then only
       // if the answer to "were you sick" was yes
       if (questionName !== "tooSickNumberOfDays" || weekData.tooSick) {
-        // TODO turn this into an error we log
-        console.log("missing answer", questionName, weekData);
+        // TODO(kalvin): log this error in Azure
       }
       return false;
     }
@@ -73,8 +72,7 @@ function WeekWithDetail(props) {
   const dates = startAndEndDate(weekIndex);
   const weekHasEmployers = weekData.workOrEarn;
   if (weekHasEmployers && !weekData.employers) {
-    // TODO turn this into an error we log
-    console.log("missing employer(s)");
+    // TODO(kalvin): log this "missing employer(s)" error in Azure
   }
 
   let questionNames;

--- a/src/client/components/WeekWithDetail/index.js
+++ b/src/client/components/WeekWithDetail/index.js
@@ -50,7 +50,7 @@ function WeekWithDetail(props) {
         // TODO turn this into an error we log
         console.log("missing answer", questionName, weekData);
       }
-      return "N/A";
+      return false;
     }
 
     // disasterChoice answers are stored in the format "choice-3 TEXT OF Q..."

--- a/src/client/components/WeekWithDetail/index.js
+++ b/src/client/components/WeekWithDetail/index.js
@@ -55,7 +55,9 @@ function WeekWithDetail(props) {
 
     // disasterChoice answers are stored in the format "choice-3 TEXT OF Q..."
     if (questionName === "disasterChoice") {
-      return answer.substring(answer.indexOf(" ") + 1);
+      return t(
+        "retrocerts-certification.disaster-choices." + answer.split(" ")[0]
+      );
     }
 
     if (answer === true) {

--- a/src/client/components/WeekWithDetail/index.js
+++ b/src/client/components/WeekWithDetail/index.js
@@ -54,6 +54,7 @@ function WeekWithDetail(props) {
     }
 
     // disasterChoice answers are stored in the format "choice-3 TEXT OF Q..."
+    // Show answer in language selected on the page, not the original language submitted
     if (questionName === "disasterChoice") {
       return t(
         "retrocerts-certification.disaster-choices." + answer.split(" ")[0]

--- a/src/client/components/WeekWithDetail/index.js
+++ b/src/client/components/WeekWithDetail/index.js
@@ -1,6 +1,6 @@
 import Alert from "react-bootstrap/Alert";
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { startAndEndDate, toWeekString } from "../../../utils/retroCertsWeeks";
 import programPlan from "../../../data/programPlan";
@@ -9,6 +9,8 @@ import WeekConfirmationDetails from "../WeekConfirmationDetails";
 function WeekWithDetail(props) {
   const { index, weekData, weekIndex, weekProgramPlan } = props;
   const { t } = useTranslation();
+
+  const [showDetail, setShowDetail] = useState(false);
 
   const baseQuestionNames = [
     "tooSick",
@@ -90,17 +92,22 @@ function WeekWithDetail(props) {
   return (
     <Alert variant="secondary" className="d-flex">
       <div className="flex-fill">
+        <button onClick={() => setShowDetail(!showDetail)}>
+          {showDetail ? "-" : "+"}
+        </button>
         <Trans
           t={t}
           i18nKey="retrocerts-week-list-item"
           values={{ ...dates, weekForUser }}
         />
-        <WeekConfirmationDetails
-          employers={weekHasEmployers ? weekData.employers : undefined}
-          questionAnswers={questionAnswers}
-          questionKeys={questionKeys}
-          weekString={toWeekString(weekIndex)}
-        />
+        {showDetail && (
+          <WeekConfirmationDetails
+            employers={weekHasEmployers ? weekData.employers : undefined}
+            questionAnswers={questionAnswers}
+            questionKeys={questionKeys}
+            weekString={toWeekString(weekIndex)}
+          />
+        )}
       </div>
     </Alert>
   );

--- a/src/client/pages/RetroCertsConfirmationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsConfirmationPage/__snapshots__/index.test.js.snap
@@ -78,18 +78,62 @@ exports[`<RetroCertsConfirmationPage /> with confirmation number 1`] = `
       >
         Retroactive Certification Weeks
       </h2>
-      <ListOfWeeks
-        showChecks={true}
-        weeksToCertify={
-          Array [
-            0,
-            1,
-            2,
-            5,
-            6,
-          ]
+      <ListOfWeeksWithDetail
+        userData={
+          Object {
+            "confirmationNumber": "CONFIRMATION_NUMBER",
+            "programPlan": Array [
+              "PUA full time",
+            ],
+            "status": "ok",
+            "weeksToCertify": Array [
+              0,
+              1,
+              2,
+              5,
+              6,
+            ],
+          }
         }
       />
+      <Alert
+        className="d-flex"
+        closeLabel="Close alert"
+        show={true}
+        transition={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "defaultProps": Object {
+              "appear": false,
+              "in": false,
+              "mountOnEnter": false,
+              "timeout": 300,
+              "unmountOnExit": false,
+            },
+            "displayName": "Fade",
+            "render": [Function],
+          }
+        }
+        variant="secondary"
+      >
+        <div
+          className="flex-fill"
+        >
+          <button
+            className="toggleAccordion"
+            onClick={[Function]}
+          >
+            <span
+              className="toggleCharacter"
+            >
+              +
+            </span>
+            <strong>
+              Acknowledgement
+            </strong>
+          </button>
+        </div>
+      </Alert>
       <h2
         className="mt-5"
       >

--- a/src/client/pages/RetroCertsConfirmationPage/_index.scss
+++ b/src/client/pages/RetroCertsConfirmationPage/_index.scss
@@ -15,6 +15,10 @@
 	margin-bottom: 20px;
 }
 
+.detail ul {
+	padding-left: 20px;
+}
+
 input[type="checkbox"] {
 	margin-right: 10px;
 	height: 15px;

--- a/src/client/pages/RetroCertsConfirmationPage/_index.scss
+++ b/src/client/pages/RetroCertsConfirmationPage/_index.scss
@@ -1,0 +1,22 @@
+.toggleAccordion {
+	border-width: 0px;
+	background-color: inherit;
+}
+
+.toggleCharacter {
+	padding-right: 20px;
+	font-weight: bold;
+}
+
+.detail {
+	padding: 20px;
+	border: 1px solid #d6d8db;
+	margin-top: -20px;
+	margin-bottom: 20px;
+}
+
+input[type="checkbox"] {
+	margin-right: 10px;
+	height: 15px;
+	width: 15px;
+}

--- a/src/client/pages/RetroCertsConfirmationPage/_index.scss
+++ b/src/client/pages/RetroCertsConfirmationPage/_index.scss
@@ -1,26 +1,26 @@
 .toggleAccordion {
-	border-width: 0px;
-	background-color: inherit;
+  border-width: 0px;
+  background-color: inherit;
 }
 
 .toggleCharacter {
-	padding-right: 20px;
-	font-weight: bold;
+  padding-right: 20px;
+  font-weight: bold;
 }
 
 .detail {
-	padding: 20px;
-	border: 1px solid #d6d8db;
-	margin-top: -20px;
-	margin-bottom: 20px;
+  padding: 20px;
+  border: 1px solid #d6d8db;
+  margin-top: -20px;
+  margin-bottom: 20px;
 }
 
 .detail ul {
-	padding-left: 20px;
+  padding-left: 20px;
 }
 
 input[type="checkbox"] {
-	margin-right: 10px;
-	height: 15px;
-	width: 15px;
+  margin-right: 10px;
+  height: 15px;
+  width: 15px;
 }

--- a/src/client/pages/RetroCertsConfirmationPage/index.js
+++ b/src/client/pages/RetroCertsConfirmationPage/index.js
@@ -1,7 +1,7 @@
 import Button from "react-bootstrap/Button";
 import { Redirect, useHistory } from "react-router-dom";
 import Alert from "react-bootstrap/Alert";
-import React from "react";
+import React, { useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
 import { userDataPropType } from "../../commonPropTypes";
 import routes from "../../../data/routes";
@@ -11,12 +11,16 @@ import LanguageSelector from "../../components/LanguageSelector";
 import ListOfWeeksWithDetail from "../../components/ListOfWeeksWithDetail";
 import { logEvent } from "../../utils";
 import { clearAuthToken } from "../../components/SessionTimer";
+import programPlan from "../../../data/programPlan";
 
 function RetroCertsConfirmationPage(props) {
   const { t } = useTranslation();
   document.title = t("retrocerts-confirmation.title");
   const history = useHistory();
   const userData = props.userData;
+  const isAnyWeekPua = userData.programPlan.includes(programPlan.puaFullTime);
+
+  const [showDetail, setShowDetail] = useState(false);
 
   // The user is here by accident. Send them back.
   if (!userData.confirmationNumber) {
@@ -47,6 +51,30 @@ function RetroCertsConfirmationPage(props) {
     window.print();
   }
 
+  function AcknowledgementDetail(props) {
+    return (
+      <div className="detail">
+        {isAnyWeekPua ? (
+          <ul>
+            <li>{t("retrocerts-certification.ack-list-pua-item-1")}</li>
+            <li>{t("retrocerts-certification.ack-list-pua-item-2")}</li>
+            <li>{t("retrocerts-certification.ack-list-pua-item-3")}</li>
+          </ul>
+        ) : (
+          <ul>
+            <li>{t("retrocerts-certification.ack-list-item-1")}</li>
+            <li>{t("retrocerts-certification.ack-list-item-2")}</li>
+            <li>{t("retrocerts-certification.ack-list-item-3")}</li>
+            <li>{t("retrocerts-certification.ack-list-item-4")}</li>
+          </ul>
+        )}
+        <input type="checkbox" checked disabled />
+        {t("retrocerts-certification.ack-label")}
+      </div>
+    );
+  }
+
+  const EN_DASH = "–";
   return (
     <div id="overflow-wrapper">
       <Header />
@@ -78,6 +106,20 @@ function RetroCertsConfirmationPage(props) {
           <p>{t("retrocerts-confirmation.p1b")}</p>
           <h2 className="mt-5">{t("retrocerts-confirmation.header2")}</h2>
           <ListOfWeeksWithDetail userData={userData} />
+          <Alert variant="secondary" className="d-flex">
+            <div className="flex-fill">
+              <button
+                className="toggleAccordion"
+                onClick={() => setShowDetail(!showDetail)}
+              >
+                <span className="toggleCharacter">
+                  {showDetail ? EN_DASH : "+"}
+                </span>
+                <strong>{t("retrocerts-certification.ack-header")}</strong>
+              </button>
+            </div>
+          </Alert>
+          {showDetail && <AcknowledgementDetail className="detail" />}
 
           <h2 className="mt-5">{t("retrocerts-confirmation.header3")}</h2>
           <p>

--- a/src/client/pages/RetroCertsConfirmationPage/index.test.js
+++ b/src/client/pages/RetroCertsConfirmationPage/index.test.js
@@ -12,6 +12,7 @@ describe("<RetroCertsConfirmationPage />", () => {
           status: AUTH_STRINGS.statusCode.ok,
           weeksToCertify: [0, 1, 2, 5, 6],
           confirmationNumber: "CONFIRMATION_NUMBER",
+          programPlan: ["PUA full time"],
         },
         setUserData: () => {},
       }
@@ -28,6 +29,7 @@ describe("<RetroCertsConfirmationPage />", () => {
         userData: {
           status: AUTH_STRINGS.statusCode.ok,
           weeksToCertify: [0, 1, 2, 5, 6],
+          programPlan: ["UI full time"],
         },
         setUserData: () => {},
       }


### PR DESCRIPTION
This PR styles the new detailed confirmation page and adds the expand/collapse functionality

Remaining todos:
- [x] Incorporate new translated content and aria label for buttons ("Show details for this week")
- [x] Don't show sub-questions that didn't appear when user certified (in a prior version of this PR it showed the question and N/A as the answer)
- [x] Don't prefix sub-questions with numbers
- [x] Align bullets in Acknowledgement with questions
- [x] Show dropdown answers in language selected on the page, not the original language of the user
- [x] fix test
- [x] add snapshots

Will do as part of separate detailed confirmation page followup ticket:
- [ ] Print CSS should expand all sections
- [ ] Make entire gray bar clickable not just the title text
- [ ] Refactor to reuse common code per TODOs in code
- [ ] Log some of the errors in Azure per TODOs in code
- [ ] Consider adding tests

![095 - Retroactive Certification for Unemployment - localhost](https://user-images.githubusercontent.com/82277/87833608-43e44f00-c856-11ea-8c54-4db0ecdf7178.jpg)

===

Along with #485, will soon resolve #344

- [x] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [x] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made

