### PR TITLE
Create Staff View confirmation page

### DIFF
--- a/src/client/App.scss
+++ b/src/client/App.scss
@@ -3,6 +3,9 @@
 
 $primary: #046b99 !default; //medium blue
 $secondary: #fdb81e !default; //yellowish gold
+$background: #e2e3e5 !default; // medium gray
+$success-bg: #d4edda !default; // light seafoam green
+$danger-bg: #f8d7da !default; // light red
 
 $font-size-base: 1.2rem !default;
 
@@ -32,6 +35,7 @@ $font-family-sans-serif: "Source Sans Pro", sans-serif !default;
 @import "components/TabbedContainer/index";
 @import "components/DisasterQuestion/index";
 @import "pages/RetroCertsConfirmationPage/index";
+@import "pages/StaffViewConfirmationPage/index";
 
 h1,
 h2,
@@ -130,7 +134,7 @@ footer {
 // Use grey for secondary alerts rather than our secondary color yellowish gold.
 .alert-secondary {
   color: #383d41;
-  background-color: #e2e3e5;
+  background-color: $background;
   border-color: #d6d8db;
 }
 
@@ -207,6 +211,20 @@ body {
 }
 
 .ssn-hint {
-  margin-bottom: .5rem;
-  margin-top: -.5rem;
+  margin-bottom: 0.5rem;
+  margin-top: -0.5rem;
+}
+
+@mixin blockquote($color) {
+  padding: 0 1rem;
+  margin: 1rem 0;
+  border-left: 0.3rem solid $color;
+}
+
+.highlight-blockquote {
+  @include blockquote($secondary);
+}
+
+.subtle-blockquote {
+  @include blockquote($background);
 }

--- a/src/client/components/ListOfCertifications/__snapshots__/index.test.js.snap
+++ b/src/client/components/ListOfCertifications/__snapshots__/index.test.js.snap
@@ -2,11 +2,6 @@
 
 exports[`<ListOfCertifications /> renders the component 1`] = `
 <Fragment>
-  <h2
-    className="mt-5"
-  >
-    Certifications Submitted
-  </h2>
   <Button
     active={false}
     className="text-dark bg-light mb-3"

--- a/src/client/components/ListOfCertifications/index.js
+++ b/src/client/components/ListOfCertifications/index.js
@@ -1,7 +1,6 @@
 import Button from "react-bootstrap/Button";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
-import PropTypes from "prop-types";
 import { userDataPropType } from "../../commonPropTypes";
 import ListOfWeeksWithDetail from "../../components/ListOfWeeksWithDetail";
 import programPlan from "../../../data/programPlan";
@@ -10,7 +9,7 @@ import AccordionItem from "../../components/AccordionItem";
 function ListOfCertifications(props) {
   const { t } = useTranslation();
 
-  const { header, userData } = props;
+  const { userData } = props;
 
   const numAccordions = userData.weeksToCertify.length + 1; // add 1 for Acknowledgement
 
@@ -64,7 +63,6 @@ function ListOfCertifications(props) {
 
   return (
     <React.Fragment>
-      <h2 className="mt-5">{header}</h2>
       <Button
         variant="outline-secondary"
         className="text-dark bg-light mb-3"
@@ -90,7 +88,6 @@ function ListOfCertifications(props) {
 }
 
 ListOfCertifications.propTypes = {
-  header: PropTypes.string.isRequired,
   userData: userDataPropType,
 };
 

--- a/src/client/components/ListOfCertifications/index.test.js
+++ b/src/client/components/ListOfCertifications/index.test.js
@@ -13,7 +13,6 @@ describe("<ListOfCertifications />", () => {
     };
 
     const wrapper = renderNonTransContent(Component, "ListOfCertifications", {
-      header: "Certifications Submitted",
       userData: {
         formData: [weekOfAnswers, weekOfAnswers, weekOfAnswers],
         weeksToCertify: [1, 2, 3],

--- a/src/client/components/TabbedContainer/_index.scss
+++ b/src/client/components/TabbedContainer/_index.scss
@@ -35,12 +35,6 @@
     margin-bottom: 1rem;
   }
 
-  .highlight-blockquote {
-    padding: 0 1rem;
-    margin: 1rem 0;
-    border-left: 0.3rem solid $secondary;
-  }
-
   .sidebar-sticky {
     position: -webkit-sticky;
     position: sticky;

--- a/src/client/pages/RetroCertsConfirmationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsConfirmationPage/__snapshots__/index.test.js.snap
@@ -83,8 +83,12 @@ exports[`<RetroCertsConfirmationPage /> with confirmation number 1`] = `
       >
         Print
       </Button>
+      <h2
+        className="mt-5"
+      >
+        Certifications Submitted
+      </h2>
       <ListOfCertifications
-        header="Certifications Submitted"
         userData={
           Object {
             "confirmationNumber": "CONFIRMATION_NUMBER",
@@ -102,11 +106,6 @@ exports[`<RetroCertsConfirmationPage /> with confirmation number 1`] = `
           }
         }
       />
-      <h2
-        className="mt-5"
-      >
-        Next Steps
-      </h2>
       <p>
         <Trans
           i18nKey="retrocerts-confirmation.p2"

--- a/src/client/pages/RetroCertsConfirmationPage/index.js
+++ b/src/client/pages/RetroCertsConfirmationPage/index.js
@@ -87,11 +87,8 @@ function RetroCertsConfirmationPage(props) {
             {t("retrocerts-confirmation.button-print")}
           </Button>
 
-          <ListOfCertifications
-            header={t("retrocerts-confirmation.header2")}
-            userData={userData}
-          />
-          <h2 className="mt-5">{t("retrocerts-confirmation.header3")}</h2>
+          <h2 className="mt-5">{t("retrocerts-confirmation.header2")}</h2>
+          <ListOfCertifications userData={userData} />
           <p>
             <Trans t={t} i18nKey="retrocerts-confirmation.p2">
               If you are still unemployed, continue to certify for benefits

--- a/src/client/pages/StaffViewConfirmationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/StaffViewConfirmationPage/__snapshots__/index.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<StaffViewConfirmationPage /> no confirmation number 1`] = `
+exports[`<StaffViewConfirmationPage /> when claimant completed 1`] = `
 <div
   id="overflow-wrapper"
 >
@@ -66,6 +66,7 @@ exports[`<StaffViewConfirmationPage /> no confirmation number 1`] = `
       <ListOfCertifications
         userData={
           Object {
+            "confirmationNumber": "33a6f278-eaa3-41c5-8d08-276fa0364833",
             "programPlan": Array [
               "UI full time",
             ],
@@ -97,7 +98,105 @@ exports[`<StaffViewConfirmationPage /> no confirmation number 1`] = `
 </div>
 `;
 
-exports[`<StaffViewConfirmationPage /> with confirmation number 1`] = `
+exports[`<StaffViewConfirmationPage /> when claimant in progress 1`] = `
+<div
+  id="overflow-wrapper"
+>
+  <Header />
+  <main
+    className="pb-5"
+    id="certification-page"
+  >
+    <div
+      className="container p-4"
+    >
+      <h1>
+        Retroactive Certification for Unemployment
+      </h1>
+      <h3>
+        Staff View
+      </h3>
+      <Button
+        active={false}
+        as={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "displayName": "Link",
+            "propTypes": Object {
+              "innerRef": [Function],
+              "onClick": [Function],
+              "replace": [Function],
+              "target": [Function],
+              "to": [Function],
+            },
+            "render": [Function],
+          }
+        }
+        className="text-dark bg-light"
+        disabled={false}
+        to="/retroactive-certification"
+        type="button"
+        variant="outline-secondary"
+      >
+        Search New Claimant
+      </Button>
+      <h3
+        className="mt-5"
+      >
+        Certification Status
+      </h3>
+      <CertificationStatus />
+      <Button
+        active={false}
+        className="text-dark bg-light"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+        variant="outline-secondary"
+      >
+        Print
+      </Button>
+      <h3
+        className="mt-5"
+      >
+        Certification Weeks
+      </h3>
+      <ListOfCertifications
+        userData={
+          Object {
+            "hasLoggedIn": true,
+            "programPlan": Array [
+              "UI full time",
+            ],
+            "status": "ok",
+            "weeksToCertify": Array [
+              0,
+              1,
+              2,
+              5,
+              6,
+            ],
+          }
+        }
+      />
+      <h3
+        className="mt-5"
+      >
+        Retroactive Certification Application Details
+      </h3>
+      <p>
+        The claimant is shown the following on the Retroactive Certification Application.
+      </p>
+      <ClaimantContent />
+    </div>
+  </main>
+  <Footer
+    backToTopTag="certification-page"
+  />
+</div>
+`;
+
+exports[`<StaffViewConfirmationPage /> when claimant not started 1`] = `
 <div
   id="overflow-wrapper"
 >
@@ -164,6 +263,7 @@ exports[`<StaffViewConfirmationPage /> with confirmation number 1`] = `
         userData={
           Object {
             "confirmationNumber": "CONFIRMATION_NUMBER",
+            "hasLoggedIn": false,
             "programPlan": Array [
               "PUA full time",
             ],

--- a/src/client/pages/StaffViewConfirmationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/StaffViewConfirmationPage/__snapshots__/index.test.js.snap
@@ -15,9 +15,11 @@ exports[`<StaffViewConfirmationPage /> when claimant completed 1`] = `
       <h1>
         Retroactive Certification for Unemployment
       </h1>
-      <h3>
+      <h2
+        className="h3 font-weight-bold mb-3"
+      >
         Staff View
-      </h3>
+      </h2>
       <Button
         active={false}
         as={
@@ -42,11 +44,11 @@ exports[`<StaffViewConfirmationPage /> when claimant completed 1`] = `
       >
         Search New Claimant
       </Button>
-      <h3
-        className="mt-5"
+      <h2
+        className="h3 font-weight-bold mt-5 mb-3"
       >
         Certification Status
-      </h3>
+      </h2>
       <CertificationStatus />
       <Button
         active={false}
@@ -58,11 +60,11 @@ exports[`<StaffViewConfirmationPage /> when claimant completed 1`] = `
       >
         Print
       </Button>
-      <h3
-        className="mt-5"
+      <h2
+        className="h3 font-weight-bold mt-5 mb-3"
       >
         Certification Weeks
-      </h3>
+      </h2>
       <ListOfCertifications
         userData={
           Object {
@@ -81,11 +83,11 @@ exports[`<StaffViewConfirmationPage /> when claimant completed 1`] = `
           }
         }
       />
-      <h3
-        className="mt-5"
+      <h2
+        className="h3 font-weight-bold mt-5 mb-3"
       >
         Retroactive Certification Application Details
-      </h3>
+      </h2>
       <p>
         The claimant is shown the following on the Retroactive Certification Application.
       </p>
@@ -113,9 +115,11 @@ exports[`<StaffViewConfirmationPage /> when claimant in progress 1`] = `
       <h1>
         Retroactive Certification for Unemployment
       </h1>
-      <h3>
+      <h2
+        className="h3 font-weight-bold mb-3"
+      >
         Staff View
-      </h3>
+      </h2>
       <Button
         active={false}
         as={
@@ -140,11 +144,11 @@ exports[`<StaffViewConfirmationPage /> when claimant in progress 1`] = `
       >
         Search New Claimant
       </Button>
-      <h3
-        className="mt-5"
+      <h2
+        className="h3 font-weight-bold mt-5 mb-3"
       >
         Certification Status
-      </h3>
+      </h2>
       <CertificationStatus />
       <Button
         active={false}
@@ -156,11 +160,11 @@ exports[`<StaffViewConfirmationPage /> when claimant in progress 1`] = `
       >
         Print
       </Button>
-      <h3
-        className="mt-5"
+      <h2
+        className="h3 font-weight-bold mt-5 mb-3"
       >
         Certification Weeks
-      </h3>
+      </h2>
       <ListOfCertifications
         userData={
           Object {
@@ -179,11 +183,11 @@ exports[`<StaffViewConfirmationPage /> when claimant in progress 1`] = `
           }
         }
       />
