### PR TITLE
Create Staff View login page

### DIFF
--- a/src/client/pages/StaffViewAuthPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/StaffViewAuthPage/__snapshots__/index.test.js.snap
@@ -1,0 +1,767 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<StaffViewAuthPage /> retro certs auth page 1`] = `
+<div
+  id="overflow-wrapper"
+>
+  <Header />
+  <main
+    id="certification-page"
+  >
+    <div
+      className="container p-4"
+    >
+      <h1>
+        Retroactive Certification for Unemployment
+      </h1>
+      <p>
+        * Indicates required text
+      </p>
+      <Form
+        inline={false}
+        noValidate={true}
+        onSubmit={[Function]}
+        validated={false}
+      >
+        <Row
+          noGutters={false}
+        >
+          <FormGroup
+            className="col-md-6"
+            controlId="formLastName"
+          >
+            <FormLabel
+              column={false}
+              srOnly={false}
+            >
+              * Last Name
+            </FormLabel>
+            <FormControl
+              onChange={[Function]}
+              required={true}
+              type="text"
+              value=""
+            />
+            <Feedback
+              type="invalid"
+            >
+              This field is required.
+            </Feedback>
+          </FormGroup>
+        </Row>
+        <div
+          className="mb-n2 mt-4"
+        >
+          * Date of Birth
+        </div>
+        <small
+          className="text-muted"
+        >
+          For example, 4 28 1990
+        </small>
+        <Row
+          noGutters={false}
+        >
+          <FormGroup
+            as={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "displayName": "Col",
+                "render": [Function],
+              }
+            }
+            controlId="formDobMonth"
+            md={2}
+          >
+            <FormLabel
+              column={false}
+              srOnly={false}
+            >
+              Month
+            </FormLabel>
+            <FormControl
+              maxLength={2}
+              onChange={[Function]}
+              pattern="(^0[1-9])|(^1[0-2])|(^[1-9]$)"
+              required={true}
+              type="text"
+              value=""
+            />
+            <Feedback
+              type="invalid"
+            >
+              This field is required.
+            </Feedback>
+          </FormGroup>
+          <FormGroup
+            as={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "displayName": "Col",
+                "render": [Function],
+              }
+            }
+            controlId="formDobDay"
+            md={2}
+          >
+            <FormLabel
+              column={false}
+              srOnly={false}
+            >
+              Day
+            </FormLabel>
+            <FormControl
+              maxLength={2}
+              onChange={[Function]}
+              pattern="(^0[1-9])|(^1[0-9])|(^2[0-9])|(^3[0-1])|(^[1-9]$)"
+              required={true}
+              type="text"
+              value=""
+            />
+            <Feedback
+              type="invalid"
+            >
+              This field is required.
+            </Feedback>
+          </FormGroup>
+          <FormGroup
+            as={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "displayName": "Col",
+                "render": [Function],
+              }
+            }
+            controlId="formDobYear"
+            md={3}
+          >
+            <FormLabel
+              column={false}
+              srOnly={false}
+            >
+              Year
+            </FormLabel>
+            <FormControl
+              maxLength={4}
+              onChange={[Function]}
+              pattern="[12][890]\\\\d\\\\d"
+              required={true}
+              type="text"
+              value=""
+            />
+            <Feedback
+              type="invalid"
+            >
+              This field is required.
+            </Feedback>
+          </FormGroup>
+        </Row>
+        <Row
+          className="mt-4"
+          noGutters={false}
+        >
+          <FormGroup
+            className="col-md-6"
+            controlId="formSsn"
+          >
+            <FormLabel
+              column={false}
+              srOnly={false}
+            >
+              * Social Security Number
+            </FormLabel>
+            <FormText
+              className="ssn-hint"
+              muted={true}
+            >
+              Enter your Social Security number with or without dashes.
+            </FormText>
+            <span
+              className="sr-only"
+              id="ssn-sr-desc"
+            >
+              You can select Show SSN after this input field
+            </span>
+            <FormControl
+              aria-describedby="ssn-sr-desc"
+              onChange={[Function]}
+              required={true}
+              value=""
+            />
+            <Feedback
+              type="invalid"
+            >
+              This field is required.
+            </Feedback>
+            <div
+              className="d-flex justify-content-end"
+            >
+              <Button
+                active={false}
+                disabled={false}
+                onClick={[Function]}
+                size="sm"
+                style={
+                  Object {
+                    "fontWeight": "normal",
+                  }
+                }
+                type="button"
+                variant="link"
+              >
+                Show SSN
+              </Button>
+            </div>
+          </FormGroup>
+        </Row>
+        <Button
+          active={false}
+          className="mt-4"
+          disabled={false}
+          type="submit"
+          variant="secondary"
+        >
+          Find Me
+        </Button>
+      </Form>
+    </div>
+  </main>
+  <SessionTimer
+    action="clear"
+    setUserData={[Function]}
+  />
+  <Footer
+    backToTopTag="certification-page"
+  />
+</div>
+`;
+
+exports[`<StaffViewAuthPage /> retro certs auth page with session timeout 1`] = `
+<div
+  id="overflow-wrapper"
+>
+  <Header />
+  <main
+    id="certification-page"
+  >
+    <div
+      className="container p-4"
+    >
+      <h1>
+        Retroactive Certification for Unemployment
+      </h1>
+      <Row
+        noGutters={false}
+      >
+        <div
+          className="col-md-12"
+        >
+          <Alert
+            closeLabel="Close alert"
+            show={true}
+            transition={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "defaultProps": Object {
+                  "appear": false,
+                  "in": false,
+                  "mountOnEnter": false,
+                  "timeout": 300,
+                  "unmountOnExit": false,
+                },
+                "displayName": "Fade",
+                "render": [Function],
+              }
+            }
+            variant="danger"
+          >
+            You were logged out after 30 minutes of inactivity. Provide your information again to certify your weeks.
+          </Alert>
+        </div>
+      </Row>
+      <p>
+        * Indicates required text
+      </p>
+      <Form
+        inline={false}
+        noValidate={true}
+        onSubmit={[Function]}
+        validated={false}
+      >
+        <Row
+          noGutters={false}
+        >
+          <FormGroup
+            className="col-md-6"
+            controlId="formLastName"
+          >
+            <FormLabel
+              column={false}
+              srOnly={false}
+            >
+              * Last Name
+            </FormLabel>
+            <FormControl
+              onChange={[Function]}
+              required={true}
+              type="text"
+              value=""
+            />
+            <Feedback
+              type="invalid"
+            >
+              This field is required.
+            </Feedback>
+          </FormGroup>
+        </Row>
+        <div
+          className="mb-n2 mt-4"
+        >
+          * Date of Birth
+        </div>
+        <small
+          className="text-muted"
+        >
+          For example, 4 28 1990
+        </small>
+        <Row
+          noGutters={false}
+        >
+          <FormGroup
+            as={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "displayName": "Col",
+                "render": [Function],
+              }
+            }
+            controlId="formDobMonth"
+            md={2}
+          >
+            <FormLabel
+              column={false}
+              srOnly={false}
+            >
+              Month
+            </FormLabel>
+            <FormControl
+              maxLength={2}
+              onChange={[Function]}
+              pattern="(^0[1-9])|(^1[0-2])|(^[1-9]$)"
+              required={true}
+              type="text"
+              value=""
+            />
+            <Feedback
+              type="invalid"
+            >
+              This field is required.
+            </Feedback>
+          </FormGroup>
+          <FormGroup
+            as={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "displayName": "Col",
+                "render": [Function],
+              }
+            }
+            controlId="formDobDay"
+            md={2}
+          >
+            <FormLabel
+              column={false}
+              srOnly={false}
+            >
+              Day
+            </FormLabel>
+            <FormControl
+              maxLength={2}
+              onChange={[Function]}
+              pattern="(^0[1-9])|(^1[0-9])|(^2[0-9])|(^3[0-1])|(^[1-9]$)"
+              required={true}
+              type="text"
+              value=""
+            />
+            <Feedback
+              type="invalid"
+            >
+              This field is required.
+            </Feedback>
+          </FormGroup>
+          <FormGroup
+            as={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "displayName": "Col",
+                "render": [Function],
+              }
+            }
+            controlId="formDobYear"
+            md={3}
+          >
+            <FormLabel
+              column={false}
+              srOnly={false}
+            >
+              Year
+            </FormLabel>
+            <FormControl
+              maxLength={4}
+              onChange={[Function]}
+              pattern="[12][890]\\\\d\\\\d"
+              required={true}
+              type="text"
+              value=""
+            />
+            <Feedback
+              type="invalid"
+            >
+              This field is required.
+            </Feedback>
+          </FormGroup>
+        </Row>
+        <Row
+          className="mt-4"
+          noGutters={false}
+        >
+          <FormGroup
+            className="col-md-6"
+            controlId="formSsn"
+          >
+            <FormLabel
+              column={false}
+              srOnly={false}
+            >
+              * Social Security Number
+            </FormLabel>
+            <FormText
+              className="ssn-hint"
+              muted={true}
+            >
+              Enter your Social Security number with or without dashes.
+            </FormText>
+            <span
+              className="sr-only"
+              id="ssn-sr-desc"
+            >
+              You can select Show SSN after this input field
+            </span>
+            <FormControl
+              aria-describedby="ssn-sr-desc"
+              onChange={[Function]}
+              required={true}
+              value=""
+            />
+            <Feedback
+              type="invalid"
+            >
+              This field is required.
+            </Feedback>
+            <div
+              className="d-flex justify-content-end"
+            >
+              <Button
+                active={false}
+                disabled={false}
+                onClick={[Function]}
+                size="sm"
+                style={
+                  Object {
+                    "fontWeight": "normal",
+                  }
+                }
+                type="button"
+                variant="link"
+              >
+                Show SSN
+              </Button>
+            </div>
+          </FormGroup>
+        </Row>
+        <Button
+          active={false}
+          className="mt-4"
+          disabled={false}
+          type="submit"
+          variant="secondary"
+        >
+          Find Me
+        </Button>
+      </Form>
+    </div>
+  </main>
+  <SessionTimer
+    action="clear"
+    setUserData={[Function]}
+  />
+  <Footer
+    backToTopTag="certification-page"
+  />
+</div>
+`;
+
+exports[`<StaffViewAuthPage /> retro certs auth page with user not found error 1`] = `
+<div
+  id="overflow-wrapper"
+>
+  <Header />
+  <main
+    id="certification-page"
+  >
+    <div
+      className="container p-4"
+    >
+      <h1>
+        Retroactive Certification for Unemployment
+      </h1>
+      <p>
+        * Indicates required text
+      </p>
+      <Form
+        inline={false}
+        noValidate={true}
+        onSubmit={[Function]}
+        validated={false}
+      >
+        <Row
+          noGutters={false}
+        >
+          <FormGroup
+            className="col-md-6"
+            controlId="formLastName"
+          >
+            <FormLabel
+              column={false}
+              srOnly={false}
+            >
+              * Last Name
+            </FormLabel>
+            <FormControl
+              onChange={[Function]}
+              required={true}
+              type="text"
+              value=""
+            />
+            <Feedback
+              type="invalid"
+            >
+              This field is required.
+            </Feedback>
+          </FormGroup>
+        </Row>
+        <div
+          className="mb-n2 mt-4"
+        >
+          * Date of Birth
+        </div>
+        <small
+          className="text-muted"
+        >
+          For example, 4 28 1990
+        </small>
+        <Row
+          noGutters={false}
+        >
+          <FormGroup
+            as={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "displayName": "Col",
+                "render": [Function],
+              }
+            }
+            controlId="formDobMonth"
+            md={2}
+          >
+            <FormLabel
+              column={false}
+              srOnly={false}
+            >
+              Month
+            </FormLabel>
+            <FormControl
+              maxLength={2}
+              onChange={[Function]}
+              pattern="(^0[1-9])|(^1[0-2])|(^[1-9]$)"
+              required={true}
+              type="text"
+              value=""
+            />
+            <Feedback
+              type="invalid"
+            >
+              This field is required.
+            </Feedback>
+          </FormGroup>
+          <FormGroup
+            as={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "displayName": "Col",
+                "render": [Function],
+              }
+            }
+            controlId="formDobDay"
+            md={2}
+          >
+            <FormLabel
+              column={false}
+              srOnly={false}
+            >
+              Day
+            </FormLabel>
+            <FormControl
+              maxLength={2}
+              onChange={[Function]}
+              pattern="(^0[1-9])|(^1[0-9])|(^2[0-9])|(^3[0-1])|(^[1-9]$)"
+              required={true}
+              type="text"
+              value=""
+            />
+            <Feedback
+              type="invalid"
+            >
+              This field is required.
+            </Feedback>
+          </FormGroup>
+          <FormGroup
+            as={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "displayName": "Col",
+                "render": [Function],
+              }
+            }
+            controlId="formDobYear"
+            md={3}
+          >
+            <FormLabel
+              column={false}
+              srOnly={false}
+            >
+              Year
+            </FormLabel>
+            <FormControl
+              maxLength={4}
+              onChange={[Function]}
+              pattern="[12][890]\\\\d\\\\d"
+              required={true}
+              type="text"
+              value=""
+            />
+            <Feedback
+              type="invalid"
+            >
+              This field is required.
+            </Feedback>
+          </FormGroup>
+        </Row>
+        <Row
+          className="mt-4"
+          noGutters={false}
+        >
+          <FormGroup
+            className="col-md-6"
+            controlId="formSsn"
+          >
+            <FormLabel
+              column={false}
+              srOnly={false}
+            >
+              * Social Security Number
+            </FormLabel>
+            <FormText
+              className="ssn-hint"
+              muted={true}
+            >
+              Enter your Social Security number with or without dashes.
+            </FormText>
+            <span
+              className="sr-only"
+              id="ssn-sr-desc"
+            >
+              You can select Show SSN after this input field
+            </span>
+            <FormControl
+              aria-describedby="ssn-sr-desc"
+              onChange={[Function]}
+              required={true}
+              value=""
+            />
+            <Feedback
+              type="invalid"
+            >
+              This field is required.
+            </Feedback>
+            <div
+              className="d-flex justify-content-end"
+            >
+              <Button
+                active={false}
+                disabled={false}
+                onClick={[Function]}
+                size="sm"
+                style={
+                  Object {
+                    "fontWeight": "normal",
+                  }
+                }
+                type="button"
+                variant="link"
+              >
+                Show SSN
+              </Button>
+            </div>
+          </FormGroup>
+        </Row>
+        <Row
+          noGutters={false}
+        >
+          <div
+            className="col-md-12"
+          >
+            <Alert
+              closeLabel="Close alert"
+              show={true}
+              transition={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "defaultProps": Object {
+                    "appear": false,
+                    "in": false,
+                    "mountOnEnter": false,
+                    "timeout": 300,
+                    "unmountOnExit": false,
+                  },
+                  "displayName": "Fade",
+                  "render": [Function],
+                }
+              }
+              variant="danger"
+            >
+              This claimant is not found in the database and does not need to retroactively certify.
+            </Alert>
+          </div>
+        </Row>
+        <Button
+          active={false}
+          className="mt-4"
+          disabled={false}
+          type="submit"
+          variant="secondary"
+        >
+          Find Me
+        </Button>
+      </Form>
+    </div>
+  </main>
+  <SessionTimer
+    action="clear"
+    setUserData={[Function]}
+  />
+  <Footer
+    backToTopTag="certification-page"
+  />
+</div>
+`;

--- a/src/client/pages/StaffViewAuthPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/StaffViewAuthPage/__snapshots__/index.test.js.snap
@@ -176,12 +176,6 @@ exports[`<StaffViewAuthPage /> retro certs auth page 1`] = `
             >
               Enter your Social Security number with or without dashes.
             </FormText>
