### PR TITLE
Refactor list of certifications into its own component

### DIFF
--- a/src/client/components/ListOfCertifications/__snapshots__/index.test.js.snap
+++ b/src/client/components/ListOfCertifications/__snapshots__/index.test.js.snap
@@ -1,0 +1,84 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ListOfCertifications /> renders the component 1`] = `
+<Fragment>
+  <h2
+    className="mt-5"
+  >
+    Certifications Submitted
+  </h2>
+  <Button
+    active={false}
+    className="text-dark bg-light mb-3"
+    disabled={false}
+    onClick={[Function]}
+    type="button"
+    variant="outline-secondary"
+  >
+    Show all
+  </Button>
+  <ListOfWeeksWithDetail
+    showContentArray={
+      Array [
+        false,
+        false,
+        false,
+        false,
+      ]
+    }
+    toggleContent={[Function]}
+    userData={
+      Object {
+        "formData": Array [
+          Object {
+            "couldNotAcceptWork": false,
+            "didYouLook": false,
+            "refuseWork": false,
+            "schoolOrTraining": false,
+            "tooSick": false,
+            "workOrEarn": false,
+          },
+          Object {
+            "couldNotAcceptWork": false,
+            "didYouLook": false,
+            "refuseWork": false,
+            "schoolOrTraining": false,
+            "tooSick": false,
+            "workOrEarn": false,
+          },
+          Object {
+            "couldNotAcceptWork": false,
+            "didYouLook": false,
+            "refuseWork": false,
+            "schoolOrTraining": false,
+            "tooSick": false,
+            "workOrEarn": false,
+          },
+        ],
+        "programPlan": Array [
+          "UI full time",
+        ],
+        "weeksToCertify": Array [
+          1,
+          2,
+          3,
+        ],
+      }
+    }
+  />
+  <AccordionItem
+    content={
+      <AcknowledgementDetail
+        className="detail"
+      />
+    }
+    header={
+      <strong>
+        Acknowledgement
+      </strong>
+    }
+    showContent={false}
+    toggleContent={[Function]}
+  />
+</Fragment>
+`;

--- a/src/client/components/ListOfCertifications/index.js
+++ b/src/client/components/ListOfCertifications/index.js
@@ -1,0 +1,97 @@
+import Button from "react-bootstrap/Button";
+import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
+import PropTypes from "prop-types";
+import { userDataPropType } from "../../commonPropTypes";
+import ListOfWeeksWithDetail from "../../components/ListOfWeeksWithDetail";
+import programPlan from "../../../data/programPlan";
+import AccordionItem from "../../components/AccordionItem";
+
+function ListOfCertifications(props) {
+  const { t } = useTranslation();
+
+  const { header, userData } = props;
+
+  const numAccordions = userData.weeksToCertify.length + 1; // add 1 for Acknowledgement
+
+  const acknowledgementIndex = numAccordions - 1;
+  const [showAll, setShowAll] = useState(false);
+  const [accordionsExpanded, setAccordionsExpanded] = useState(
+    Array(numAccordions).fill(false)
+  );
+  const isAnyWeekPua = userData.programPlan.includes(programPlan.puaFullTime);
+
+  function toggleAllAccordions() {
+    setShowAll(!showAll);
+    setAccordionsExpanded(Array(numAccordions).fill(!showAll));
+  }
+
+  function toggleAccordion(index) {
+    // Need to clone the state variable here, React doesn't allow mutating them
+    const newAccordionsExpanded = [...accordionsExpanded];
+    newAccordionsExpanded[index] = !newAccordionsExpanded[index];
+    setAccordionsExpanded(newAccordionsExpanded);
+
+    // If all the accordions are now either closed or open,
+    // update the Show all / Hide all button to match
+    if (newAccordionsExpanded.every((x) => x === newAccordionsExpanded[0])) {
+      setShowAll(newAccordionsExpanded[index]);
+    }
+  }
+
+  function AcknowledgementDetail(props) {
+    return (
+      <React.Fragment>
+        {isAnyWeekPua ? (
+          <ul>
+            <li>{t("retrocerts-certification.ack-list-pua-item-1")}</li>
+            <li>{t("retrocerts-certification.ack-list-pua-item-2")}</li>
+            <li>{t("retrocerts-certification.ack-list-pua-item-3")}</li>
+          </ul>
+        ) : (
+          <ul>
+            <li>{t("retrocerts-certification.ack-list-item-1")}</li>
+            <li>{t("retrocerts-certification.ack-list-item-2")}</li>
+            <li>{t("retrocerts-certification.ack-list-item-3")}</li>
+            <li>{t("retrocerts-certification.ack-list-item-4")}</li>
+          </ul>
+        )}
+        <input type="checkbox" checked disabled />
+        {t("retrocerts-certification.ack-label")}
+      </React.Fragment>
+    );
+  }
+
+  return (
+    <React.Fragment>
+      <h2 className="mt-5">{header}</h2>
+      <Button
+        variant="outline-secondary"
+        className="text-dark bg-light mb-3"
+        onClick={toggleAllAccordions}
+      >
+        {showAll
+          ? t("retrocerts-confirmation.button-hide-all")
+          : t("retrocerts-confirmation.button-show-all")}
+      </Button>
+      <ListOfWeeksWithDetail
+        showContentArray={accordionsExpanded}
+        toggleContent={toggleAccordion}
+        userData={userData}
+      />
+      <AccordionItem
+        header={<strong>{t("retrocerts-certification.ack-header")}</strong>}
+        content={<AcknowledgementDetail className="detail" />}
+        showContent={accordionsExpanded[acknowledgementIndex]}
+        toggleContent={() => toggleAccordion(acknowledgementIndex)}
+      />
+    </React.Fragment>
+  );
+}
+
+ListOfCertifications.propTypes = {
+  header: PropTypes.string.isRequired,
+  userData: userDataPropType,
+};
+
+export default ListOfCertifications;

--- a/src/client/components/ListOfCertifications/index.test.js
+++ b/src/client/components/ListOfCertifications/index.test.js
@@ -1,0 +1,26 @@
+import renderNonTransContent from "../../test-helpers/renderNonTransContent";
+import Component from "./index";
+
+describe("<ListOfCertifications />", () => {
+  it("renders the component", async () => {
+    const weekOfAnswers = {
+      tooSick: false,
+      couldNotAcceptWork: false,
+      didYouLook: false,
+      refuseWork: false,
+      schoolOrTraining: false,
+      workOrEarn: false,
+    };
+
+    const wrapper = renderNonTransContent(Component, "ListOfCertifications", {
+      header: "Certifications Submitted",
+      userData: {
+        formData: [weekOfAnswers, weekOfAnswers, weekOfAnswers],
+        weeksToCertify: [1, 2, 3],
+        programPlan: ["UI full time"],
+      },
+    });
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/client/pages/RetroCertsConfirmationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsConfirmationPage/__snapshots__/index.test.js.snap
@@ -83,33 +83,8 @@ exports[`<RetroCertsConfirmationPage /> with confirmation number 1`] = `
       >
         Print
       </Button>