-      <h3
-        className="mt-5"
+      <h2
+        className="h3 font-weight-bold mt-5 mb-3"
       >
         Retroactive Certification Application Details
-      </h3>
+      </h2>
       <p>
         The claimant is shown the following on the Retroactive Certification Application.
       </p>
@@ -211,9 +215,11 @@ exports[`<StaffViewConfirmationPage /> when claimant not started 1`] = `
       <h1>
         Retroactive Certification for Unemployment
       </h1>
-      <h3>
+      <h2
+        className="h3 font-weight-bold mb-3"
+      >
         Staff View
-      </h3>
+      </h2>
       <Button
         active={false}
         as={
@@ -238,11 +244,11 @@ exports[`<StaffViewConfirmationPage /> when claimant not started 1`] = `
       >
         Search New Claimant
       </Button>
-      <h3
-        className="mt-5"
+      <h2
+        className="h3 font-weight-bold mt-5 mb-3"
       >
         Certification Status
-      </h3>
+      </h2>
       <CertificationStatus />
       <Button
         active={false}
@@ -254,11 +260,11 @@ exports[`<StaffViewConfirmationPage /> when claimant not started 1`] = `
       >
         Print
       </Button>
-      <h3
-        className="mt-5"
+      <h2
+        className="h3 font-weight-bold mt-5 mb-3"
       >
         Certification Weeks
-      </h3>
+      </h2>
       <ListOfCertifications
         userData={
           Object {
@@ -278,11 +284,11 @@ exports[`<StaffViewConfirmationPage /> when claimant not started 1`] = `
           }
         }
       />
