### PR TITLE
Batch app insights logging in prod.

### DIFF
--- a/src/services/azureApplicationInsights.js
+++ b/src/services/azureApplicationInsights.js
@@ -45,7 +45,7 @@ const createTelemetryService = () => {
     appInsights.loadAppInsights();
     if (
       process.env.NODE_ENV === "development" ||
-      window.location !== "unemployment.edd.ca.gov"
+      window.location.hostname !== "unemployment.edd.ca.gov"
     ) {
       // Normally metrics are sent as batches. In development mode, send immediately.
       // https://docs.microsoft.com/en-us/azure/azure-monitor/app/api-custom-events-metrics#debug


### PR DESCRIPTION
Found by Kalvin: The check to see if we're in prod or
not was incorrect. Fix the check by using the hostname.

===

Resolves #XXX

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
