### PR TITLE
Fix site loading under Safari and Firefox

### DIFF
--- a/src/utils/csp.js
+++ b/src/utils/csp.js
@@ -10,8 +10,14 @@ function buildPolicies() {
       "www.googletagmanager.com",
       "www.google-analytics.com",
       "*.google.com",
+      "'sha256-y7pLeNIruC+hCYcWLjrAKfMTQoptl6BVn8PcBOXd+aw='", // GA inline script, needed on Safari
     ],
-    connect: ["'self'", "*.visualstudio.com"],
+    connect: [
+      "'self'",
+      "*.visualstudio.com",
+      "www.google-analytics.com", // For Safari
+      "*.doubleclick.net", // For Safari
+    ],
     object: ["'none'"],
     scriptElem: [
       "'self'",

--- a/src/utils/csp.js
+++ b/src/utils/csp.js
@@ -7,10 +7,11 @@ function buildPolicies() {
     font: ["fonts.googleapis.com", "fonts.gstatic.com"],
     script: [
       "'self'",
+      "*.google.com",
       "www.googletagmanager.com",
       "www.google-analytics.com",
-      "*.google.com",
-      "'sha256-y7pLeNIruC+hCYcWLjrAKfMTQoptl6BVn8PcBOXd+aw='", // GA inline script, needed on Safari
+      "www.gstatic.com",
+      "'sha256-y7pLeNIruC+hCYcWLjrAKfMTQoptl6BVn8PcBOXd+aw='", // GA inline script
     ],
     connect: [
       "'self'",
@@ -19,6 +20,7 @@ function buildPolicies() {
       "*.doubleclick.net", // For Safari
     ],
     object: ["'none'"],
+    // Not yet supported by Safari or Firefox.
     scriptElem: [
       "'self'",
       "*.google.com",


### PR DESCRIPTION
Safari & Firefox don't know about script-src-elem (they bundle
everything under script-scr). Also, Safari treats the google
analytics tracking requests as 'connect' rather than
'img'.

===

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [X] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