-            <span
-              className="sr-only"
-              id="ssn-sr-desc"
-            >
-              You can select Show SSN after this input field
-            </span>
             <FormControl
               aria-describedby="ssn-sr-desc"
               onChange={[Function]}
@@ -193,25 +187,6 @@ exports[`<StaffViewAuthPage /> retro certs auth page 1`] = `
             >
               This field is required.
             </Feedback>
-            <div
-              className="d-flex justify-content-end"
-            >
-              <Button
-                active={false}
-                disabled={false}
-                onClick={[Function]}
-                size="sm"
-                style={
-                  Object {
-                    "fontWeight": "normal",
-                  }
-                }
-                type="button"
-                variant="link"
-              >
-                Show SSN
-              </Button>
-            </div>
           </FormGroup>
         </Row>
         <Button
@@ -226,275 +201,6 @@ exports[`<StaffViewAuthPage /> retro certs auth page 1`] = `
       </Form>
     </div>
   </main>
-  <SessionTimer
-    action="clear"
-    setUserData={[Function]}
-  />
-  <Footer
-    backToTopTag="certification-page"
-  />
-</div>
-`;
-
-exports[`<StaffViewAuthPage /> retro certs auth page with session timeout 1`] = `
-<div
-  id="overflow-wrapper"
->
-  <Header />
-  <main
-    id="certification-page"
-  >
-    <div
-      className="container p-4"
-    >
-      <h1>
-        Retroactive Certification for Unemployment
-      </h1>
-      <Row
-        noGutters={false}
-      >
-        <div
-          className="col-md-12"
-        >
-          <Alert
-            closeLabel="Close alert"
-            show={true}
-            transition={
-              Object {
-                "$$typeof": Symbol(react.forward_ref),
-                "defaultProps": Object {
-                  "appear": false,
-                  "in": false,
-                  "mountOnEnter": false,
-                  "timeout": 300,
-                  "unmountOnExit": false,
-                },
-                "displayName": "Fade",
-                "render": [Function],
-              }
-            }
-            variant="danger"
-          >
-            You were logged out after 30 minutes of inactivity. Provide your information again to certify your weeks.
-          </Alert>
-        </div>
-      </Row>
-      <p>
-        * Indicates required text
-      </p>
-      <Form
-        inline={false}
-        noValidate={true}
-        onSubmit={[Function]}
-        validated={false}
-      >
-        <Row
-          noGutters={false}
-        >
-          <FormGroup
-            className="col-md-6"
-            controlId="formLastName"
-          >
-            <FormLabel
-              column={false}
-              srOnly={false}
-            >
-              * Last Name
-            </FormLabel>
-            <FormControl
-              onChange={[Function]}
-              required={true}
-              type="text"
-              value=""
-            />
-            <Feedback
-              type="invalid"
-            >
-              This field is required.
-            </Feedback>
-          </FormGroup>
-        </Row>
-        <div
-          className="mb-n2 mt-4"
-        >
-          * Date of Birth
-        </div>
-        <small
-          className="text-muted"
-        >
-          For example, 4 28 1990
-        </small>
-        <Row
-          noGutters={false}
-        >
-          <FormGroup
-            as={
-              Object {
-                "$$typeof": Symbol(react.forward_ref),
-                "displayName": "Col",
-                "render": [Function],
-              }
-            }
-            controlId="formDobMonth"
-            md={2}
-          >
-            <FormLabel
-              column={false}
-              srOnly={false}
-            >
-              Month
-            </FormLabel>
-            <FormControl
-              maxLength={2}
-              onChange={[Function]}
-              pattern="(^0[1-9])|(^1[0-2])|(^[1-9]$)"
-              required={true}
-              type="text"
-              value=""
-            />
-            <Feedback
-              type="invalid"
-            >
-              This field is required.
-            </Feedback>
-          </FormGroup>
-          <FormGroup
-            as={
-              Object {
-                "$$typeof": Symbol(react.forward_ref),
-                "displayName": "Col",
-                "render": [Function],
-              }
-            }
-            controlId="formDobDay"
-            md={2}
-          >
-            <FormLabel
-              column={false}
-              srOnly={false}
-            >
-              Day
-            </FormLabel>
-            <FormControl
-              maxLength={2}
-              onChange={[Function]}
-              pattern="(^0[1-9])|(^1[0-9])|(^2[0-9])|(^3[0-1])|(^[1-9]$)"
-              required={true}
-              type="text"
-              value=""
-            />
-            <Feedback
-              type="invalid"
-            >
-              This field is required.
-            </Feedback>
-          </FormGroup>
-          <FormGroup
-            as={
-              Object {
-                "$$typeof": Symbol(react.forward_ref),
-                "displayName": "Col",
-                "render": [Function],
-              }
-            }
-            controlId="formDobYear"
-            md={3}
-          >
-            <FormLabel
-              column={false}
-              srOnly={false}
-            >
-              Year
-            </FormLabel>
-            <FormControl
-              maxLength={4}
-              onChange={[Function]}
-              pattern="[12][890]\\\\d\\\\d"
-              required={true}
-              type="text"
-              value=""
-            />
-            <Feedback
-              type="invalid"
-            >
-              This field is required.
-            </Feedback>
-          </FormGroup>
-        </Row>
-        <Row
-          className="mt-4"
-          noGutters={false}
-        >
-          <FormGroup
-            className="col-md-6"
-            controlId="formSsn"
-          >
-            <FormLabel
-              column={false}
-              srOnly={false}
-            >
-              * Social Security Number
-            </FormLabel>
-            <FormText
-              className="ssn-hint"
-              muted={true}
-            >
-              Enter your Social Security number with or without dashes.
-            </FormText>
-            <span
-              className="sr-only"
-              id="ssn-sr-desc"
-            >
-              You can select Show SSN after this input field
-            </span>
-            <FormControl
-              aria-describedby="ssn-sr-desc"
-              onChange={[Function]}
-              required={true}
-              value=""
-            />
-            <Feedback
-              type="invalid"
-            >
-              This field is required.
-            </Feedback>
-            <div
-              className="d-flex justify-content-end"
-            >
-              <Button
-                active={false}
-                disabled={false}
-                onClick={[Function]}
-                size="sm"
-                style={
-                  Object {
-                    "fontWeight": "normal",
-                  }
-                }
-                type="button"
-                variant="link"
-              >
-                Show SSN
-              </Button>
-            </div>
-          </FormGroup>
-        </Row>
-        <Button
-          active={false}
-          className="mt-4"
-          disabled={false}
-          type="submit"
-          variant="secondary"
-        >
-          Find Me
-        </Button>
-      </Form>
-    </div>
-  </main>
-  <SessionTimer
-    action="clear"
-    setUserData={[Function]}
-  />
   <Footer
     backToTopTag="certification-page"
   />
