### PR TITLE
Add expand all / hide all button, move print button

### DIFF
--- a/src/client/components/AccordionItem/__snapshots__/index.test.js.snap
+++ b/src/client/components/AccordionItem/__snapshots__/index.test.js.snap
@@ -32,7 +32,7 @@ exports[`<AccordionItem /> renders the component 1`] = `
         <span
           className="toggleCharacter"
         >
-          +
+          –
         </span>
         <div>
           header react element
@@ -44,7 +44,7 @@ exports[`<AccordionItem /> renders the component 1`] = `
     className="detail"
     style={
       Object {
-        "display": "none",
+        "display": "block",
       }
     }
   >

--- a/src/client/components/AccordionItem/index.js
+++ b/src/client/components/AccordionItem/index.js
@@ -1,15 +1,14 @@
 import Alert from "react-bootstrap/Alert";
 import { useTranslation } from "react-i18next";
 import PropTypes from "prop-types";
-import React, { useState } from "react";
+import React from "react";
 
 function AccordionItem(props) {
-  const { header, expandedBody } = props;
+  const { header, content, showContent, toggleContent } = props;
   const { t } = useTranslation();
 
-  const [showDetail, setShowDetail] = useState(false);
   const displayStyle = {
-    display: showDetail ? "block" : "none",
+    display: showContent ? "block" : "none",
   };
 
   const EN_DASH = "–";
@@ -18,19 +17,19 @@ function AccordionItem(props) {
       <Alert
         variant="secondary"
         className="d-flex toggleAccordion"
-        onClick={() => setShowDetail(!showDetail)}
+        onClick={() => toggleContent()}
       >
-        <button aria-label={t("retrocerts-confirmation.show-details")}>
+        <button aria-label={t("retrocerts-confirmation.aria-show-details")}>
           <div className="flex-fill">
             <span className="toggleCharacter">
-              {showDetail ? EN_DASH : "+"}
+              {showContent ? EN_DASH : "+"}
             </span>
             {header}
           </div>
         </button>
       </Alert>
       <div className="detail" style={displayStyle}>
-        {expandedBody}
+        {content}
       </div>
     </React.Fragment>
   );
@@ -38,7 +37,9 @@ function AccordionItem(props) {
 
 AccordionItem.propTypes = {
   header: PropTypes.element.isRequired,
-  expandedBody: PropTypes.element.isRequired,
+  content: PropTypes.element.isRequired,
+  showContent: PropTypes.bool.isRequired,
+  toggleContent: PropTypes.func.isRequired,
 };
 
 export default AccordionItem;

--- a/src/client/components/AccordionItem/index.test.js
+++ b/src/client/components/AccordionItem/index.test.js
@@ -6,7 +6,9 @@ describe("<AccordionItem />", () => {
   it("renders the component", async () => {
     const wrapper = renderNonTransContent(Component, "AccordionItem", {
       header: <div>header react element</div>,
-      expandedBody: <div>detailed body react element</div>,
+      content: <div>detailed body react element</div>,
+      showContent: [true, true, true, true],
+      toggleContent: jest.fn(),
     });
 
     expect(wrapper).toMatchSnapshot();

--- a/src/client/components/AccordionItem/index.test.js
+++ b/src/client/components/AccordionItem/index.test.js
@@ -7,7 +7,7 @@ describe("<AccordionItem />", () => {
     const wrapper = renderNonTransContent(Component, "AccordionItem", {
       header: <div>header react element</div>,
       content: <div>detailed body react element</div>,
-      showContent: [true, true, true, true],
+      showContent: true,
       toggleContent: jest.fn(),
     });
 

--- a/src/client/components/ListOfWeeksWithDetail/__snapshots__/index.test.js.snap
+++ b/src/client/components/ListOfWeeksWithDetail/__snapshots__/index.test.js.snap
@@ -5,6 +5,15 @@ Array [
   <WeekWithDetail
     index={0}
     key="0"
+    showContent={
+      Array [
+        true,
+        true,
+        true,
+        true,
+      ]
+    }
+    toggleContent={[MockFunction]}
     weekData={
       Object {
         "couldNotAcceptWork": false,
@@ -21,6 +30,15 @@ Array [
   <WeekWithDetail
     index={1}
     key="1"
+    showContent={
+      Array [
+        true,
+        true,
+        true,
+        true,
+      ]
+    }
+    toggleContent={[MockFunction]}
     weekData={
       Object {
         "couldNotAcceptWork": false,
@@ -37,6 +55,15 @@ Array [
   <WeekWithDetail
     index={2}
     key="2"
+    showContent={
+      Array [
+        true,
+        true,
+        true,
+        true,
+      ]
+    }
+    toggleContent={[MockFunction]}
     weekData={
       Object {
         "couldNotAcceptWork": false,

--- a/src/client/components/ListOfWeeksWithDetail/__snapshots__/index.test.js.snap
+++ b/src/client/components/ListOfWeeksWithDetail/__snapshots__/index.test.js.snap
@@ -5,7 +5,7 @@ Array [
   <WeekWithDetail
     index={0}
     key="0"
-    showContent={
+    showContentArray={
       Array [
         true,
         true,
@@ -30,7 +30,7 @@ Array [
   <WeekWithDetail
     index={1}
     key="1"
-    showContent={
+    showContentArray={
       Array [
         true,
         true,
@@ -55,7 +55,7 @@ Array [
   <WeekWithDetail
     index={2}
     key="2"
-    showContent={
+    showContentArray={
       Array [
         true,
         true,

--- a/src/client/components/ListOfWeeksWithDetail/index.js
+++ b/src/client/components/ListOfWeeksWithDetail/index.js
@@ -1,10 +1,11 @@
 import React from "react";
 import { userDataPropType } from "../../commonPropTypes";
+import PropTypes from "prop-types";
 import WeekWithDetail from "../WeekWithDetail";
 import getWeekProgramPlan from "../../../utils/getWeekProgramPlan";
 
 function ListOfWeeksWithDetail(props) {
-  const { userData } = props;
+  const { userData, showContent, toggleContent } = props;
 
   return userData.weeksToCertify.map((weekIndex, index) => {
     const weekForUser = index + 1;
@@ -18,6 +19,8 @@ function ListOfWeeksWithDetail(props) {
       <WeekWithDetail
         index={index}
         key={index}
+        showContent={showContent}
+        toggleContent={toggleContent}
         weekData={weekData}
         weekIndex={weekIndex}
         weekProgramPlan={weekProgramPlan}
@@ -28,6 +31,8 @@ function ListOfWeeksWithDetail(props) {
 
 ListOfWeeksWithDetail.propTypes = {
   userData: userDataPropType.isRequired,
+  showContent: PropTypes.arrayOf(PropTypes.bool).isRequired,
+  toggleContent: PropTypes.func.isRequired,
 };
 
 export default ListOfWeeksWithDetail;

--- a/src/client/components/ListOfWeeksWithDetail/index.js
+++ b/src/client/components/ListOfWeeksWithDetail/index.js
@@ -5,7 +5,7 @@ import WeekWithDetail from "../WeekWithDetail";
 import getWeekProgramPlan from "../../../utils/getWeekProgramPlan";
 
 function ListOfWeeksWithDetail(props) {
-  const { userData, showContent, toggleContent } = props;
+  const { userData, showContentArray, toggleContent } = props;
 
   return userData.weeksToCertify.map((weekIndex, index) => {
     const weekForUser = index + 1;
@@ -19,7 +19,7 @@ function ListOfWeeksWithDetail(props) {
       <WeekWithDetail
         index={index}
         key={index}
-        showContent={showContent}
+        showContentArray={showContentArray}
         toggleContent={toggleContent}
         weekData={weekData}
         weekIndex={weekIndex}
@@ -31,7 +31,7 @@ function ListOfWeeksWithDetail(props) {
 
 ListOfWeeksWithDetail.propTypes = {
   userData: userDataPropType.isRequired,
-  showContent: PropTypes.arrayOf(PropTypes.bool).isRequired,
+  showContentArray: PropTypes.arrayOf(PropTypes.bool).isRequired,
   toggleContent: PropTypes.func.isRequired,
 };
 

--- a/src/client/components/ListOfWeeksWithDetail/index.test.js
+++ b/src/client/components/ListOfWeeksWithDetail/index.test.js
@@ -18,7 +18,7 @@ describe("<ListOfWeeksWithDetail />", () => {
         weeksToCertify: [1, 2, 3],
         programPlan: ["UI full time"],
       },
-      showContent: [true, true, true, true],
+      showContentArray: [true, true, true, true],
       toggleContent: jest.fn(),
     });
 

--- a/src/client/components/ListOfWeeksWithDetail/index.test.js
+++ b/src/client/components/ListOfWeeksWithDetail/index.test.js
@@ -18,6 +18,8 @@ describe("<ListOfWeeksWithDetail />", () => {
         weeksToCertify: [1, 2, 3],
         programPlan: ["UI full time"],
       },
+      showContent: [true, true, true, true],
+      toggleContent: jest.fn(),
     });
 
     expect(wrapper).toMatchSnapshot();

--- a/src/client/components/WeekWithDetail/__snapshots__/index.test.js.snap
+++ b/src/client/components/WeekWithDetail/__snapshots__/index.test.js.snap
@@ -3,7 +3,7 @@
 exports[`<WeekWithDetail /> renders the WeekWithDetail component 1`] = `
 <WeekWithDetail
   index={0}
-  showContent={
+  showContentArray={
     Array [
       true,
       true,

--- a/src/client/components/WeekWithDetail/__snapshots__/index.test.js.snap
+++ b/src/client/components/WeekWithDetail/__snapshots__/index.test.js.snap
@@ -3,6 +3,15 @@
 exports[`<WeekWithDetail /> renders the WeekWithDetail component 1`] = `
 <WeekWithDetail
   index={0}
+  showContent={
+    Array [
+      true,
+      true,
+      true,
+      true,
+    ]
+  }
+  toggleContent={[MockFunction]}
   weekData={
     Object {
       "couldNotAcceptWork": false,
@@ -17,7 +26,7 @@ exports[`<WeekWithDetail /> renders the WeekWithDetail component 1`] = `
   weekProgramPlan="UI full time"
 >
   <AccordionItem
-    expandedBody={
+    content={
       <WeekConfirmationDetails
         questionAnswers={
           Array [
@@ -57,6 +66,8 @@ exports[`<WeekWithDetail /> renders the WeekWithDetail component 1`] = `
         }
       />
     }
+    showContent={true}
+    toggleContent={[Function]}
   >
     <Alert
       className="d-flex toggleAccordion"
@@ -118,7 +129,7 @@ exports[`<WeekWithDetail /> renders the WeekWithDetail component 1`] = `
                 <span
                   className="toggleCharacter"
                 >
-                  +
+                  –
                 </span>
                 <Trans
                   i18nKey="retrocerts-week-list-item"
@@ -148,7 +159,7 @@ exports[`<WeekWithDetail /> renders the WeekWithDetail component 1`] = `
       className="detail"
       style={
         Object {
-          "display": "none",
+          "display": "block",
         }
       }
     >

--- a/src/client/components/WeekWithDetail/index.js
+++ b/src/client/components/WeekWithDetail/index.js
@@ -8,7 +8,14 @@ import AccordionItem from "../AccordionItem";
 import getRetroCertQuestionKey from "../../../utils/getRetroCertQuestionKey";
 
 function WeekWithDetail(props) {
-  const { index, weekData, weekIndex, weekProgramPlan } = props;
+  const {
+    index,
+    showContent,
+    toggleContent,
+    weekData,
+    weekIndex,
+    weekProgramPlan,
+  } = props;
   const { t } = useTranslation();
 
   const baseQuestionNames = [
@@ -89,7 +96,7 @@ function WeekWithDetail(props) {
           values={{ ...dates, weekForUser }}
         />
       }
-      expandedBody={
+      content={
         <WeekConfirmationDetails
           employers={weekHasEmployers ? weekData.employers : undefined}
           questionAnswers={questionAnswers}
@@ -97,12 +104,16 @@ function WeekWithDetail(props) {
           weekString={toWeekString(weekIndex)}
         />
       }
+      showContent={showContent[index]}
+      toggleContent={() => toggleContent(index)}
     />
   );
 }
 
 WeekWithDetail.propTypes = {
   index: PropTypes.number.isRequired,
+  showContent: PropTypes.arrayOf(PropTypes.bool).isRequired,
+  toggleContent: PropTypes.func.isRequired,
   weekData: PropTypes.object.isRequired,
   weekIndex: PropTypes.number.isRequired,
   weekProgramPlan: PropTypes.string.isRequired,

--- a/src/client/components/WeekWithDetail/index.js
+++ b/src/client/components/WeekWithDetail/index.js
@@ -10,7 +10,7 @@ import getRetroCertQuestionKey from "../../../utils/getRetroCertQuestionKey";
 function WeekWithDetail(props) {
   const {
     index,
-    showContent,
+    showContentArray,
     toggleContent,
     weekData,
     weekIndex,
@@ -104,7 +104,7 @@ function WeekWithDetail(props) {
           weekString={toWeekString(weekIndex)}
         />
       }
-      showContent={showContent[index]}
+      showContent={showContentArray[index]}
       toggleContent={() => toggleContent(index)}
     />
   );
@@ -112,7 +112,7 @@ function WeekWithDetail(props) {
 
 WeekWithDetail.propTypes = {
   index: PropTypes.number.isRequired,
-  showContent: PropTypes.arrayOf(PropTypes.bool).isRequired,
+  showContentArray: PropTypes.arrayOf(PropTypes.bool).isRequired,
   toggleContent: PropTypes.func.isRequired,
   weekData: PropTypes.object.isRequired,
   weekIndex: PropTypes.number.isRequired,

--- a/src/client/components/WeekWithDetail/index.test.js
+++ b/src/client/components/WeekWithDetail/index.test.js
@@ -14,6 +14,8 @@ describe("<WeekWithDetail />", () => {
 
     const content = renderTransContent(Component, {
       index: 0,
+      showContent: [true, true, true, true],
+      toggleContent: jest.fn(),
       weekData: weekOfAnswers,
       weekIndex: 1,
       weekProgramPlan: "UI full time",

--- a/src/client/components/WeekWithDetail/index.test.js
+++ b/src/client/components/WeekWithDetail/index.test.js
@@ -14,7 +14,7 @@ describe("<WeekWithDetail />", () => {
 
     const content = renderTransContent(Component, {
       index: 0,
-      showContent: [true, true, true, true],
+      showContentArray: [true, true, true, true],
       toggleContent: jest.fn(),
       weekData: weekOfAnswers,
       weekIndex: 1,

--- a/src/client/pages/RetroCertsConfirmationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsConfirmationPage/__snapshots__/index.test.js.snap
@@ -99,7 +99,7 @@ exports[`<RetroCertsConfirmationPage /> with confirmation number 1`] = `
         Show all
       </Button>
       <ListOfWeeksWithDetail
-        showContent={
+        showContentArray={
           Array [
             false,
             false,

--- a/src/client/pages/RetroCertsConfirmationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsConfirmationPage/__snapshots__/index.test.js.snap
@@ -73,12 +73,43 @@ exports[`<RetroCertsConfirmationPage /> with confirmation number 1`] = `
       <p>
         You’ve been logged out of the system and may close this window.
       </p>
+      <Button
+        active={false}
+        className="text-dark bg-light"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+        variant="outline-secondary"
+      >
+        Print
+      </Button>
       <h2
         className="mt-5"
       >
         Certifications Submitted
       </h2>
+      <Button
+        active={false}
+        className="text-dark bg-light mb-3"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+        variant="outline-secondary"
+      >
+        Show all
+      </Button>
       <ListOfWeeksWithDetail
+        showContent={
+          Array [
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+          ]
+        }
+        toggleContent={[Function]}
         userData={
           Object {
             "confirmationNumber": "CONFIRMATION_NUMBER",
@@ -97,7 +128,7 @@ exports[`<RetroCertsConfirmationPage /> with confirmation number 1`] = `
         }
       />
       <AccordionItem
-        expandedBody={
+        content={
           <AcknowledgementDetail
             className="detail"
           />
@@ -107,6 +138,8 @@ exports[`<RetroCertsConfirmationPage /> with confirmation number 1`] = `
             Acknowledgement
           </strong>
         }
+        showContent={false}
+        toggleContent={[Function]}
       />
       <h2
         className="mt-5"
@@ -128,16 +161,6 @@ exports[`<RetroCertsConfirmationPage /> with confirmation number 1`] = `
           .
         </Trans>
       </p>
-      <Button
-        active={false}
-        className="text-dark bg-light mt-5"
-        disabled={false}
-        onClick={[Function]}
-        type="button"
-        variant="outline-secondary"
-      >
-        Print this page
-      </Button>
     </div>
   </main>
   <Footer

--- a/src/client/pages/RetroCertsConfirmationPage/index.js
+++ b/src/client/pages/RetroCertsConfirmationPage/index.js
@@ -148,7 +148,7 @@ function RetroCertsConfirmationPage(props) {
               : t("retrocerts-confirmation.button-show-all")}
           </Button>
           <ListOfWeeksWithDetail
-            showContent={accordionsExpanded}
+            showContentArray={accordionsExpanded}
             toggleContent={toggleAccordion}
             userData={userData}
           />

--- a/src/data/locales/en/translation.json
+++ b/src/data/locales/en/translation.json
@@ -356,11 +356,13 @@
     "p1": "Your retroactive certification has been submitted. Your confirmation number is <strong>{{confirmationNumber}}</strong>.",
     "p1a": "Keep this number for your records.",
     "p1b": "You’ve been logged out of the system and may close this window.",
+    "button-print": "Print",
     "header2": "Certifications Submitted",
-    "show-details": "Show details for this week",
+    "button-show-all": "Show all",
+    "button-hide-all": "Hide all",
+    "aria-show-details": "Show details for this week",
     "header3": "Next Steps",
-    "p2": "If you are still unemployed, continue to certify for benefits every two weeks. The fastest way is to use <2>UI Online</2>.",
-    "button-print": "Print this page"
+    "p2": "If you are still unemployed, continue to certify for benefits every two weeks. The fastest way is to use <2>UI Online</2>."
   },
   "generic-validation-error-message": "There are one or more errors on this page. Review and correct them to continue. Complete all fields and try again."
 }

--- a/src/data/locales/es/translation.json
+++ b/src/data/locales/es/translation.json
@@ -355,11 +355,13 @@
     "p1": "Su certificación retroactiva ha sido presentada. Su número de confirmación es <strong>{{confirmationNumber}}</strong>.",
     "p1a": "Guarde este número para sus archivos.",
     "p1b": "Se ha cerrado la sesión en este sistema y puede cerrar esta página.",
+    "button-print": "Imprimir",
     "header2": "Certificaciones presentadas",
-    "show-details": "Mostrar detalles para esta semana",
+    "button-show-all": "Mostrar todo",
+    "button-hide-all": "Ocultar todo",
+    "aria-show-details": "Mostrar detalles para esta semana",
     "header3": "Siguientes pasos",
-    "p2": "Si todavía está desempleado, continúe realizando la certificación para los beneficios cada dos semanas. La manera más rápida es a través de <2>UI Online</2>.",
-    "button-print": "Imprimir esta página"
+    "p2": "Si todavía está desempleado, continúe realizando la certificación para los beneficios cada dos semanas. La manera más rápida es a través de <2>UI Online</2>."
   },
   "generic-validation-error-message": "Hay más de un error en esta página. Revise y corrija los errores para continuar. Complete todo los campos e intente de nuevo."
 }


### PR DESCRIPTION
This PR adds an expand all / hide all button to the detail confirmation page, and moves the print button higher up the page.

Bonus feature: if all accordions are closed or opened one by one, the "Show all / Hide all" button will update to match. E.g. if you click Show all and then hide each accordion individually, the button will change back to Hide all.

![image](https://user-images.githubusercontent.com/82277/88598328-1443fc80-d037-11ea-812c-148fb5c6df0a.png)

![image](https://user-images.githubusercontent.com/82277/88598331-14dc9300-d037-11ea-98be-420dcdcc329d.png)

===

Resolves #

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
