### PR TITLE
Session warning dialog shouldn't reset timer

### DIFF
--- a/src/client/components/SessionTimer/index.js
+++ b/src/client/components/SessionTimer/index.js
@@ -69,7 +69,8 @@ function SessionTimer(props) {
     sessionStorage.removeItem(TIMEOUT_KEY);
   }
 
-  if (action === "startOrUpdate") {
+  // If the modal is showing, we don't want to restart the timer.
+  if (action === "startOrUpdate" && !showWarningModal) {
     startOrUpdate();
   } else if (action === "clear") {
     clear();


### PR DESCRIPTION
When we show the dialog, we change the state of the
SessionTimer, which causes it to re-render. The render
path resets all the timers!

Avoid this by not resetting the timers when the dialog
is showing.

===

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
