### PR TITLE
Adjusted spacing across Retro Cert App

### DIFF
--- a/src/client/App.scss
+++ b/src/client/App.scss
@@ -47,7 +47,7 @@ h6 {
 }
 
 h2 {
-  margin-bottom: .5rem;
+  margin-bottom: 2rem;
 }
 
 h3 {
@@ -157,6 +157,10 @@ footer {
     max-width: 800px !important;
     margin-top: 3rem;
     margin-bottom: 3rem;
+  }
+
+  h2 {
+    margin-bottom: 0.5rem;
   }
 }
 

--- a/src/client/App.scss
+++ b/src/client/App.scss
@@ -47,7 +47,7 @@ h6 {
 }
 
 h2 {
-  margin-bottom: 2rem;
+  margin-bottom: .5rem;
 }
 
 h3 {
@@ -155,6 +155,8 @@ footer {
 #certification-page {
   .container {
     max-width: 800px !important;
+    margin-top: 3rem;
+    margin-bottom: 3rem;
   }
 }
 

--- a/src/client/pages/RetroCertsAuthPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsAuthPage/__snapshots__/index.test.js.snap
@@ -17,7 +17,9 @@ exports[`<RetroCertsAuthPage /> retro certs auth page 1`] = `
       <LanguageSelector
         className="mt-3 mb-4"
       />
-      <p>
+      <p
+        className="mt-3"
+      >
         You are required to certify for Unemployment Insurance (UI) and Pandemic Unemployment Assistance (PUA) benefits you received for weeks of your claim early in the pandemic through the week ending May 9, 2020. The exact dates you are required to certify for will depend on your specific claim history.
       </p>
       <p>
@@ -227,7 +229,7 @@ exports[`<RetroCertsAuthPage /> retro certs auth page 1`] = `
           noGutters={false}
         >
           <FormGroup
-            className="col-md-6"
+            className="col-md-6 mt-3"
             controlId="formReCaptcha"
           >
             <AsyncScriptLoader(ReCAPTCHA)
@@ -281,7 +283,9 @@ exports[`<RetroCertsAuthPage /> retro certs auth page with captcha timeout error
       <LanguageSelector
         className="mt-3 mb-4"
       />
-      <p>
+      <p
+        className="mt-3"
+      >
         You are required to certify for Unemployment Insurance (UI) and Pandemic Unemployment Assistance (PUA) benefits you received for weeks of your claim early in the pandemic through the week ending May 9, 2020. The exact dates you are required to certify for will depend on your specific claim history.
       </p>
       <p>
@@ -491,7 +495,7 @@ exports[`<RetroCertsAuthPage /> retro certs auth page with captcha timeout error
           noGutters={false}
         >
           <FormGroup
-            className="col-md-6"
+            className="col-md-6 mt-3"
             controlId="formReCaptcha"
           >
             <AsyncScriptLoader(ReCAPTCHA)
@@ -603,7 +607,9 @@ exports[`<RetroCertsAuthPage /> retro certs auth page with session timeout 1`] =
           </Alert>
         </div>
       </Row>
-      <p>
+      <p
+        className="mt-3"
+      >
         You are required to certify for Unemployment Insurance (UI) and Pandemic Unemployment Assistance (PUA) benefits you received for weeks of your claim early in the pandemic through the week ending May 9, 2020. The exact dates you are required to certify for will depend on your specific claim history.
       </p>
       <p>
@@ -813,7 +819,7 @@ exports[`<RetroCertsAuthPage /> retro certs auth page with session timeout 1`] =
           noGutters={false}
         >
           <FormGroup
-            className="col-md-6"
+            className="col-md-6 mt-3"
             controlId="formReCaptcha"
           >
             <AsyncScriptLoader(ReCAPTCHA)
@@ -867,7 +873,9 @@ exports[`<RetroCertsAuthPage /> retro certs auth page with user not found error 
       <LanguageSelector
         className="mt-3 mb-4"
       />
-      <p>
+      <p
+        className="mt-3"
+      >
         You are required to certify for Unemployment Insurance (UI) and Pandemic Unemployment Assistance (PUA) benefits you received for weeks of your claim early in the pandemic through the week ending May 9, 2020. The exact dates you are required to certify for will depend on your specific claim history.
       </p>
       <p>
@@ -1077,7 +1085,7 @@ exports[`<RetroCertsAuthPage /> retro certs auth page with user not found error 
           noGutters={false}
         >
           <FormGroup
-            className="col-md-6"
+            className="col-md-6 mt-3"
             controlId="formReCaptcha"
           >
             <AsyncScriptLoader(ReCAPTCHA)

--- a/src/client/pages/RetroCertsAuthPage/index.js
+++ b/src/client/pages/RetroCertsAuthPage/index.js
@@ -191,7 +191,7 @@ function RetroCertsAuthPage(props) {
           <LanguageSelector className="mt-3 mb-4" />
           {showGenericValidationError && validated && genericValidationError}
           {errorTransKey === "retrocert-login.session-timed-out" && errorAlert}
-          <p>{t("retrocert-login.help")}</p>
+          <p className="mt-3">{t("retrocert-login.help")}</p>
           <p>{t("retrocert-login.instructions")}</p>
           <p>{t("retrocert-login.required-text")}</p>
           <Form noValidate validated={validated} onSubmit={handleSubmit}>
@@ -294,7 +294,7 @@ function RetroCertsAuthPage(props) {
               </Form.Group>
             </Row>
             <Row>
-              <Form.Group controlId="formReCaptcha" className="col-md-6">
+              <Form.Group controlId="formReCaptcha" className="col-md-6 mt-3">
                 <ReCAPTCHA
                   key={currentLanguage}
                   sitekey="6Lf-DQEVAAAAABCMwJ-Gnbqec08RuiPhMZPtZPm9"

--- a/src/client/pages/RetroCertsAuthPage/index.js
+++ b/src/client/pages/RetroCertsAuthPage/index.js
@@ -150,12 +150,11 @@ function RetroCertsAuthPage(props) {
 
   useEffect(() => {
     const ssnRef = document.getElementById("formSsn");
+    Inputmask.remove(ssnRef);
     if (showSsn) {
-      Inputmask.remove(ssnRef);
       Inputmask("ssn", { placeholder: "#" }).mask(ssnRef);
       ssnRef.type = "text";
     } else {
-      Inputmask.remove(ssnRef);
       Inputmask("9", { repeat: "9", jitMasking: true }).mask(ssnRef);
       ssnRef.type = "password";
       ssnRef.placeholder = "###-##-####";

--- a/src/client/pages/RetroCertsCertificationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsCertificationPage/__snapshots__/index.test.js.snap
@@ -6,6 +6,7 @@ exports[`<RetroCertsCertificationPage /> Certify for 2nd week of 2 1`] = `
 >
   <Header />
   <main
+    className="questions"
     id="certification-page"
   >
     <div
@@ -246,6 +247,7 @@ exports[`<RetroCertsCertificationPage /> Certify for one week of 2 1`] = `
 >
   <Header />
   <main
+    className="questions"
     id="certification-page"
   >
     <div

--- a/src/client/pages/RetroCertsCertificationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsCertificationPage/__snapshots__/index.test.js.snap
@@ -6,7 +6,6 @@ exports[`<RetroCertsCertificationPage /> Certify for 2nd week of 2 1`] = `
 >
   <Header />
   <main
-    className="pb-5 questions"
     id="certification-page"
   >
     <div
@@ -19,7 +18,7 @@ exports[`<RetroCertsCertificationPage /> Certify for 2nd week of 2 1`] = `
         className="mt-3 mb-4"
       />
       <h2
-        className="h3 font-weight-bold mt-5"
+        className="h3 font-weight-bold mt-4"
       >
         <Trans
           i18nKey="retrocerts-certification.form-header"
@@ -247,7 +246,6 @@ exports[`<RetroCertsCertificationPage /> Certify for one week of 2 1`] = `
 >
   <Header />
   <main
-    className="pb-5 questions"
     id="certification-page"
   >
     <div
@@ -260,7 +258,7 @@ exports[`<RetroCertsCertificationPage /> Certify for one week of 2 1`] = `
         className="mt-3 mb-4"
       />
       <h2
-        className="h3 font-weight-bold mt-5"
+        className="h3 font-weight-bold mt-4"
       >
         <Trans
           i18nKey="retrocerts-certification.form-header"

--- a/src/client/pages/RetroCertsCertificationPage/index.js
+++ b/src/client/pages/RetroCertsCertificationPage/index.js
@@ -195,7 +195,7 @@ function RetroCertsCertificationPage(props) {
   return (
     <div id="overflow-wrapper">
       <Header />
-      <main id="certification-page" className="pb-5 questions">
+      <main id="certification-page">
         <div className="container p-4">
           <h1 ref={headingElement}>
             {t("retrocerts-certification.question-page-title")}
@@ -207,7 +207,7 @@ function RetroCertsCertificationPage(props) {
             </Alert>
           )}
           {showGenericValidationError && validated && genericValidationError}
-          <h2 className="h3 font-weight-bold mt-5">
+          <h2 className="h3 font-weight-bold mt-4">
             <Trans
               t={t}
               i18nKey="retrocerts-certification.form-header"

--- a/src/client/pages/RetroCertsCertificationPage/index.js
+++ b/src/client/pages/RetroCertsCertificationPage/index.js
@@ -195,7 +195,7 @@ function RetroCertsCertificationPage(props) {
   return (
     <div id="overflow-wrapper">
       <Header />
-      <main id="certification-page">
+      <main id="certification-page" className="questions">
         <div className="container p-4">
           <h1 ref={headingElement}>
             {t("retrocerts-certification.question-page-title")}

--- a/src/client/pages/RetroCertsConfirmationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsConfirmationPage/__snapshots__/index.test.js.snap
@@ -12,7 +12,6 @@ exports[`<RetroCertsConfirmationPage /> with confirmation number 1`] = `
 >
   <Header />
   <main
-    className="pb-5"
     id="certification-page"
   >
     <div
@@ -25,7 +24,7 @@ exports[`<RetroCertsConfirmationPage /> with confirmation number 1`] = `
         className="mt-3 mb-4"
       />
       <Alert
-        className="mt-5"
+        className="mt-4"
         closeLabel="Close alert"
         show={true}
         transition={

--- a/src/client/pages/RetroCertsConfirmationPage/index.js
+++ b/src/client/pages/RetroCertsConfirmationPage/index.js
@@ -52,11 +52,11 @@ function RetroCertsConfirmationPage(props) {
   return (
     <div id="overflow-wrapper">
       <Header />
-      <main id="certification-page" className="pb-5">
+      <main id="certification-page">
         <div className="container p-4">
           <h1>{t("retrocerts-confirmation.title")}</h1>
           <LanguageSelector className="mt-3 mb-4" />
-          <Alert variant="success" className="mt-5">
+          <Alert variant="success" className="mt-4">
             <img
               className="checkmark"
               src="/images/check-circle-fill.svg"

--- a/src/client/pages/RetroCertsWeeksToCertifyPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsWeeksToCertifyPage/__snapshots__/index.test.js.snap
@@ -6,7 +6,6 @@ exports[`<RetroCertsWeeksToCertifyPage /> has user data 1`] = `
 >
   <Header />
   <main
-    className="pb-5"
     id="certification-page"
   >
     <div

--- a/src/client/pages/RetroCertsWeeksToCertifyPage/index.js
+++ b/src/client/pages/RetroCertsWeeksToCertifyPage/index.js
@@ -20,7 +20,7 @@ function RetroCertsWeeksToCertifyPage(props) {
   return (
     <div id="overflow-wrapper">
       <Header />
-      <main id="certification-page" className="pb-5">
+      <main id="certification-page">
         <div className="container p-4">
           <h1>{t("retrocerts-weeks.title")}</h1>
           <LanguageSelector className="mt-3 mb-4" />

--- a/src/client/pages/StaffViewAuthPage/index.js
+++ b/src/client/pages/StaffViewAuthPage/index.js
@@ -8,7 +8,7 @@ import Form from "react-bootstrap/Form";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
 import Alert from "react-bootstrap/Alert";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import AUTH_STRINGS from "../../../data/authStrings";
 import routes from "../../../data/routes";
 import { userDataPropType, setUserDataPropType } from "../../commonPropTypes";
@@ -16,6 +16,7 @@ import Footer from "../../components/Footer";
 import Header from "../../components/Header";
 import weeksCompleted from "../../../utils/checkFormData";
 import { fromIndexToPathString } from "../../../utils/retroCertsWeeks";
+import Inputmask from "inputmask";
 import { autoScroll, TOP, BEHAVIOR } from "../../../utils/autoScroll";
 
 function StaffViewAuthPage(props) {
@@ -126,6 +127,12 @@ function StaffViewAuthPage(props) {
   const handleChange = (event, setter) => {
     setter(event.target.value);
   };
+
+  useEffect(() => {
+    const ssnRef = document.getElementById("formSsn");
+    Inputmask("ssn", { placeholder: "#" }).mask(ssnRef);
+    ssnRef.type = "text";
+  }, []);
 
   const genericValidationError = (
     <Row>


### PR DESCRIPTION
adjusted spacing, including more padding at the top and bottom on all pages, removing redundant bottom padding, and reduced padding for mb on h2


===

Resolves #XXX

- [x] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
