### PR TITLE
Fix accordion element background color in IE11

### DIFF
--- a/src/client/pages/RetroCertsConfirmationPage/_index.scss
+++ b/src/client/pages/RetroCertsConfirmationPage/_index.scss
@@ -3,7 +3,7 @@
 
   button {
     border: 0;
-    background-color: inherit;
+    background-color: transparent; /* note: inherit is ignored by IE11 */
   }
 }
 


### PR DESCRIPTION
The inherit value for background-color is ignored by IE11 so it looks terrible. Changing it to transparent works for IE11 and for other browsers.

Now:
![image](https://user-images.githubusercontent.com/82277/88570476-22c7ef00-d00a-11ea-907d-dbf6bbc3f4c4.png)

===

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [x] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
