### PR TITLE
Allowing commas for gross earnings

### DIFF
--- a/src/client/components/EmployersQuestions/index.js
+++ b/src/client/components/EmployersQuestions/index.js
@@ -188,7 +188,7 @@ function EmployerQuestions(props) {
       })}
       {renderTextInput("grossEarnings", {
         className: "col-md-2",
-        pattern: "[$]?\\d+[.]?(\\d{2})?",
+        pattern: "[$]?(\\d+|\\d{1,3},\\d{3})[.]?(\\d{2})?",
         maxLength: 11,
       })}
       <Form.Group controlId={props.employerData.id + "reason-select"}>


### PR DESCRIPTION
- Updates the gross earnings field to accept commas. 

===

Resolves #XXX

- [x] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