-      <h3
-        className="mt-5"
+      <h2
+        className="h3 font-weight-bold mt-5 mb-3"
       >
         Retroactive Certification Application Details
-      </h3>
+      </h2>
       <p>
         The claimant is shown the following on the Retroactive Certification Application.
       </p>

--- a/src/client/pages/StaffViewConfirmationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/StaffViewConfirmationPage/__snapshots__/index.test.js.snap
@@ -1,0 +1,196 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<StaffViewConfirmationPage /> no confirmation number 1`] = `
+<div
+  id="overflow-wrapper"
+>
+  <Header />
+  <main
+    className="pb-5"
+    id="certification-page"
+  >
+    <div
+      className="container p-4"
+    >
+      <h1>
+        Retroactive Certification for Unemployment
+      </h1>
+      <h3>
+        Staff View
+      </h3>
+      <Button
+        active={false}
+        as={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "displayName": "Link",
+            "propTypes": Object {
+              "innerRef": [Function],
+              "onClick": [Function],
+              "replace": [Function],
+              "target": [Function],
+              "to": [Function],
+            },
+            "render": [Function],
+          }
+        }
+        className="text-dark bg-light"
+        disabled={false}
+        to="/retroactive-certification"
+        type="button"
+        variant="outline-secondary"
+      >
+        Search New Claimant
+      </Button>
+      <h3
+        className="mt-5"
+      >
+        Certification Status
+      </h3>
+      <CertificationStatus />
+      <Button
+        active={false}
+        className="text-dark bg-light"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+        variant="outline-secondary"
+      >
+        Print
+      </Button>
+      <h3
+        className="mt-5"
+      >
+        Certification Weeks
+      </h3>
+      <ListOfCertifications
+        userData={
+          Object {
+            "programPlan": Array [
+              "UI full time",
+            ],
+            "status": "ok",
+            "weeksToCertify": Array [
+              0,
+              1,
+              2,
+              5,
+              6,
+            ],
+          }
+        }
+      />
+      <h3
+        className="mt-5"
+      >
+        Retroactive Certification Application Details
+      </h3>
+      <p>
+        The claimant is shown the following on the Retroactive Certification Application.
+      </p>
+      <ClaimantContent />
+    </div>
+  </main>
+  <Footer
+    backToTopTag="certification-page"
+  />
+</div>
+`;
+
+exports[`<StaffViewConfirmationPage /> with confirmation number 1`] = `
+<div
+  id="overflow-wrapper"
+>
+  <Header />
+  <main
+    className="pb-5"
+    id="certification-page"
+  >
+    <div
+      className="container p-4"
+    >
+      <h1>
+        Retroactive Certification for Unemployment
+      </h1>
+      <h3>
+        Staff View
+      </h3>
+      <Button
+        active={false}
+        as={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "displayName": "Link",
+            "propTypes": Object {
+              "innerRef": [Function],
+              "onClick": [Function],
+              "replace": [Function],
+              "target": [Function],
+              "to": [Function],
+            },
+            "render": [Function],
+          }
+        }
+        className="text-dark bg-light"
+        disabled={false}
+        to="/retroactive-certification"
+        type="button"
+        variant="outline-secondary"
+      >
+        Search New Claimant
+      </Button>
+      <h3
+        className="mt-5"
+      >
+        Certification Status
+      </h3>
+      <CertificationStatus />
+      <Button
+        active={false}
+        className="text-dark bg-light"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+        variant="outline-secondary"
+      >
+        Print
+      </Button>
+      <h3
+        className="mt-5"
+      >
+        Certification Weeks
+      </h3>
+      <ListOfCertifications
+        userData={
+          Object {
+            "confirmationNumber": "CONFIRMATION_NUMBER",
+            "programPlan": Array [
+              "PUA full time",
+            ],
+            "status": "ok",
+            "weeksToCertify": Array [
+              0,
+              1,
+              2,
+              5,
+              6,
+            ],
+          }
+        }
+      />
+      <h3
+        className="mt-5"
+      >
+        Retroactive Certification Application Details
+      </h3>
+      <p>
+        The claimant is shown the following on the Retroactive Certification Application.
+      </p>
+      <ClaimantContent />
+    </div>
+  </main>
+  <Footer
+    backToTopTag="certification-page"
+  />
+</div>
+`;

--- a/src/client/pages/StaffViewConfirmationPage/_index.scss
+++ b/src/client/pages/StaffViewConfirmationPage/_index.scss
@@ -1,0 +1,56 @@
+.toggleAccordion {
+  cursor: pointer;
+
+  button {
+    border: 0;
+    background-color: transparent; /* note: inherit is ignored by IE11 */
+  }
+}
+
+.toggleCharacter {
+  padding-right: 20px;
+  font-weight: bold;
+}
+
+.detail {
+  padding: 20px;
+  border: 1px solid #d6d8db;
+  margin-top: -20px;
+  margin-bottom: 20px;
+}
+
+.detail ul {
+  padding-left: 20px;
+}
+
+input[type="checkbox"] {
+  margin-right: 10px;
+  height: 15px;
+  width: 15px;
+}
+
+/* Expand all weeks when user prints */
+@media print {
+  .detail {
+    display: block !important;
+  }
+}
+
+@mixin status($bg-color) {
+  font-size: 100%;
+  font-weight: normal;
+  padding: 0.5em 0.4em;
+  background-color: $bg-color;
+}
+
+.not-started {
+  @include status($danger-bg);
+}
+
+.in-progress {
+  @include status($secondary);
+}
+
+.completed {
+  @include status($success-bg);
+}

--- a/src/client/pages/StaffViewConfirmationPage/index.js
+++ b/src/client/pages/StaffViewConfirmationPage/index.js
@@ -32,8 +32,8 @@ function StaffViewConfirmationPage(props) {
     shortConfirmationNumber = confirmationNumber
       .substr(startIndex)
       .toUpperCase();
-  } else if (userData.lastLoginTime) {
-    // TODO(kalvin): make lastLoginTime real
+  } else if (userData.hasLoggedIn) {
+    // TODO(kalvin): make hasLoggedIn real
     status = statuses.IN_PROGRESS;
   } else {
     status = statuses.NOT_STARTED;

--- a/src/client/pages/StaffViewConfirmationPage/index.js
+++ b/src/client/pages/StaffViewConfirmationPage/index.js
@@ -1,0 +1,165 @@
+import Button from "react-bootstrap/Button";
+import React from "react";
+import { Link } from "react-router-dom";
+import routes from "../../../data/routes";
+import { useTranslation, Trans } from "react-i18next";
+import { userDataPropType } from "../../commonPropTypes";
+import Footer from "../../components/Footer";
+import Header from "../../components/Header";
+import { clearAuthToken } from "../../components/SessionTimer";
+import ListOfCertifications from "../../components/ListOfCertifications";
+
+function StaffViewConfirmationPage(props) {
+  const { t } = useTranslation();
+
+  const userData = props.userData;
+
+  const statuses = {
+    NOT_STARTED: "not started",
+    IN_PROGRESS: "in progress",
+    COMPLETED: "completed",
+  };
+
+  let status, shortConfirmationNumber;
+  const confirmationNumber = userData.confirmationNumber;
+  if (confirmationNumber) {
+    status = statuses.COMPLETED;
+
+    // For historical reasons the confirmation code is stored as a uuidv4
+    // hash in the database, but we display only the last 7 characters to the user.
+    const shorterLength = 7;
+    const startIndex = confirmationNumber.length - shorterLength;
+    shortConfirmationNumber = confirmationNumber
+      .substr(startIndex)
+      .toUpperCase();
+  } else if (userData.lastLoginTime) {
+    // TODO(kalvin): make lastLoginTime real
+    status = statuses.IN_PROGRESS;
+  } else {
+    status = statuses.NOT_STARTED;
+  }
+
+  document.title = t("staff-view-confirmation.title");
+
+  // Log out the user since they are done!
+  clearAuthToken();
+
+  function handlePrint() {
+    window.print();
+  }
+
+  function CertificationStatus() {
+    switch (status) {
+      case statuses.NOT_STARTED:
+        return (
+          <React.Fragment>
+            <span className="badge not-started">
+              {t("staff-view-confirmation.not-started.status")}
+            </span>
+            {/* TODO(kalvin): update with EDD content when received */}
+            <p>{t("staff-view-confirmation.not-started.p1")}</p>
+          </React.Fragment>
+        );
+      case statuses.IN_PROGRESS:
+        return (
+          <React.Fragment>
+            <span className="badge in-progress">
+              {t("staff-view-confirmation.in-progress.status")}
+            </span>
+            {/* TODO(kalvin): update with EDD content when received */}
+            <p>{t("staff-view-confirmation.in-progress.p1")}</p>
+          </React.Fragment>
+        );
+      case statuses.COMPLETED:
+        return (
+          <React.Fragment>
+            <span className="badge completed">
+              {t("staff-view-confirmation.completed.status")}
+            </span>
+            {/* TODO(kalvin): make last name real */}
+            <p>
+              {t("staff-view-confirmation.completed.last-name")}
+              <br />
+              {t("staff-view-confirmation.completed.confirmation-number") +
+                shortConfirmationNumber}
+            </p>
+            <p>
+              <Trans
+                t={t}
+                i18nKey="staff-view-confirmation.completed.p1"
+                values={{ confirmationNumber, shortConfirmationNumber }}
+              >
+                Note: The claimant may have seen or saved a much longer
+                confirmation number in the past. If so, it was{" "}
+                <strong>adfdsaf</strong>. If they log in now, they will see
+                <strong>adfdsafdfds</strong> instead, which is the last 7
+                characters of the original number.
+              </Trans>
+            </p>
+          </React.Fragment>
+        );
+    }
+  }
+
+  function ClaimantContent() {
+    return status === statuses.COMPLETED ? (
+      <div className="subtle-blockquote mb-5">
+        <p>{t("retrocerts-confirmation.p1b")}</p>
+        <Trans t={t} i18nKey="retrocerts-confirmation.p2">
+          If you are still unemployed, continue to certify for benefits every
+          two weeks. The fastest way is to use{" "}
+          <a href={t("links.edd-login")}>UI Online</a>.
+        </Trans>
+      </div>
+    ) : (
+      <div className="subtle-blockquote mb-5">
+        <p>{t("retrocerts-weeks.p3")}</p>
+        <p>{t("retrocerts-weeks.p4")}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div id="overflow-wrapper">
+      <Header />
+      <main id="certification-page" className="pb-5">
+        <div className="container p-4">
+          <h1>{t("staff-view-confirmation.title")}</h1>
+          <h3>{t("staff-view-confirmation.header1")}</h3>
+          <Button
+            variant="outline-secondary"
+            className="text-dark bg-light"
+            as={Link}
+            to={routes.retroCertsAuth}
+          >
+            {t("staff-view-confirmation.button-search")}
+          </Button>
+
+          <h3 className="mt-5">{t("staff-view-confirmation.header2")}</h3>
+          <CertificationStatus />
+          <Button
+            variant="outline-secondary"
+            className="text-dark bg-light"
+            onClick={handlePrint}
+          >
+            {t("staff-view-confirmation.button-print")}
+          </Button>
+
+          <h3 className="mt-5">{t("staff-view-confirmation.header3")}</h3>
+          <ListOfCertifications userData={userData} />
+
+          <h3 className="mt-5">{t("staff-view-confirmation.header4")}</h3>
+          <p>{t("staff-view-confirmation.p2")}</p>
+          <ClaimantContent />
+        </div>
+      </main>
+      <Footer backToTopTag="certification-page" />
+    </div>
+  );
+}
+
+StaffViewConfirmationPage.propTypes = {
+  userData: userDataPropType,
+};
+
+export default StaffViewConfirmationPage;

--- a/src/client/pages/StaffViewConfirmationPage/index.js
+++ b/src/client/pages/StaffViewConfirmationPage/index.js
@@ -125,7 +125,9 @@ function StaffViewConfirmationPage(props) {
       <main id="certification-page" className="pb-5">
         <div className="container p-4">
           <h1>{t("staff-view-confirmation.title")}</h1>
-          <h3>{t("staff-view-confirmation.header1")}</h3>
+          <h2 className="h3 font-weight-bold mb-3">
+            {t("staff-view-confirmation.header1")}
+          </h2>
           <Button
             variant="outline-secondary"
             className="text-dark bg-light"
@@ -135,7 +137,9 @@ function StaffViewConfirmationPage(props) {
             {t("staff-view-confirmation.button-search")}
           </Button>
 
-          <h3 className="mt-5">{t("staff-view-confirmation.header2")}</h3>
+          <h2 className="h3 font-weight-bold mt-5 mb-3">
+            {t("staff-view-confirmation.header2")}
+          </h2>
           <CertificationStatus />
           <Button
             variant="outline-secondary"
@@ -145,10 +149,14 @@ function StaffViewConfirmationPage(props) {
             {t("staff-view-confirmation.button-print")}
           </Button>
 
-          <h3 className="mt-5">{t("staff-view-confirmation.header3")}</h3>
+          <h2 className="h3 font-weight-bold mt-5 mb-3">
+            {t("staff-view-confirmation.header3")}
+          </h2>
           <ListOfCertifications userData={userData} />
 
-          <h3 className="mt-5">{t("staff-view-confirmation.header4")}</h3>
+          <h2 className="h3 font-weight-bold mt-5 mb-3">
+            {t("staff-view-confirmation.header4")}
+          </h2>
           <p>{t("staff-view-confirmation.p2")}</p>
           <ClaimantContent />
         </div>

--- a/src/client/pages/StaffViewConfirmationPage/index.test.js
+++ b/src/client/pages/StaffViewConfirmationPage/index.test.js
@@ -1,0 +1,40 @@
+import renderNonTransContent from "../../test-helpers/renderNonTransContent";
+import Component from "./index";
+import AUTH_STRINGS from "../../../data/authStrings";
+
+describe("<StaffViewConfirmationPage />", () => {
+  it("with confirmation number", async () => {
+    const wrapper = renderNonTransContent(
+      Component,
+      "StaffViewConfirmationPage",
+      {
+        userData: {
+          status: AUTH_STRINGS.statusCode.ok,
+          weeksToCertify: [0, 1, 2, 5, 6],
+          confirmationNumber: "CONFIRMATION_NUMBER",
+          programPlan: ["PUA full time"],
+        },
+        setUserData: () => {},
+      }
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("no confirmation number", async () => {
+    const wrapper = renderNonTransContent(
+      Component,
+      "StaffViewConfirmationPage",
+      {
+        userData: {
+          status: AUTH_STRINGS.statusCode.ok,
+          weeksToCertify: [0, 1, 2, 5, 6],
+          programPlan: ["UI full time"],
+        },
+        setUserData: () => {},
+      }
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/client/pages/StaffViewConfirmationPage/index.test.js
+++ b/src/client/pages/StaffViewConfirmationPage/index.test.js
@@ -3,12 +3,13 @@ import Component from "./index";
 import AUTH_STRINGS from "../../../data/authStrings";
 
 describe("<StaffViewConfirmationPage />", () => {
-  it("with confirmation number", async () => {
+  it("when claimant not started", async () => {
     const wrapper = renderNonTransContent(
       Component,
       "StaffViewConfirmationPage",
       {
         userData: {
+          hasLoggedIn: false,
           status: AUTH_STRINGS.statusCode.ok,
           weeksToCertify: [0, 1, 2, 5, 6],
           confirmationNumber: "CONFIRMATION_NUMBER",
@@ -21,12 +22,31 @@ describe("<StaffViewConfirmationPage />", () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it("no confirmation number", async () => {
+  it("when claimant in progress", async () => {
     const wrapper = renderNonTransContent(
       Component,
       "StaffViewConfirmationPage",
       {
         userData: {
+          hasLoggedIn: true,
+          status: AUTH_STRINGS.statusCode.ok,
+          weeksToCertify: [0, 1, 2, 5, 6],
+          programPlan: ["UI full time"],
+        },
+        setUserData: () => {},
+      }
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("when claimant completed", async () => {
+    const wrapper = renderNonTransContent(
+      Component,
+      "StaffViewConfirmationPage",
+      {
+        userData: {
+          confirmationNumber: "33a6f278-eaa3-41c5-8d08-276fa0364833",
           status: AUTH_STRINGS.statusCode.ok,
           weeksToCertify: [0, 1, 2, 5, 6],
           programPlan: ["UI full time"],

--- a/src/data/locales/en/translation.json
+++ b/src/data/locales/en/translation.json
@@ -345,7 +345,7 @@
     "ack-list-item-3": "I declare under penalty of perjury that I am a US Citizen or National; or an Alien in satisfactory immigration status and permitted to work by the United States Citizenship and Immigration Service.",
     "ack-list-item-4": "I understand when submitting my request for benefits my submission is considered the same as my written signature.",
     "ack-list-pua-item-1": "I declare under penalty of perjury that the information I have provided is true and correct to the best of my knowledge or belief, including the reason I am unemployed due to the COVID-19 pandemic.",
-    "ack-list-pua-item-2": "I understand that intentional misrepresentation in self-certifying that I fall within one or more of the  COVID-19 categories is fraud and that I may be subject to criminal prosecution if I have been found to have committed fraud to receive Pandemic Unemployment Assistance benefits.",
+    "ack-list-pua-item-2": "I understand that intentional misrepresentation in self-certifying that I fall within one or more of the COVID-19 categories is fraud and that I may be subject to criminal prosecution if I have been found to have committed fraud to receive Pandemic Unemployment Assistance benefits.",
     "ack-list-pua-item-3": "I understand when submitting my request for benefits my submission is considered the same as my written signature.",
     "ack-label": "You must indicate your acceptance of the statement by checking the box before your certification can be submitted.",
     "submit-p1": "You are about to submit your retroactive certifications. You will <strong>not</strong> be able to change your answers once you select <strong>Submit</strong>.",
@@ -369,6 +369,33 @@
     "aria-show-details": "Show details for this week",
     "header3": "Next Steps",
     "p2": "If you are still unemployed, continue to certify for benefits every two weeks. The fastest way is to use <2>UI Online</2>."
+  },
+  "staff-view-confirmation": {
+    "title": "Retroactive Certification for Unemployment",
+    "header1": "Staff View",
+    "button-search": "Search New Claimant",
+    "header2": "Certification Status",
+    "not-started": {
+      "status": "Not started",
+      "p1": "Claimant Xaybz has never logged in and has not begun retroactive certification."
+    },
+    "in-progress": {
+      "status": "In progress",
+      "p1": "Claimant Xaybz has logged in and begun retroactive certification."
+    },
+    "completed": {
+      "status": "Completed",
+      "last-name": "Claimant Last Name: ",
+      "confirmation-number": "Confirmation Number: ",
+      "p1": "Note: The claimant may have seen or saved a much longer confirmation number in the past. If so, it was <strong>{{confirmationNumber}}</strong>. If they log in now, they will see <strong>{{shortConfirmationNumber}}</strong> instead, which is the last 7 characters of the original number."
+    },
+    "button-print": "Print",
+    "header3": "Certification Weeks",
+    "button-show-all": "Show all",
+    "button-hide-all": "Hide all",
+    "aria-show-details": "Show details for this week",
+    "header4": "Retroactive Certification Application Details",
+    "p2": "The claimant is shown the following on the Retroactive Certification Application."
   },
   "generic-validation-error-message": "There are one or more errors on this page. Review and correct them to continue. Complete all fields and try again.",
   "timeout-modal": {

--- a/src/data/locales/es/translation.json
+++ b/src/data/locales/es/translation.json
@@ -369,6 +369,33 @@
     "header3": "Siguientes pasos",
     "p2": "Si todavía está desempleado, continúe realizando la certificación para los beneficios cada dos semanas. La manera más rápida es a través de <2>UI Online</2>."
   },
+  "staff-view-confirmation": {
+    "title": "Retroactive Certification for Unemployment",
+    "header1": "Staff View",
+    "button-search": "Search New Claimant",
+    "header2": "Certification Status",
+    "not-started": {
+      "status": "Not started",
+      "p1": "Claimant Xaybz has never logged in and has not begun retroactive certification."
+    },
+    "in-progress": {
+      "status": "In progress",
+      "p1": "Claimant Xaybz has logged in and begun retroactive certification."
+    },
+    "completed": {
+      "status": "Completed",
+      "last-name": "Claimant Last Name: ",
+      "confirmation-number": "Confirmation Number: ",
+      "p1": "Note: The claimant may have seen or saved a much longer confirmation number in the past. If so, it was <strong>{{confirmationNumber}}</strong>. If they log in now, they will see <strong>{{shortConfirmationNumber}}</strong> instead, which is the last 7 characters of the original number."
+    },
+    "button-print": "Print",
+    "header3": "Certification Weeks",
+    "button-show-all": "Show all",
+    "button-hide-all": "Hide all",
+    "aria-show-details": "Show details for this week",
+    "header4": "Retroactive Certification Application Details",
+    "p2": "The claimant is shown the following on the Retroactive Certification Application."
+  },
   "generic-validation-error-message": "Hay más de un error en esta página. Revise y corrija los errores para continuar. Complete todo los campos e intente de nuevo.",
   "timeout-modal": {
     "header": "Su sesión cerrara pronto",


### PR DESCRIPTION
This PR creates the view for the Staff View confirmation page (it's really an info page, but seems better to keep the "confirmation" name in the codebase since it's most similar to the existing Confirmation Page?)

Some of the content has not yet been finalized, and the last name and hasLoggedIn value needs to be included. I've added TODOs to the code which I'll return to once we hear back from EDD.

<h1>Completed looks like:</h1>

![image](https://user-images.githubusercontent.com/82277/89350225-a1adcf00-d67d-11ea-9ba0-1a0dc3f6db37.png)

<h1>In progress looks like:</h1>

![image](https://user-images.githubusercontent.com/82277/89335461-0826f300-d666-11ea-9bd4-25466994f9eb.png)

<h1>Not started looks like:</h1>

![image](https://user-images.githubusercontent.com/82277/89335468-0bba7a00-d666-11ea-8810-6f0936187d7b.png)

I moved the highlight-blockquote CSS class used in the Guide to the main .scss as part of refactoring, and verified that it hasn't caused any issues in the Guide:

![image](https://user-images.githubusercontent.com/82277/89335381-f1809c00-d665-11ea-96cc-6cf95c7d5788.png)


===

Resolves #517 

- [x] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [x] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