@@ -677,12 +383,6 @@ exports[`<StaffViewAuthPage /> retro certs auth page with user not found error 1
             >
               Enter your Social Security number with or without dashes.
             </FormText>
-            <span
-              className="sr-only"
-              id="ssn-sr-desc"
-            >
-              You can select Show SSN after this input field
-            </span>
             <FormControl
               aria-describedby="ssn-sr-desc"
               onChange={[Function]}
@@ -694,25 +394,6 @@ exports[`<StaffViewAuthPage /> retro certs auth page with user not found error 1
             >
               This field is required.
             </Feedback>
-            <div
-              className="d-flex justify-content-end"
-            >
-              <Button
-                active={false}
-                disabled={false}
-                onClick={[Function]}
-                size="sm"
-                style={
-                  Object {
-                    "fontWeight": "normal",
-                  }
-                }
-                type="button"
-                variant="link"
-              >
-                Show SSN
-              </Button>
-            </div>
           </FormGroup>
         </Row>
         <Row
@@ -756,10 +437,6 @@ exports[`<StaffViewAuthPage /> retro certs auth page with user not found error 1
       </Form>
     </div>
   </main>
-  <SessionTimer
-    action="clear"
-    setUserData={[Function]}
-  />
   <Footer
     backToTopTag="certification-page"
   />

--- a/src/client/pages/StaffViewAuthPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/StaffViewAuthPage/__snapshots__/index.test.js.snap
@@ -14,6 +14,14 @@ exports[`<StaffViewAuthPage /> retro certs auth page 1`] = `
       <h1>
         Retroactive Certification for Unemployment
       </h1>
+      <h2
+        className="h3 font-weight-bold mb-3"
+      >
+        Staff View
+      </h2>
+      <p>
+        Enter claimant information below.
+      </p>
       <p>
         * Indicates required text
       </p>
@@ -196,7 +204,7 @@ exports[`<StaffViewAuthPage /> retro certs auth page 1`] = `
           type="submit"
           variant="secondary"
         >
-          Find Me
+          Search
         </Button>
       </Form>
     </div>
@@ -221,6 +229,14 @@ exports[`<StaffViewAuthPage /> retro certs auth page with user not found error 1
       <h1>
         Retroactive Certification for Unemployment
       </h1>
+      <h2
+        className="h3 font-weight-bold mb-3"
+      >
+        Staff View
+      </h2>
+      <p>
+        Enter claimant information below.
+      </p>
       <p>
         * Indicates required text
       </p>
@@ -397,6 +413,7 @@ exports[`<StaffViewAuthPage /> retro certs auth page with user not found error 1
           </FormGroup>
         </Row>
         <Row
+          className="mt-3"
           noGutters={false}
         >
           <div
@@ -432,7 +449,7 @@ exports[`<StaffViewAuthPage /> retro certs auth page with user not found error 1
           type="submit"
           variant="secondary"
         >
-          Find Me
+          Search
         </Button>
       </Form>
     </div>

--- a/src/client/pages/StaffViewAuthPage/index.js
+++ b/src/client/pages/StaffViewAuthPage/index.js
@@ -40,7 +40,7 @@ function StaffViewAuthPage(props) {
   const errorTransKey = new Map([
     [
       AUTH_STRINGS.statusCode.userNotFound,
-      "retrocert-login.invalid-user-error-staff-view",
+      "staff-view-login.invalid-user-error",
     ],
   ]).get(status);
 
@@ -142,10 +142,10 @@ function StaffViewAuthPage(props) {
         <div className="container p-4">
           <h1>{t("retrocert-login.title")}</h1>
           <h2 className="h3 font-weight-bold mb-3">
-            {t("retrocert-login.header1-staff-view")}
+            {t("staff-view-login.header1")}
           </h2>
           {showGenericValidationError && validated && genericValidationError}
-          <p>{t("retrocert-login.instructions-staff-view")}</p>
+          <p>{t("staff-view-login.instructions")}</p>
           <p>{t("retrocert-login.required-text")}</p>
           <Form noValidate validated={validated} onSubmit={handleSubmit}>
             <Row>
@@ -231,10 +231,10 @@ function StaffViewAuthPage(props) {
                 </Form.Control.Feedback>
               </Form.Group>
             </Row>
-            {errorTransKey ===
-              "retrocert-login.invalid-user-error-staff-view" && errorAlert}
+            {errorTransKey === "staff-view-login.invalid-user-error" &&
+              errorAlert}
             <Button variant="secondary" type="submit" className="mt-4">
-              {t("retrocert-login.submit")}
+              {t("staff-view-login.submit")}
             </Button>
           </Form>
         </div>

--- a/src/client/pages/StaffViewAuthPage/index.js
+++ b/src/client/pages/StaffViewAuthPage/index.js
@@ -1,6 +1,6 @@
 // This page is identical to RetroCertsAuthPage, minus the captcha, Spanish
-// translation button, and helper text below the header. It also has a
-// different error message for userNotFound.
+// translation button, Show SSN button, and helper text below the header.
+// It also has a different error message for userNotFound.
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import Button from "react-bootstrap/Button";
@@ -8,16 +8,14 @@ import Form from "react-bootstrap/Form";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
 import Alert from "react-bootstrap/Alert";
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import AUTH_STRINGS from "../../../data/authStrings";
 import routes from "../../../data/routes";
 import { userDataPropType, setUserDataPropType } from "../../commonPropTypes";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header";
-import SessionTimer from "../../components/SessionTimer";
 import weeksCompleted from "../../../utils/checkFormData";
 import { fromIndexToPathString } from "../../../utils/retroCertsWeeks";
-import Inputmask from "inputmask";
 import { autoScroll, TOP, BEHAVIOR } from "../../../utils/autoScroll";
 
 function StaffViewAuthPage(props) {
@@ -34,7 +32,6 @@ function StaffViewAuthPage(props) {
   const [dobYear, setDobYear] = useState("");
   const [ssn, setSsn] = useState("");
   const [validated, setValidated] = useState(false);
-  const [showSsn, setShowSsn] = useState(false);
   const [showGenericValidationError, setShowGenericValidationError] = useState(
     false
   );
@@ -44,10 +41,6 @@ function StaffViewAuthPage(props) {
     [
       AUTH_STRINGS.statusCode.userNotFound,
       "retrocert-login.invalid-user-error-staff-view",
-    ],
-    [
-      AUTH_STRINGS.statusCode.sessionTimedOut,
-      "retrocert-login.session-timed-out",
     ],
   ]).get(status);
 
@@ -91,9 +84,7 @@ function StaffViewAuthPage(props) {
       body: JSON.stringify({
         lastName: lastName.trim(),
         dob: `${month}-${day}-${dobYear}`.trim(),
-        ssn: ssn.inputmask
-          ? ssn.inputmask.unmaskedvalue()
-          : ssn.trim().replace(/-/g, ""),
+        ssn: ssn.trim().replace(/-/g, ""),
       }),
     })
       .then((response) => response.json())
@@ -135,31 +126,6 @@ function StaffViewAuthPage(props) {
   const handleChange = (event, setter) => {
     setter(event.target.value);
   };
-
-  useEffect(() => {
-    const ssnRef = document.getElementById("formSsn");
-    if (showSsn) {
-      Inputmask.remove(ssnRef);
-      Inputmask("ssn", { placeholder: "#" }).mask(ssnRef);
-      ssnRef.type = "text";
-    } else {
-      Inputmask.remove(ssnRef);
-      Inputmask("9", { repeat: "9", jitMasking: true }).mask(ssnRef);
-      ssnRef.type = "password";
-      ssnRef.placeholder = "###-##-####";
-    }
-  });
-
-  function toggleSsn() {
-    const toggle = !showSsn;
-    setShowSsn(toggle);
-  }
-
-  function getSsnToggleText() {
-    return showSsn
-      ? t("retrocert-login.hide-ssn")
-      : t("retrocert-login.show-ssn");
-  }
 
   const genericValidationError = (
     <Row>
@@ -251,11 +217,6 @@ function StaffViewAuthPage(props) {
                 <Form.Text muted className="ssn-hint">
                   {t("retrocert-login.ssn-hint")}
                 </Form.Text>
-                {/* sr-only is invisible and used for screen readers:
-                https://v4-alpha.getbootstrap.com/getting-started/accessibility/#skip-navigation */}
-                <span id="ssn-sr-desc" className="sr-only">
-                  {t("retrocert-login.ssn-screen-reader")}
-                </span>
                 <Form.Control
                   value={ssn}
                   onChange={(e) => handleChange(e, setSsn)}
@@ -265,16 +226,6 @@ function StaffViewAuthPage(props) {
                 <Form.Control.Feedback type="invalid">
                   {t("required-error")}
                 </Form.Control.Feedback>
-                <div className="d-flex justify-content-end">
-                  <Button
-                    onClick={toggleSsn}
-                    variant="link"
-                    style={{ fontWeight: "normal" }}
-                    size="sm"
-                  >
-                    {getSsnToggleText()}
-                  </Button>
-                </div>
               </Form.Group>
             </Row>
             {errorTransKey ===
@@ -285,7 +236,6 @@ function StaffViewAuthPage(props) {
           </Form>
         </div>
       </main>
-      <SessionTimer action="clear" setUserData={setUserDataPropType} />
       <Footer backToTopTag="certification-page" />
     </div>
   );

--- a/src/client/pages/StaffViewAuthPage/index.js
+++ b/src/client/pages/StaffViewAuthPage/index.js
@@ -141,8 +141,11 @@ function StaffViewAuthPage(props) {
       <main id="certification-page">
         <div className="container p-4">
           <h1>{t("retrocert-login.title")}</h1>
+          <h2 className="h3 font-weight-bold mb-3">
+            {t("retrocert-login.header1-staff-view")}
+          </h2>
           {showGenericValidationError && validated && genericValidationError}
-          {errorTransKey === "retrocert-login.session-timed-out" && errorAlert}
+          <p>{t("retrocert-login.instructions-staff-view")}</p>
           <p>{t("retrocert-login.required-text")}</p>
           <Form noValidate validated={validated} onSubmit={handleSubmit}>
             <Row>

--- a/src/client/pages/StaffViewAuthPage/index.js
+++ b/src/client/pages/StaffViewAuthPage/index.js
@@ -1,0 +1,299 @@
+// This page is identical to RetroCertsAuthPage, minus the captcha, Spanish
+// translation button, and helper text below the header. It also has a
+// different error message for userNotFound.
+import { useTranslation } from "react-i18next";
+import { useHistory } from "react-router-dom";
+import Button from "react-bootstrap/Button";
+import Form from "react-bootstrap/Form";
+import Col from "react-bootstrap/Col";
+import Row from "react-bootstrap/Row";
+import Alert from "react-bootstrap/Alert";
+import React, { useState, useEffect } from "react";
+import AUTH_STRINGS from "../../../data/authStrings";
+import routes from "../../../data/routes";
+import { userDataPropType, setUserDataPropType } from "../../commonPropTypes";
+import Footer from "../../components/Footer";
+import Header from "../../components/Header";
+import SessionTimer from "../../components/SessionTimer";
+import weeksCompleted from "../../../utils/checkFormData";
+import { fromIndexToPathString } from "../../../utils/retroCertsWeeks";
+import Inputmask from "inputmask";
+import { autoScroll, TOP, BEHAVIOR } from "../../../utils/autoScroll";
+
+function StaffViewAuthPage(props) {
+  const { t } = useTranslation();
+  document.title = t("retrocert-login.title");
+  const history = useHistory();
+
+  const userData = props.userData;
+  const setUserData = props.setUserData;
+
+  const [lastName, setLastName] = useState("");
+  const [dobMonth, setDobMonth] = useState("");
+  const [dobDay, setDobDay] = useState("");
+  const [dobYear, setDobYear] = useState("");
+  const [ssn, setSsn] = useState("");
+  const [validated, setValidated] = useState(false);
+  const [showSsn, setShowSsn] = useState(false);
+  const [showGenericValidationError, setShowGenericValidationError] = useState(
+    false
+  );
+
+  const status = userData && userData.status;
+  const errorTransKey = new Map([
+    [
+      AUTH_STRINGS.statusCode.userNotFound,
+      "retrocert-login.invalid-user-error-staff-view",
+    ],
+    [
+      AUTH_STRINGS.statusCode.sessionTimedOut,
+      "retrocert-login.session-timed-out",
+    ],
+  ]).get(status);
+
+  const errorAlert = errorTransKey && (
+    <Row>
+      <div className="col-md-12">
+        <Alert variant="danger">{t(errorTransKey)}</Alert>
+      </div>
+    </Row>
+  );
+
+  const handleSubmit = (event) => {
+    const form = event.currentTarget;
+    const isValid = form.checkValidity();
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    setValidated(true);
+
+    if (!isValid) {
+      setShowGenericValidationError(true);
+      autoScroll({
+        y: TOP.y,
+        x: TOP.x,
+        behavior: BEHAVIOR.smooth,
+      });
+      return;
+    }
+
+    setShowGenericValidationError(false);
+
+    const month = dobMonth.length < 2 ? "0" + dobMonth : dobMonth;
+    const day = dobDay.length < 2 ? "0" + dobDay : dobDay;
+
+    fetch(AUTH_STRINGS.apiPath.login, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        lastName: lastName.trim(),
+        dob: `${month}-${day}-${dobYear}`.trim(),
+        ssn: ssn.inputmask
+          ? ssn.inputmask.unmaskedvalue()
+          : ssn.trim().replace(/-/g, ""),
+      }),
+    })
+      .then((response) => response.json())
+      .then((data) => {
+        setUserData(data);
+        if (data.authToken) {
+          // Session storage is destroyed when the tab is closed! That's a bit weird.
+          // If we want to allow the user to use multiple tabs, we could sync the
+          // value across tabs:
+          // https://medium.com/@marciomariani/sharing-sessionstorage-between-tabs-5b6f42c6348c
+          sessionStorage.setItem(AUTH_STRINGS.authToken, data.authToken);
+
+          if (data.confirmationNumber) {
+            // The user has already completed the retro-certs process.
+            history.push(routes.retroCertsConfirmation, { isReturning: true });
+          } else {
+            const completedWeeks = weeksCompleted(
+              data.formData,
+              data.programPlan
+            );
+            if (completedWeeks === 0) {
+              history.push(routes.retroCertsWeeksToCertify);
+            } else {
+              history.push(
+                `${routes.retroCertsCertify}/${fromIndexToPathString(
+                  data.weeksToCertify[
+                    Math.min(completedWeeks, data.weeksToCertify.length - 1)
+                  ]
+                )}`,
+                { returningUser: true }
+              );
+            }
+          }
+        }
+      })
+      .catch((error) => console.error(error));
+  };
+
+  const handleChange = (event, setter) => {
+    setter(event.target.value);
+  };
+
+  useEffect(() => {
+    const ssnRef = document.getElementById("formSsn");
+    if (showSsn) {
+      Inputmask.remove(ssnRef);
+      Inputmask("ssn", { placeholder: "#" }).mask(ssnRef);
+      ssnRef.type = "text";
+    } else {
+      Inputmask.remove(ssnRef);
+      Inputmask("9", { repeat: "9", jitMasking: true }).mask(ssnRef);
+      ssnRef.type = "password";
+      ssnRef.placeholder = "###-##-####";
+    }
+  });
+
+  function toggleSsn() {
+    const toggle = !showSsn;
+    setShowSsn(toggle);
+  }
+
+  function getSsnToggleText() {
+    return showSsn
+      ? t("retrocert-login.hide-ssn")
+      : t("retrocert-login.show-ssn");
+  }
+
+  const genericValidationError = (
+    <Row>
+      <div className="col-md-12">
+        <Alert variant="danger">{t("generic-validation-error-message")}</Alert>
+      </div>
+    </Row>
+  );
+
+  return (
+    <div id="overflow-wrapper">
+      <Header />
+      <main id="certification-page">
+        <div className="container p-4">
+          <h1>{t("retrocert-login.title")}</h1>
+          {showGenericValidationError && validated && genericValidationError}
+          {errorTransKey === "retrocert-login.session-timed-out" && errorAlert}
+          <p>{t("retrocert-login.required-text")}</p>
+          <Form noValidate validated={validated} onSubmit={handleSubmit}>
+            <Row>
+              <Form.Group controlId="formLastName" className="col-md-6">
+                <Form.Label>{`* ${t(
+                  "retrocert-login.last-name-label"
+                )}`}</Form.Label>
+                <Form.Control
+                  type="text"
+                  value={lastName}
+                  onChange={(e) => handleChange(e, setLastName)}
+                  required
+                />
+                <Form.Control.Feedback type="invalid">
+                  {t("required-error")}
+                </Form.Control.Feedback>
+              </Form.Group>
+            </Row>
+            <div className="mb-n2 mt-4">{`* ${t(
+              "retrocert-login.dob-heading"
+            )}`}</div>
+            <small className="text-muted">
+              {t("retrocert-login.dob-hint")}
+            </small>
+            <Row>
+              <Form.Group controlId="formDobMonth" as={Col} md={2}>
+                <Form.Label>{t("retrocert-login.dob-month")}</Form.Label>
+                <Form.Control
+                  type="text"
+                  value={dobMonth}
+                  maxLength={2}
+                  onChange={(e) => handleChange(e, setDobMonth)}
+                  required
+                  pattern="(^0[1-9])|(^1[0-2])|(^[1-9]$)"
+                />
+                <Form.Control.Feedback type="invalid">
+                  {t("required-error")}
+                </Form.Control.Feedback>
+              </Form.Group>
+              <Form.Group controlId="formDobDay" as={Col} md={2}>
+                <Form.Label>{t("retrocert-login.dob-day")}</Form.Label>
+                <Form.Control
+                  type="text"
+                  value={dobDay}
+                  maxLength={2}
+                  onChange={(e) => handleChange(e, setDobDay)}
+                  required
+                  pattern="(^0[1-9])|(^1[0-9])|(^2[0-9])|(^3[0-1])|(^[1-9]$)"
+                />
+                <Form.Control.Feedback type="invalid">
+                  {t("required-error")}
+                </Form.Control.Feedback>
+              </Form.Group>
+              <Form.Group controlId="formDobYear" as={Col} md={3}>
+                <Form.Label>{t("retrocert-login.dob-year")}</Form.Label>
+                <Form.Control
+                  type="text"
+                  value={dobYear}
+                  maxLength={4}
+                  onChange={(e) => handleChange(e, setDobYear)}
+                  required
+                  pattern="[12][890]\d\d"
+                />
+                <Form.Control.Feedback type="invalid">
+                  {t("required-error")}
+                </Form.Control.Feedback>
+              </Form.Group>
+            </Row>
+            <Row className="mt-4">
+              <Form.Group controlId="formSsn" className="col-md-6">
+                <Form.Label>{`* ${t("retrocert-login.ssn-label")}`}</Form.Label>
+                <Form.Text muted className="ssn-hint">
+                  {t("retrocert-login.ssn-hint")}
+                </Form.Text>
+                {/* sr-only is invisible and used for screen readers:
+                https://v4-alpha.getbootstrap.com/getting-started/accessibility/#skip-navigation */}
+                <span id="ssn-sr-desc" className="sr-only">
+                  {t("retrocert-login.ssn-screen-reader")}
+                </span>
+                <Form.Control
+                  value={ssn}
+                  onChange={(e) => handleChange(e, setSsn)}
+                  aria-describedby="ssn-sr-desc"
+                  required
+                />
+                <Form.Control.Feedback type="invalid">
+                  {t("required-error")}
+                </Form.Control.Feedback>
+                <div className="d-flex justify-content-end">
+                  <Button
+                    onClick={toggleSsn}
+                    variant="link"
+                    style={{ fontWeight: "normal" }}
+                    size="sm"
+                  >
+                    {getSsnToggleText()}
+                  </Button>
+                </div>
+              </Form.Group>
+            </Row>
+            {errorTransKey ===
+              "retrocert-login.invalid-user-error-staff-view" && errorAlert}
+            <Button variant="secondary" type="submit" className="mt-4">
+              {t("retrocert-login.submit")}
+            </Button>
+          </Form>
+        </div>
+      </main>
+      <SessionTimer action="clear" setUserData={setUserDataPropType} />
+      <Footer backToTopTag="certification-page" />
+    </div>
+  );
+}
+
+StaffViewAuthPage.propTypes = {
+  userData: userDataPropType,
+  setUserData: setUserDataPropType,
+};
+
+export default StaffViewAuthPage;

--- a/src/client/pages/StaffViewAuthPage/index.js
+++ b/src/client/pages/StaffViewAuthPage/index.js
@@ -45,7 +45,7 @@ function StaffViewAuthPage(props) {
   ]).get(status);
 
   const errorAlert = errorTransKey && (
-    <Row>
+    <Row className="mt-3">
       <div className="col-md-12">
         <Alert variant="danger">{t(errorTransKey)}</Alert>
       </div>

--- a/src/client/pages/StaffViewAuthPage/index.test.js
+++ b/src/client/pages/StaffViewAuthPage/index.test.js
@@ -1,0 +1,27 @@
+import renderNonTransContent from "../../test-helpers/renderNonTransContent";
+import AUTH_STRINGS from "../../../data/authStrings";
+import Component from "./index";
+
+describe("<StaffViewAuthPage />", () => {
+  it("retro certs auth page", async () => {
+    const wrapper = renderNonTransContent(Component, "StaffViewAuthPage");
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("retro certs auth page with user not found error", async () => {
+    const wrapper = renderNonTransContent(Component, "StaffViewAuthPage", {
+      userData: { status: AUTH_STRINGS.statusCode.userNotFound },
+    });
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("retro certs auth page with session timeout", async () => {
+    const wrapper = renderNonTransContent(Component, "StaffViewAuthPage", {
+      userData: { status: AUTH_STRINGS.statusCode.sessionTimedOut },
+    });
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/client/pages/StaffViewAuthPage/index.test.js
+++ b/src/client/pages/StaffViewAuthPage/index.test.js
@@ -16,12 +16,4 @@ describe("<StaffViewAuthPage />", () => {
 
     expect(wrapper).toMatchSnapshot();
   });
-
-  it("retro certs auth page with session timeout", async () => {
-    const wrapper = renderNonTransContent(Component, "StaffViewAuthPage", {
-      userData: { status: AUTH_STRINGS.statusCode.sessionTimedOut },
-    });
-
-    expect(wrapper).toMatchSnapshot();
-  });
 });

--- a/src/data/locales/en/translation.json
+++ b/src/data/locales/en/translation.json
@@ -189,8 +189,10 @@
   "required-error": "This field is required.",
   "retrocert-login": {
     "title": "Retroactive Certification for Unemployment",
+    "header1-staff-view": "Staff View",
     "help": "You are required to certify for Unemployment Insurance (UI) and Pandemic Unemployment Assistance (PUA) benefits you received for weeks of your claim early in the pandemic through the week ending May 9, 2020. The exact dates you are required to certify for will depend on your specific claim history.",
     "instructions": "Enter your information to confirm if you have any benefit weeks that you need to retroactively certify.",
+    "instructions-staff-view": "Enter claimant information below.",
     "last-name-label": "Last Name",
     "dob-heading": "Date of Birth",
     "dob-hint": "For example, 4 28 1990",

--- a/src/data/locales/en/translation.json
+++ b/src/data/locales/en/translation.json
@@ -189,10 +189,8 @@
   "required-error": "This field is required.",
   "retrocert-login": {
     "title": "Retroactive Certification for Unemployment",
-    "header1-staff-view": "Staff View",
     "help": "You are required to certify for Unemployment Insurance (UI) and Pandemic Unemployment Assistance (PUA) benefits you received for weeks of your claim early in the pandemic through the week ending May 9, 2020. The exact dates you are required to certify for will depend on your specific claim history.",
     "instructions": "Enter your information to confirm if you have any benefit weeks that you need to retroactively certify.",
-    "instructions-staff-view": "Enter claimant information below.",
     "last-name-label": "Last Name",
     "dob-heading": "Date of Birth",
     "dob-hint": "For example, 4 28 1990",
@@ -205,12 +203,17 @@
     "recaptcha-text": "Security check provided by reCAPTCHA.",
     "submit": "Find Me",
     "invalid-user-error": "Review and verify the information you entered is correct. If your information is correct, then you don’t need to certify.",
-    "invalid-user-error-staff-view": "This claimant is not found in the database and does not need to retroactively certify.",
     "invalid-recaptcha-error": "Security check is not complete.",
     "session-timed-out": "You were logged out after 30 minutes of inactivity. Provide your information again to certify your weeks.",
     "show-ssn": "Show SSN",
     "hide-ssn": "Hide SSN",
     "required-text": "* Indicates required text"
+  },
+  "staff-view-login": {
+    "header1": "Staff View",
+    "instructions": "Enter claimant information below.",
+    "invalid-user-error": "This claimant is not found in the database and does not need to retroactively certify.",
+    "submit": "Search"
   },
   "retrocerts-week-list-item": "<strong>Week {{weekForUser}}</strong>: Sunday, {{startDate}} – Saturday, {{endDate}}",
   "retrocerts-weeks": {

--- a/src/data/locales/en/translation.json
+++ b/src/data/locales/en/translation.json
@@ -203,6 +203,7 @@
     "recaptcha-text": "Security check provided by reCAPTCHA.",
     "submit": "Find Me",
     "invalid-user-error": "Review and verify the information you entered is correct. If your information is correct, then you don’t need to certify.",
+    "invalid-user-error-staff-view": "This claimant is not found in the database and does not need to retroactively certify.",
     "invalid-recaptcha-error": "Security check is not complete.",
     "session-timed-out": "You were logged out after 30 minutes of inactivity. Provide your information again to certify your weeks.",
     "show-ssn": "Show SSN",

--- a/src/data/locales/es/translation.json
+++ b/src/data/locales/es/translation.json
@@ -191,6 +191,7 @@
     "title": "Certificación retroactiva para el Seguro de Desempleo",
     "help": "Usted debe realizar la certificación para los beneficios del Seguro de Desempleo (UI, por sus siglas en inglés) y de la Asistencia de Desempleo por la Pandemia (PUA, por sus siglas en inglés) que recibió durante las semanas en que comenzó la pandemia correspondiente a su solicitud, hasta la semana que termina el 9 de mayo de 2020. Las fechas exactas para las que debe realizar la certificación dependerán específicamente del historial de su solicitud.",
     "instructions": "Ingrese su información para confirmar si usted tiene alguna semana de beneficios en que necesite certificar retroactivamente.",
+    "instructions-staff-view": "Enter claimant information below.",
     "last-name-label": "Apellido",
     "dob-heading": "Fecha de nacimiento",
     "dob-hint": "Por ejemplo, 4 28 1990",
@@ -224,6 +225,7 @@
   },
   "retrocerts-certification": {
     "title": "Certificación retroactiva para el Seguro de Desempleo",
+    "header1-staff-view": "Staff View",
     "question-page-title": "Certificar retroactivamente y revisar",
     "alert-found-save": "Usted tiene al menos una semana disponible para certificar retroactivamente. Comience donde se quedó la última vez. Sus semanas anteriores han sido guardadas.",
     "p1-multiple": "Usted está en la semana {{weekForUser}} de {{numberOfWeeks}} semanas para certificar retroactivamente.",

--- a/src/data/locales/es/translation.json
+++ b/src/data/locales/es/translation.json
@@ -191,7 +191,6 @@
     "title": "Certificación retroactiva para el Seguro de Desempleo",
     "help": "Usted debe realizar la certificación para los beneficios del Seguro de Desempleo (UI, por sus siglas en inglés) y de la Asistencia de Desempleo por la Pandemia (PUA, por sus siglas en inglés) que recibió durante las semanas en que comenzó la pandemia correspondiente a su solicitud, hasta la semana que termina el 9 de mayo de 2020. Las fechas exactas para las que debe realizar la certificación dependerán específicamente del historial de su solicitud.",
     "instructions": "Ingrese su información para confirmar si usted tiene alguna semana de beneficios en que necesite certificar retroactivamente.",
-    "instructions-staff-view": "Enter claimant information below.",
     "last-name-label": "Apellido",
     "dob-heading": "Fecha de nacimiento",
     "dob-hint": "Por ejemplo, 4 28 1990",
@@ -204,12 +203,17 @@
     "recaptcha-text": "Control de seguridad proporcionado por reCAPTCHA.",
     "submit": "Encuéntrame",
     "invalid-user-error": "Revise y verifique que la información que ingresó sea correcta. Si su información es correcta, entonces no necesita certificar.",
-    "invalid-user-error-staff-view": "This claimant is not found in the database and does not need to retroactively certify",
     "invalid-recaptcha-error": "El control de seguridad no está completo.",
     "session-timed-out": "Su sesión se cerró después de 30 minutos de inactividad. Proporcione su información nuevamente para certificar sus semanas.",
     "show-ssn": "Mostrar SSN",
     "hide-ssn": "Ocultar SSN",
     "required-text": "*Indica un campo requerido que falta completar"
+  },
+  "staff-view-login": {
+    "header1": "Staff View",
+    "instructions": "Enter claimant information below.",
+    "invalid-user-error": "This claimant is not found in the database and does not need to retroactively certify.",
+    "submit": "Search"
   },
   "retrocerts-week-list-item": "<strong>Semana {{weekForUser}}</strong>: Domingo, {{startDate}} – Sábado, {{endDate}}",
   "retrocerts-weeks": {
@@ -225,7 +229,6 @@
   },
   "retrocerts-certification": {
     "title": "Certificación retroactiva para el Seguro de Desempleo",
-    "header1-staff-view": "Staff View",
     "question-page-title": "Certificar retroactivamente y revisar",
     "alert-found-save": "Usted tiene al menos una semana disponible para certificar retroactivamente. Comience donde se quedó la última vez. Sus semanas anteriores han sido guardadas.",
     "p1-multiple": "Usted está en la semana {{weekForUser}} de {{numberOfWeeks}} semanas para certificar retroactivamente.",

--- a/src/data/locales/es/translation.json
+++ b/src/data/locales/es/translation.json
@@ -203,6 +203,7 @@
     "recaptcha-text": "Control de seguridad proporcionado por reCAPTCHA.",
     "submit": "Encuéntrame",
     "invalid-user-error": "Revise y verifique que la información que ingresó sea correcta. Si su información es correcta, entonces no necesita certificar.",
+    "invalid-user-error-staff-view": "This claimant is not found in the database and does not need to retroactively certify",
     "invalid-recaptcha-error": "El control de seguridad no está completo.",
     "session-timed-out": "Su sesión se cerró después de 30 minutos de inactividad. Proporcione su información nuevamente para certificar sus semanas.",
     "show-ssn": "Mostrar SSN",
@@ -368,5 +369,5 @@
     "header": "Su sesión cerrara pronto",
     "warning": "Para proteger su información, se cerrará su sesión en 5 minutos si no continúa teniendo actividad en su cuenta. Se perderá cualquier cambio que no haya sido guardado.",
     "button": "Continuar actividad en su cuenta"
-  }  
+  }
 }


### PR DESCRIPTION
This PR creates the view for the Staff View login page. 

This page is identical to RetroCertsAuthPage, minus the captcha, Spanish translation button, Show SSN button, and helper text below the header. It also has a different error message for userNotFound and submit button copy.

![image](https://user-images.githubusercontent.com/82277/89348882-4c70be00-d67b-11ea-8f9c-a7f34c791b75.png)

===

Resolves #516

- [x] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
