### PR TITLE
Log certain front-end errors in Azure 

### DIFF
--- a/src/client/components/WeekConfirmationDetails/index.js
+++ b/src/client/components/WeekConfirmationDetails/index.js
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import React from "react";
 import { Trans, useTranslation } from "react-i18next";
+import { logError } from "../../utils";
 
 function WeekConfirmationDetails(props) {
   const { employers, questionAnswers, questionKeys, weekString } = props;
@@ -109,7 +110,8 @@ function WeekConfirmationDetails(props) {
       answer === undefined ||
       (answer === "" && employer.reason !== "still-working")
     ) {
-      // TODO(kalvin): log this "missing answer" error in Azure
+      logError(`The answer is ${answer} for question ${questionName} on employer
+        ${employer}, which should never occur`);
     }
 
     if (questionName === "reason") {

--- a/src/client/components/WeekWithDetail/index.js
+++ b/src/client/components/WeekWithDetail/index.js
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import React from "react";
 import { Trans, useTranslation } from "react-i18next";
+import { logError } from "../../utils";
 import { startAndEndDate, toWeekString } from "../../../utils/retroCertsWeeks";
 import programPlan from "../../../data/programPlan";
 import WeekConfirmationDetails from "../WeekConfirmationDetails";
@@ -44,7 +45,8 @@ function WeekWithDetail(props) {
       // the "number of days you were sick" question, and then only
       // if the answer to "were you sick" was yes
       if (questionName !== "tooSickNumberOfDays" || weekData.tooSick) {
-        // TODO(kalvin): log this error in Azure
+        logError(`The answer is undefined for question ${questionName} with
+        weekData ${weekData}, which should never occur`);
       }
       return false;
     }
@@ -69,7 +71,8 @@ function WeekWithDetail(props) {
   const dates = startAndEndDate(weekIndex);
   const weekHasEmployers = weekData.workOrEarn;
   if (weekHasEmployers && !weekData.employers) {
-    // TODO(kalvin): log this "missing employer(s)" error in Azure
+    logError(`The employers field is missing from weekData ${weekData},
+      which should never occur`);
   }
 
   let questionNames;

--- a/src/client/utils.js
+++ b/src/client/utils.js
@@ -32,3 +32,10 @@ export function logPage(path) {
     page_path: path,
   });
 }
+
+// To view these errors, go to production Azure and click through:
+// Application Insights > Failures > Browser > Exceptions
+export function logError(errorMessage) {
+  const appInsights = getAppInsights();
+  appInsights.trackException({ exception: new Error(errorMessage) });
+}


### PR DESCRIPTION
This PR manually logs front-end errors to Application Insights for the first time, as a followup to #438. Our implementation isn't intended to be particularly robust, just a simple way to log basic front-end errors, when and where they occur.

Here's what the errors look like:
![image](https://user-images.githubusercontent.com/82277/89232831-58467c80-d5b6-11ea-94f0-ad2bd243fb0a.png)

To view these errors, go to production Azure and click through:
Application Insights > Failures > Browser > Exceptions

===

Resolves #505 

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
