### PR TITLE
Fix Google Analytics.

### DIFF
--- a/src/client/App.js
+++ b/src/client/App.js
@@ -22,17 +22,6 @@ export default function App() {
   if (initialPageLoad.current) {
     initialPageLoad.current = false;
 
-    // Initialize Google Analytics.
-    /* eslint-disable */
-    window.dataLayer = window.dataLayer || [];
-    window.gtag = (...args) => dataLayer.push(args);
-    gtag("js", new Date());
-    // For details see: https://support.google.com/analytics/answer/9310895?hl=en
-    // https://developers.google.com/analytics/devguides/collection/gtagjs/ip-anonymization
-    gtag("config", "UA-3419582-2", { anonymize_ip: true }); // www.ca.gov
-    gtag("config", "UA-3419582-31", { anonymize_ip: true }); // edd.ca.gov
-    /* eslint-enable */
-
     // <App> re-mounts every time user data is changed. To have only one
     // history listener, add it during the initial page load only.
     history.listen((location) => logPage(location.pathname));

--- a/src/routes/single-page-app.js
+++ b/src/routes/single-page-app.js
@@ -41,6 +41,19 @@ singlePageAppRouter.get("/*", (req, res) => {
   const is404 = Object.values(pageRoutes).indexOf(req.path) === -1;
   const statusCode = is404 ? 404 : 200;
 
+  // NOTE: If you change the GA script code, you need to update the hash in
+  // csp.js to allow this script to run. Chrome dev tools will have an error
+  // with the correct hash value to use.
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#Unsafe_inline_script
+  const gaScript = `
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      // For details see: https://support.google.com/analytics/answer/9310895?hl=en
+      // https://developers.google.com/analytics/devguides/collection/gtagjs/ip-anonymization
+      gtag('config', 'UA-3419582-2', { 'anonymize_ip': true }); // www.ca.gov
+      gtag('config', 'UA-3419582-31', { 'anonymize_ip': true }); // edd.ca.gov`;
+
   res
     .status(statusCode)
     .set("Referrer-Policy", "strict-origin-when-cross-origin")
@@ -52,6 +65,7 @@ singlePageAppRouter.get("/*", (req, res) => {
       <base href="/">
       <!-- Global site tag (gtag.js) - Google Analytics -->
       <script async src="https://www.googletagmanager.com/gtag/js?id=UA-3419582-2"></script>
+      <script>${gaScript}</script>
       <meta http-equiv="X-UA-Compatible" content="IE=edge" />
       <meta charset="utf-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/utils/csp.js
+++ b/src/utils/csp.js
@@ -19,6 +19,7 @@ function buildPolicies() {
       "www.googletagmanager.com",
       "www.google-analytics.com",
       "www.gstatic.com",
+      "'sha256-y7pLeNIruC+hCYcWLjrAKfMTQoptl6BVn8PcBOXd+aw='", // GA inline script
     ],
   };
 


### PR DESCRIPTION
For some reason, moving the inline script code into
App.js causes events to not be collected. I can't
tell from the minimized JS code why that's happening,
so instead move back to inlining the script code.
We allow the script by including the hash per the
docs:
https://developers.google.com/tag-manager/web/csp

===

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
