### PR TITLE
Add completed at timestamp when submitting completed form

### DIFF
--- a/src/routes/retro-certs.js
+++ b/src/routes/retro-certs.js
@@ -86,6 +86,7 @@ function createRouter() {
               weeksCompleted(formRecord.formData, userRecord.programPlan) &&
             postJson.completed === true
           ) {
+            formRecord.completedAt = Date.now();
             formRecord.confirmationNumber = uuidv4();
             responseJson.confirmationNumber = formRecord.confirmationNumber;
           }


### PR DESCRIPTION
This PR adds a completedAt timestamp when a user submits a completed form, to the forms container in cosmosdb. 

This is a screenshot of Data Explorer on staging for a test user's form submission:
![image](https://user-images.githubusercontent.com/82277/89443879-eb9ac180-d71e-11ea-8311-b70863cdfcb3.png)

An automatically-included property _ts exists already in the forms container, but it's updated whenever the object/document is updated, which includes every time the user logs back in to view their confirmation page (since that updates the access token field).

===

Resolves #521

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
