### PR TITLE
Tell screen reader users about "Show SSN" option

### DIFF
--- a/src/client/pages/RetroCertsAuthPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsAuthPage/__snapshots__/index.test.js.snap
@@ -184,7 +184,14 @@ exports[`<RetroCertsAuthPage /> retro certs auth page 1`] = `
             >
               Enter your Social Security number with or without dashes.
             </FormText>
+            <span
+              className="sr-only"
+              id="ssn-sr-desc"
+            >
+              You can select Show SSN after this input field
+            </span>
             <FormControl
+              aria-describedby="ssn-sr-desc"
               onChange={[Function]}
               required={true}
               value=""
@@ -440,7 +447,14 @@ exports[`<RetroCertsAuthPage /> retro certs auth page with captcha timeout error
             >
               Enter your Social Security number with or without dashes.
             </FormText>
+            <span
+              className="sr-only"
+              id="ssn-sr-desc"
+            >
+              You can select Show SSN after this input field
+            </span>
             <FormControl
+              aria-describedby="ssn-sr-desc"
               onChange={[Function]}
               required={true}
               value=""
@@ -754,7 +768,14 @@ exports[`<RetroCertsAuthPage /> retro certs auth page with session timeout 1`] =
             >
               Enter your Social Security number with or without dashes.
             </FormText>
+            <span
+              className="sr-only"
+              id="ssn-sr-desc"
+            >
+              You can select Show SSN after this input field
+            </span>
             <FormControl
+              aria-describedby="ssn-sr-desc"
               onChange={[Function]}
               required={true}
               value=""
@@ -1010,7 +1031,14 @@ exports[`<RetroCertsAuthPage /> retro certs auth page with user not found error 
             >
               Enter your Social Security number with or without dashes.
             </FormText>
+            <span
+              className="sr-only"
+              id="ssn-sr-desc"
+            >
+              You can select Show SSN after this input field
+            </span>
             <FormControl
+              aria-describedby="ssn-sr-desc"
               onChange={[Function]}
               required={true}
               value=""

--- a/src/client/pages/RetroCertsAuthPage/index.js
+++ b/src/client/pages/RetroCertsAuthPage/index.js
@@ -266,9 +266,15 @@ function RetroCertsAuthPage(props) {
               <Form.Group controlId="formSsn" className="col-md-6">
                 <Form.Label>{`* ${t("retrocert-login.ssn-label")}`}</Form.Label>
                 <Form.Text muted>{t("retrocert-login.ssn-hint")}</Form.Text>
+                {/* sr-only is invisible and used for screen readers:
+                https://v4-alpha.getbootstrap.com/getting-started/accessibility/#skip-navigation */}
+                <span id="ssn-sr-desc" className="sr-only">
+                  {t("retrocert-login.ssn-screen-reader")}
+                </span>
                 <Form.Control
                   value={ssn}
                   onChange={(e) => handleChange(e, setSsn)}
+                  aria-describedby="ssn-sr-desc"
                   required
                 />
                 <Form.Control.Feedback type="invalid">

--- a/src/data/locales/en/translation.json
+++ b/src/data/locales/en/translation.json
@@ -199,6 +199,7 @@
     "dob-year": "Year",
     "ssn-label": "Social Security Number",
     "ssn-hint": "Enter your Social Security number with or without dashes.",
+    "ssn-screen-reader": "You can select Show SSN after this input field",
     "recaptcha-text": "Security check provided by reCAPTCHA.",
     "submit": "Find Me",
     "invalid-user-error": "Review and verify the information you entered is correct. If your information is correct, then you don’t need to certify.",

--- a/src/data/locales/es/translation.json
+++ b/src/data/locales/es/translation.json
@@ -199,6 +199,7 @@
     "dob-year": "Año",
     "ssn-label": "Número de Seguro Social",
     "ssn-hint": "Ingrese su número de Seguro Social con o sin guiones.",
+    "ssn-screen-reader": "Puede seleccionar Mostrar SSN después de este campo de entrada",
     "recaptcha-text": "Control de seguridad proporcionado por reCAPTCHA.",
     "submit": "Encuéntrame",
     "invalid-user-error": "Revise y verifique que la información que ingresó sea correcta. Si su información es correcta, entonces no necesita certificar.",


### PR DESCRIPTION
This PR lets screen reader users know about the existence of the "Show SSN" link/button after the SSN input field, when they enter the input field, in case they want to hear what they're typing being read aloud to them, instead of (e.g.) "asterisk asterisk asterisk..."

No visual changes whatsoever:

![image](https://user-images.githubusercontent.com/82277/87963839-5e513f00-ca87-11ea-8e92-9caa3fa474d4.png)

===

Resolves #464

- [x] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [x] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
