### PR TITLE
Make accordions on detailed confirmation page accessible

### DIFF
--- a/src/client/components/AccordionItem/__snapshots__/index.test.js.snap
+++ b/src/client/components/AccordionItem/__snapshots__/index.test.js.snap
@@ -3,11 +3,9 @@
 exports[`<AccordionItem /> renders the component 1`] = `
 <Fragment>
   <Alert
-    aria-label="Show details for this week"
     className="d-flex toggleAccordion"
     closeLabel="Close alert"
     onClick={[Function]}
-    role="button"
     show={true}
     transition={
       Object {
@@ -25,18 +23,22 @@ exports[`<AccordionItem /> renders the component 1`] = `
     }
     variant="secondary"
   >
-    <div
-      className="flex-fill"
+    <button
+      aria-label="Show details for this week"
     >
-      <span
-        className="toggleCharacter"
+      <div
+        className="flex-fill"
       >
-        +
-      </span>
-      <div>
-        header react element
+        <span
+          className="toggleCharacter"
+        >
+          +
+        </span>
+        <div>
+          header react element
+        </div>
       </div>
-    </div>
+    </button>
   </Alert>
   <div
     className="detail"

--- a/src/client/components/AccordionItem/index.js
+++ b/src/client/components/AccordionItem/index.js
@@ -19,13 +19,15 @@ function AccordionItem(props) {
         variant="secondary"
         className="d-flex toggleAccordion"
         onClick={() => setShowDetail(!showDetail)}
-        role="button"
-        aria-label={t("retrocerts-confirmation.show-details")}
       >
-        <div className="flex-fill">
-          <span className="toggleCharacter">{showDetail ? EN_DASH : "+"}</span>
-          {header}
-        </div>
+        <button aria-label={t("retrocerts-confirmation.show-details")}>
+          <div className="flex-fill">
+            <span className="toggleCharacter">
+              {showDetail ? EN_DASH : "+"}
+            </span>
+            {header}
+          </div>
+        </button>
       </Alert>
       <div className="detail" style={displayStyle}>
         {expandedBody}

--- a/src/client/components/WeekWithDetail/__snapshots__/index.test.js.snap
+++ b/src/client/components/WeekWithDetail/__snapshots__/index.test.js.snap
@@ -59,11 +59,9 @@ exports[`<WeekWithDetail /> renders the WeekWithDetail component 1`] = `
     }
   >
     <Alert
-      aria-label="Show details for this week"
       className="d-flex toggleAccordion"
       closeLabel="Close alert"
       onClick={[Function]}
-      role="button"
       show={true}
       transition={
         Object {
@@ -83,18 +81,15 @@ exports[`<WeekWithDetail /> renders the WeekWithDetail component 1`] = `
     >
       <Fade
         appear={false}
-        aria-label="Show details for this week"
         in={true}
         mountOnEnter={false}
         onClick={[Function]}
-        role="button"
         timeout={300}
         unmountOnExit={true}
       >
         <Transition
           addEndListener={[Function]}
           appear={false}
-          aria-label="Show details for this week"
           enter={true}
           exit={true}
           in={true}
@@ -106,43 +101,45 @@ exports[`<WeekWithDetail /> renders the WeekWithDetail component 1`] = `
           onExit={[Function]}
           onExited={[Function]}
           onExiting={[Function]}
-          role="button"
           timeout={300}
           unmountOnExit={true}
         >
           <div
-            aria-label="Show details for this week"
             className="fade d-flex toggleAccordion alert alert-secondary show"
             onClick={[Function]}
-            role="button"
+            role="alert"
           >
-            <div
-              className="flex-fill"
+            <button
+              aria-label="Show details for this week"
             >
-              <span
-                className="toggleCharacter"
+              <div
+                className="flex-fill"
               >
-                +
-              </span>
-              <Trans
-                i18nKey="retrocerts-week-list-item"
-                t={[Function]}
-                values={
-                  Object {
-                    "endDate": "02/15/2020",
-                    "startDate": "02/09/2020",
-                    "weekForUser": 1,
-                  }
-                }
-              >
-                <strong
-                  key="strong-0"
+                <span
+                  className="toggleCharacter"
                 >
-                  Week 1
-                </strong>
-                : Sunday, 02/09/2020 – Saturday, 02/15/2020
-              </Trans>
-            </div>
+                  +
+                </span>
+                <Trans
+                  i18nKey="retrocerts-week-list-item"
+                  t={[Function]}
+                  values={
+                    Object {
+                      "endDate": "02/15/2020",
+                      "startDate": "02/09/2020",
+                      "weekForUser": 1,
+                    }
+                  }
+                >
+                  <strong
+                    key="strong-0"
+                  >
+                    Week 1
+                  </strong>
+                  : Sunday, 02/09/2020 – Saturday, 02/15/2020
+                </Trans>
+              </div>
+            </button>
           </div>
         </Transition>
       </Fade>

--- a/src/client/pages/RetroCertsConfirmationPage/_index.scss
+++ b/src/client/pages/RetroCertsConfirmationPage/_index.scss
@@ -1,5 +1,10 @@
 .toggleAccordion {
   cursor: pointer;
+
+  button {
+    border: 0;
+    background-color: inherit;
+  }
 }
 
 .toggleCharacter {


### PR DESCRIPTION
This PR makes each accordion item (week certified) on the detailed confirmation page a <button> so it's keyboard focusable and accessible for screen readers. Prior to this fix, it wasn't possible to tab through them. 

===

- [x] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