-      <h2
-        className="mt-5"
-      >
-        Certifications Submitted
-      </h2>
-      <Button
-        active={false}
-        className="text-dark bg-light mb-3"
-        disabled={false}
-        onClick={[Function]}
-        type="button"
-        variant="outline-secondary"
-      >
-        Show all
-      </Button>
-      <ListOfWeeksWithDetail
-        showContentArray={
-          Array [
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-          ]
-        }
-        toggleContent={[Function]}
+      <ListOfCertifications
+        header="Certifications Submitted"
         userData={
           Object {
             "confirmationNumber": "CONFIRMATION_NUMBER",
@@ -126,20 +101,6 @@ exports[`<RetroCertsConfirmationPage /> with confirmation number 1`] = `
             ],
           }
         }
-      />
-      <AccordionItem
-        content={
-          <AcknowledgementDetail
-            className="detail"
-          />
-        }
-        header={
-          <strong>
-            Acknowledgement
-          </strong>
-        }
-        showContent={false}
-        toggleContent={[Function]}
       />
       <h2
         className="mt-5"

--- a/src/client/pages/RetroCertsConfirmationPage/index.js
+++ b/src/client/pages/RetroCertsConfirmationPage/index.js
@@ -1,30 +1,22 @@
 import Button from "react-bootstrap/Button";
 import { Redirect, useHistory } from "react-router-dom";
 import Alert from "react-bootstrap/Alert";
-import React, { useState } from "react";
+import React from "react";
 import { useTranslation, Trans } from "react-i18next";
 import { userDataPropType } from "../../commonPropTypes";
 import routes from "../../../data/routes";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header";
 import LanguageSelector from "../../components/LanguageSelector";
-import ListOfWeeksWithDetail from "../../components/ListOfWeeksWithDetail";
 import { logEvent } from "../../utils";
 import { clearAuthToken } from "../../components/SessionTimer";
-import programPlan from "../../../data/programPlan";
-import AccordionItem from "../../components/AccordionItem";
+import ListOfCertifications from "../../components/ListOfCertifications";
 
 function RetroCertsConfirmationPage(props) {
   const { t } = useTranslation();
   const history = useHistory();
 
   const userData = props.userData;
-  const numAccordions = userData.weeksToCertify.length + 1; // add 1 for Acknowledgement
-  const acknowledgementIndex = numAccordions - 1;
-  const [showAll, setShowAll] = useState(false);
-  const [accordionsExpanded, setAccordionsExpanded] = useState(
-    Array(numAccordions).fill(false)
-  );
 
   // The user is here by accident. Send them back.
   if (!userData.confirmationNumber) {
@@ -34,7 +26,6 @@ function RetroCertsConfirmationPage(props) {
   }
 
   document.title = t("retrocerts-confirmation.title");
-  const isAnyWeekPua = userData.programPlan.includes(programPlan.puaFullTime);
 
   // For historical reasons the confirmation code is stored as a uuidv4
   // hash in the database, but we display only the last 7 characters to the user.
@@ -56,47 +47,6 @@ function RetroCertsConfirmationPage(props) {
   function handlePrint() {
     logEvent("RetroCerts", "PrintConfirmation");
     window.print();
-  }
-
-  function toggleAllAccordions() {
-    setShowAll(!showAll);
-    setAccordionsExpanded(Array(numAccordions).fill(!showAll));
-  }
-
-  function toggleAccordion(index) {
-    // Need to clone the state variable here, React doesn't allow mutating them
-    const newAccordionsExpanded = [...accordionsExpanded];
-    newAccordionsExpanded[index] = !newAccordionsExpanded[index];
-    setAccordionsExpanded(newAccordionsExpanded);
-
-    // If all the accordions are now either closed or open,
-    // update the Show all / Hide all button to match
-    if (newAccordionsExpanded.every((x) => x === newAccordionsExpanded[0])) {
-      setShowAll(newAccordionsExpanded[index]);
-    }
-  }
-
-  function AcknowledgementDetail(props) {
-    return (
-      <React.Fragment>
-        {isAnyWeekPua ? (
-          <ul>
-            <li>{t("retrocerts-certification.ack-list-pua-item-1")}</li>
-            <li>{t("retrocerts-certification.ack-list-pua-item-2")}</li>
-            <li>{t("retrocerts-certification.ack-list-pua-item-3")}</li>
-          </ul>
-        ) : (
-          <ul>
-            <li>{t("retrocerts-certification.ack-list-item-1")}</li>
-            <li>{t("retrocerts-certification.ack-list-item-2")}</li>
-            <li>{t("retrocerts-certification.ack-list-item-3")}</li>
-            <li>{t("retrocerts-certification.ack-list-item-4")}</li>
-          </ul>
-        )}
-        <input type="checkbox" checked disabled />
-        {t("retrocerts-certification.ack-label")}
-      </React.Fragment>
-    );
   }
 
   return (
@@ -137,28 +87,10 @@ function RetroCertsConfirmationPage(props) {
             {t("retrocerts-confirmation.button-print")}
           </Button>
 
-          <h2 className="mt-5">{t("retrocerts-confirmation.header2")}</h2>
-          <Button
-            variant="outline-secondary"
-            className="text-dark bg-light mb-3"
-            onClick={toggleAllAccordions}
-          >
-            {showAll
-              ? t("retrocerts-confirmation.button-hide-all")
-              : t("retrocerts-confirmation.button-show-all")}
-          </Button>
-          <ListOfWeeksWithDetail
-            showContentArray={accordionsExpanded}
-            toggleContent={toggleAccordion}
+          <ListOfCertifications
+            header={t("retrocerts-confirmation.header2")}
             userData={userData}
           />
-          <AccordionItem
-            header={<strong>{t("retrocerts-certification.ack-header")}</strong>}
-            content={<AcknowledgementDetail className="detail" />}
-            showContent={accordionsExpanded[acknowledgementIndex]}
-            toggleContent={() => toggleAccordion(acknowledgementIndex)}
-          />
-
           <h2 className="mt-5">{t("retrocerts-confirmation.header3")}</h2>
           <p>
             <Trans t={t} i18nKey="retrocerts-confirmation.p2">


### PR DESCRIPTION
This PR refactors the "Certifications Submitted" section into its own component. Preparing for staff access portal which will reuse this new component. There are no changes other than extracting the existing components to a new file and updating snapshots. 

===

- [x] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
