### PR TITLE
Add staff view routes

### DIFF
--- a/src/client/App.js
+++ b/src/client/App.js
@@ -55,7 +55,6 @@ export default function App() {
             userData: retroCertsUserData,
             setUserData: setRetroCertsUserData,
           }}
-          requiresAuthentication
         />
         <RetroCertsRoute
           path={routes.retroCertsWeeksToCertify}

--- a/src/client/App.js
+++ b/src/client/App.js
@@ -1,12 +1,16 @@
 import React, { Suspense, useState, useRef } from "react";
 import { Switch, Route, Redirect, useHistory } from "react-router-dom";
 import RetroCertsRoute from "./components/RetroCertsRoute";
+import StaffViewRoute from "./components/StaffViewRoute";
 import GuidePage from "./pages/GuidePage";
 import PageNotFound from "./pages/PageNotFound";
 import RetroCertsAuthPage from "./pages/RetroCertsAuthPage";
 import RetroCertsWeeksToCertifyPage from "./pages/RetroCertsWeeksToCertifyPage";
 import RetroCertsCertificationPage from "./pages/RetroCertsCertificationPage";
 import RetroCertsConfirmationPage from "./pages/RetroCertsConfirmationPage";
+import StaffViewAuthPage from "./pages/StaffViewAuthPage";
+import StaffViewConfirmationPage from "./pages/StaffViewConfirmationPage";
+
 import AUTH_STRINGS from "../data/authStrings";
 import routes from "../data/routes";
 import { logPage } from "./utils.js";
@@ -36,6 +40,23 @@ export default function App() {
           <Redirect to={routes.guideBenefits} />
         </Route>
         <Route path="/guide" component={GuidePage} />
+        <StaffViewRoute
+          path={routes.staffViewAuth}
+          pageComponent={StaffViewAuthPage}
+          pageProps={{
+            userData: retroCertsUserData,
+            setUserData: setRetroCertsUserData,
+          }}
+        />
+        <StaffViewRoute
+          path={routes.staffViewConfirmation}
+          pageComponent={StaffViewConfirmationPage}
+          pageProps={{
+            userData: retroCertsUserData,
+            setUserData: setRetroCertsUserData,
+          }}
+          requiresAuthentication
+        />
         <RetroCertsRoute
           path={routes.retroCertsWeeksToCertify}
           pageComponent={RetroCertsWeeksToCertifyPage}

--- a/src/client/__snapshots__/App.test.js.snap
+++ b/src/client/__snapshots__/App.test.js.snap
@@ -17,6 +17,31 @@ exports[`<App /> renders application with retro-certs 1`] = `
       component={[Function]}
       path="/guide"
     />
+    <StaffViewRoute
+      pageComponent={[Function]}
+      pageProps={
+        Object {
+          "setUserData": [Function],
+          "userData": Object {
+            "status": "not-logged-in",
+          },
+        }
+      }
+      path="/retroactive-certification/staff-view"
+    />
+    <StaffViewRoute
+      pageComponent={[Function]}
+      pageProps={
+        Object {
+          "setUserData": [Function],
+          "userData": Object {
+            "status": "not-logged-in",
+          },
+        }
+      }
+      path="/retroactive-certification/staff-view/claimant-info"
+      requiresAuthentication={true}
+    />
     <RetroCertsRoute
       pageComponent={[Function]}
       pageProps={
@@ -91,6 +116,31 @@ exports[`<App /> renders application without retro-certs 1`] = `
     <Route
       component={[Function]}
       path="/guide"
+    />
+    <StaffViewRoute
+      pageComponent={[Function]}
+      pageProps={
+        Object {
+          "setUserData": [Function],
+          "userData": Object {
+            "status": "not-logged-in",
+          },
+        }
+      }
+      path="/retroactive-certification/staff-view"
+    />
+    <StaffViewRoute
+      pageComponent={[Function]}
+      pageProps={
+        Object {
+          "setUserData": [Function],
+          "userData": Object {
+            "status": "not-logged-in",
+          },
+        }
+      }
+      path="/retroactive-certification/staff-view/claimant-info"
+      requiresAuthentication={true}
     />
     <RetroCertsRoute
       pageComponent={[Function]}

--- a/src/client/__snapshots__/App.test.js.snap
+++ b/src/client/__snapshots__/App.test.js.snap
@@ -40,7 +40,6 @@ exports[`<App /> renders application with retro-certs 1`] = `
         }
       }
       path="/retroactive-certification/staff-view/claimant-info"
-      requiresAuthentication={true}
     />
     <RetroCertsRoute
       pageComponent={[Function]}
@@ -140,7 +139,6 @@ exports[`<App /> renders application without retro-certs 1`] = `
         }
       }
       path="/retroactive-certification/staff-view/claimant-info"
-      requiresAuthentication={true}
     />
     <RetroCertsRoute
       pageComponent={[Function]}

--- a/src/client/components/StaffViewRoute/__snapshots__/index.test.js.snap
+++ b/src/client/components/StaffViewRoute/__snapshots__/index.test.js.snap
@@ -2,46 +2,37 @@
 
 exports[`<StaffViewRoute /> basic route 1`] = `
 <Route
+  exact={true}
   path="/path"
 >
   <TestComponent />
 </Route>
 `;
 
-exports[`<StaffViewRoute /> route in production (should be PageNotFound) 1`] = `
-<Route
-  isProduction={true}
-  path="/path"
->
-  <TestComponent />
-</Route>
-`;
-
-exports[`<StaffViewRoute /> route needing auth with authToken 1`] = `
-<Route
-  path="/path"
->
-  <div>
-    Loading...
-  </div>
-</Route>
-`;
-
-exports[`<StaffViewRoute /> route needing auth with user data 1`] = `
+exports[`<StaffViewRoute /> route needing user data 1`] = `
 <Route
   computedMatch={Object {}}
-  path="/path"
+  exact={true}
+  path="/retroactive-certification/staff-view/claimant-info"
 >
-  <Redirect
-    push={true}
-    to="/retroactive-certification/staff-view"
+  <TestComponent
+    setUserData={[Function]}
+    userData={
+      Object {
+        "weeksToCertify": Array [
+          0,
+        ],
+      }
+    }
   />
 </Route>
 `;
 
-exports[`<StaffViewRoute /> route needing auth, but no data 1`] = `
+exports[`<StaffViewRoute /> route needing user data, without user data 1`] = `
 <Route
-  path="/path"
+  computedMatch={Object {}}
+  exact={true}
+  path="/retroactive-certification/staff-view/claimant-info"
 >
   <Redirect
     push={true}

--- a/src/client/components/StaffViewRoute/__snapshots__/index.test.js.snap
+++ b/src/client/components/StaffViewRoute/__snapshots__/index.test.js.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<StaffViewRoute /> basic route 1`] = `
+<Route
+  path="/path"
+>
+  <TestComponent />
+</Route>
+`;
+
+exports[`<StaffViewRoute /> route in production (should be PageNotFound) 1`] = `
+<Route
+  isProduction={true}
+  path="/path"
+>
+  <TestComponent />
+</Route>
+`;
+
+exports[`<StaffViewRoute /> route needing auth with authToken 1`] = `
+<Route
+  path="/path"
+>
+  <div>
+    Loading...
+  </div>
+</Route>
+`;
+
+exports[`<StaffViewRoute /> route needing auth with user data 1`] = `
+<Route
+  computedMatch={Object {}}
+  path="/path"
+>
+  <Redirect
+    push={true}
+    to="/retroactive-certification/staff-view"
+  />
+</Route>
+`;
+
+exports[`<StaffViewRoute /> route needing auth, but no data 1`] = `
+<Route
+  path="/path"
+>
+  <Redirect
+    push={true}
+    to="/retroactive-certification/staff-view"
+  />
+</Route>
+`;

--- a/src/client/components/StaffViewRoute/index.js
+++ b/src/client/components/StaffViewRoute/index.js
@@ -4,59 +4,14 @@ import PropTypes from "prop-types";
 import { Route, Redirect } from "react-router-dom";
 import React from "react";
 import { userDataPropType, setUserDataPropType } from "../../commonPropTypes";
-import AUTH_STRINGS from "../../../data/authStrings";
 import routes from "../../../data/routes";
-import SessionTimer, { clearAuthToken } from "../SessionTimer";
-import ScrollToTop from "../ScrollToTop";
-
-function userIsAuthenticated() {
-  return !!sessionStorage.getItem(AUTH_STRINGS.authToken);
-}
 
 function userDataIsSet(userData) {
   return !!userData.weeksToCertify;
 }
 
-/**
- * A component that wraps authorized page components.
- *
- * This does the following:
- * - Passes props from the Route down to the page component.
- * - Adds the session timer to each page
- *
- * @returns {React.ReactElement}
- */
-function AuthorizedPageWrapper(props) {
-  const { pageComponent: Component, pageProps, computedMatch } = props;
-
-  return (
-    <React.Fragment>
-      <ScrollToTop />
-      <Component routeComputedMatch={computedMatch} {...pageProps} />
-      <SessionTimer
-        action="startOrUpdate"
-        setUserData={pageProps.setUserData}
-      />
-    </React.Fragment>
-  );
-}
-
-AuthorizedPageWrapper.propTypes = {
-  pageComponent: PropTypes.func.isRequired,
-  pageProps: PropTypes.shape({
-    userData: userDataPropType,
-    setUserData: setUserDataPropType,
-  }),
-  computedMatch: PropTypes.object.isRequired,
-};
-
 function StaffViewRoute(props) {
-  const {
-    pageComponent: Component,
-    pageProps,
-    requiresAuthentication,
-    ...routeProps
-  } = props;
+  const { pageComponent: Component, pageProps, ...routeProps } = props;
 
   let routeChild = <div>Loading...</div>;
   const hostname = window.location.hostname;
@@ -64,41 +19,20 @@ function StaffViewRoute(props) {
   if (isProdEnvironment) {
     // Staff view should currently not load on production at all,
     routeChild = <Redirect to={routes.retroCertsAuth} push />;
+  } else if (
+    routeProps.path === routes.staffViewConfirmation &&
+    !userDataIsSet(pageProps.userData)
+  ) {
+    routeChild = <Redirect to={routes.staffViewAuth} push />;
   } else {
-    if (!requiresAuthentication) {
-      routeChild = <Component {...pageProps} />;
-    } else if (userIsAuthenticated() && userDataIsSet(pageProps.userData)) {
-      routeChild = <AuthorizedPageWrapper {...props} />;
-    } else {
-      // This page requires authentication and the user is not authenticated.
-      // Try using the auth token if they have one.
-      const authToken = sessionStorage.getItem(AUTH_STRINGS.authToken);
-      if (!authToken) {
-        // The user came here directly, send them back to the login page.
-        routeChild = <Redirect to={routes.staffViewAuth} push />;
-      } else {
-        // Try to refresh the data with the auth token.
-        fetch(AUTH_STRINGS.apiPath.data, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ authToken }),
-        })
-          .then((response) => response.json())
-          .then((data) => {
-            pageProps.setUserData(data);
-            if (data.status !== AUTH_STRINGS.statusCode.ok) {
-              clearAuthToken();
-            }
-          })
-          .catch((error) => console.error(error));
-        // While the refresh happens, we show the default Loading.... text.
-      }
-    }
+    routeChild = <Component {...pageProps} />;
   }
 
-  return <Route {...routeProps}>{routeChild}</Route>;
+  return (
+    <Route {...routeProps} exact>
+      {routeChild}
+    </Route>
+  );
 }
 
 StaffViewRoute.propTypes = {
@@ -109,7 +43,6 @@ StaffViewRoute.propTypes = {
     setUserData: setUserDataPropType,
   }),
   path: PropTypes.string.isRequired,
-  requiresAuthentication: PropTypes.bool,
 };
 
 export default StaffViewRoute;

--- a/src/client/components/StaffViewRoute/index.js
+++ b/src/client/components/StaffViewRoute/index.js
@@ -1,5 +1,3 @@
-// This file is identical to RetroCertsRoute other than the section
-// near `if (isProdEnvironment)` which restricts access to Staff View
 import PropTypes from "prop-types";
 import { Route, Redirect } from "react-router-dom";
 import React from "react";

--- a/src/client/components/StaffViewRoute/index.js
+++ b/src/client/components/StaffViewRoute/index.js
@@ -1,0 +1,113 @@
+import PropTypes from "prop-types";
+import { Route, Redirect } from "react-router-dom";
+import React from "react";
+import { userDataPropType, setUserDataPropType } from "../../commonPropTypes";
+import AUTH_STRINGS from "../../../data/authStrings";
+import routes from "../../../data/routes";
+import SessionTimer, { clearAuthToken } from "../SessionTimer";
+import ScrollToTop from "../ScrollToTop";
+
+function userIsAuthenticated() {
+  return !!sessionStorage.getItem(AUTH_STRINGS.authToken);
+}
+
+function userDataIsSet(userData) {
+  return !!userData.weeksToCertify;
+}
+
+/**
+ * A component that wraps authorized page components.
+ *
+ * This does the following:
+ * - Passes props from the Route down to the page component.
+ * - Adds the session timer to each page
+ *
+ * @returns {React.ReactElement}
+ */
+function AuthorizedPageWrapper(props) {
+  const { pageComponent: Component, pageProps, computedMatch } = props;
+
+  return (
+    <React.Fragment>
+      <ScrollToTop />
+      <Component routeComputedMatch={computedMatch} {...pageProps} />
+      <SessionTimer
+        action="startOrUpdate"
+        setUserData={pageProps.setUserData}
+      />
+    </React.Fragment>
+  );
+}
+
+AuthorizedPageWrapper.propTypes = {
+  pageComponent: PropTypes.func.isRequired,
+  pageProps: PropTypes.shape({
+    userData: userDataPropType,
+    setUserData: setUserDataPropType,
+  }),
+  computedMatch: PropTypes.object.isRequired,
+};
+
+function StaffViewRoute(props) {
+  const {
+    pageComponent: Component,
+    pageProps,
+    requiresAuthentication,
+    ...routeProps
+  } = props;
+
+  let routeChild = <div>Loading...</div>;
+  const hostname = window.location.hostname;
+  const isProdEnvironment = hostname === "unemployment.edd.ca.gov";
+  if (isProdEnvironment) {
+    // Staff view should currently not load on production at all,
+    routeChild = <Redirect to={routes.retroCertsAuth} push />;
+  } else {
+    if (!requiresAuthentication) {
+      routeChild = <Component {...pageProps} />;
+    } else if (userIsAuthenticated() && userDataIsSet(pageProps.userData)) {
+      routeChild = <AuthorizedPageWrapper {...props} />;
+    } else {
+      // This page requires authentication and the user is not authenticated.
+      // Try using the auth token if they have one.
+      const authToken = sessionStorage.getItem(AUTH_STRINGS.authToken);
+      if (!authToken) {
+        // The user came here directly, send them back to the login page.
+        routeChild = <Redirect to={routes.staffViewAuth} push />;
+      } else {
+        // Try to refresh the data with the auth token.
+        fetch(AUTH_STRINGS.apiPath.data, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ authToken }),
+        })
+          .then((response) => response.json())
+          .then((data) => {
+            pageProps.setUserData(data);
+            if (data.status !== AUTH_STRINGS.statusCode.ok) {
+              clearAuthToken();
+            }
+          })
+          .catch((error) => console.error(error));
+        // While the refresh happens, we show the default Loading.... text.
+      }
+    }
+  }
+
+  return <Route {...routeProps}>{routeChild}</Route>;
+}
+
+StaffViewRoute.propTypes = {
+  exact: PropTypes.bool,
+  pageComponent: PropTypes.func.isRequired,
+  pageProps: PropTypes.shape({
+    userData: userDataPropType,
+    setUserData: setUserDataPropType,
+  }),
+  path: PropTypes.string.isRequired,
+  requiresAuthentication: PropTypes.bool,
+};
+
+export default StaffViewRoute;

--- a/src/client/components/StaffViewRoute/index.js
+++ b/src/client/components/StaffViewRoute/index.js
@@ -1,3 +1,5 @@
+// This file is identical to RetroCertsRoute other than the section
+// near `if (isProdEnvironment)` which restricts access to Staff View
 import PropTypes from "prop-types";
 import { Route, Redirect } from "react-router-dom";
 import React from "react";

--- a/src/client/components/StaffViewRoute/index.test.js
+++ b/src/client/components/StaffViewRoute/index.test.js
@@ -1,0 +1,108 @@
+import renderNonTransContent from "../../test-helpers/renderNonTransContent";
+import React from "react";
+import Component from "./index";
+import AUTH_STRINGS from "../../../data/authStrings";
+
+const TestComponent = () => {
+  return <div>TestComponent</div>;
+};
+
+describe("<StaffViewRoute />", () => {
+  it("basic route", async () => {
+    sessionStorage.removeItem(AUTH_STRINGS.authToken);
+    const wrapper = renderNonTransContent(Component, "StaffViewRoute", {
+      path: "/path",
+      pageComponent: TestComponent,
+    });
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("route in production (should be PageNotFound)", async () => {
+    sessionStorage.removeItem(AUTH_STRINGS.authToken);
+    const wrapper = renderNonTransContent(Component, "StaffViewRoute", {
+      path: "/path",
+      pageComponent: TestComponent,
+      isProduction: true,
+    });
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("route needing auth, but no data", async () => {
+    sessionStorage.removeItem(AUTH_STRINGS.authToken);
+    const wrapper = renderNonTransContent(Component, "StaffViewRoute", {
+      path: "/path",
+      pageComponent: TestComponent,
+      pageProps: {
+        userData: {},
+        setUserData: () => {},
+      },
+      requiresAuthentication: true,
+    });
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("route needing auth with user data", async () => {
+    sessionStorage.removeItem(AUTH_STRINGS.authToken);
+    const wrapper = renderNonTransContent(Component, "StaffViewRoute", {
+      path: "/path",
+      pageComponent: TestComponent,
+      pageProps: {
+        userData: { weeksToCertify: [0] },
+        setUserData: () => {},
+      },
+      requiresAuthentication: true,
+      computedMatch: {},
+    });
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("route needing auth with authToken", async () => {
+    sessionStorage.setItem(AUTH_STRINGS.authToken, "TEST_TOKEN");
+
+    // fetch isn't part of nodejs. If we pull in node-fetch, we
+    // need to update the test codes to mock global.fetch.
+    expect(global.fetch).toBeUndefined();
+    const mockFetch = jest.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            status: AUTH_STRINGS.statusCode.ok,
+            weeksToCertify: [0, 1],
+          }),
+      })
+    );
+    global.fetch = mockFetch;
+
+    const wrapper = renderNonTransContent(Component, "StaffViewRoute", {
+      path: "/path",
+      pageComponent: TestComponent,
+      pageProps: {
+        userData: {},
+        setUserData: () => {},
+      },
+      requiresAuthentication: true,
+    });
+
+    // Test cleanup.
+    sessionStorage.removeItem(AUTH_STRINGS.authToken);
+    global.fetch = undefined;
+
+    expect(mockFetch.mock.calls.length).toBe(1);
+    expect(mockFetch.mock.calls[0]).toEqual([
+      AUTH_STRINGS.apiPath.data,
+      {
+        body: JSON.stringify({ authToken: "TEST_TOKEN" }),
+        headers: {
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      },
+    ]);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/client/components/StaffViewRoute/index.test.js
+++ b/src/client/components/StaffViewRoute/index.test.js
@@ -1,7 +1,6 @@
 import renderNonTransContent from "../../test-helpers/renderNonTransContent";
 import React from "react";
 import Component from "./index";
-import AUTH_STRINGS from "../../../data/authStrings";
 
 const TestComponent = () => {
   return <div>TestComponent</div>;
@@ -9,7 +8,6 @@ const TestComponent = () => {
 
 describe("<StaffViewRoute />", () => {
   it("basic route", async () => {
-    sessionStorage.removeItem(AUTH_STRINGS.authToken);
     const wrapper = renderNonTransContent(Component, "StaffViewRoute", {
       path: "/path",
       pageComponent: TestComponent,
@@ -18,90 +16,30 @@ describe("<StaffViewRoute />", () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it("route in production (should be PageNotFound)", async () => {
-    sessionStorage.removeItem(AUTH_STRINGS.authToken);
+  it("route needing user data", async () => {
     const wrapper = renderNonTransContent(Component, "StaffViewRoute", {
-      path: "/path",
-      pageComponent: TestComponent,
-      isProduction: true,
-    });
-
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it("route needing auth, but no data", async () => {
-    sessionStorage.removeItem(AUTH_STRINGS.authToken);
-    const wrapper = renderNonTransContent(Component, "StaffViewRoute", {
-      path: "/path",
-      pageComponent: TestComponent,
-      pageProps: {
-        userData: {},
-        setUserData: () => {},
-      },
-      requiresAuthentication: true,
-    });
-
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it("route needing auth with user data", async () => {
-    sessionStorage.removeItem(AUTH_STRINGS.authToken);
-    const wrapper = renderNonTransContent(Component, "StaffViewRoute", {
-      path: "/path",
+      path: "/retroactive-certification/staff-view/claimant-info",
       pageComponent: TestComponent,
       pageProps: {
         userData: { weeksToCertify: [0] },
         setUserData: () => {},
       },
-      requiresAuthentication: true,
       computedMatch: {},
     });
 
     expect(wrapper).toMatchSnapshot();
   });
 
-  it("route needing auth with authToken", async () => {
-    sessionStorage.setItem(AUTH_STRINGS.authToken, "TEST_TOKEN");
-
-    // fetch isn't part of nodejs. If we pull in node-fetch, we
-    // need to update the test codes to mock global.fetch.
-    expect(global.fetch).toBeUndefined();
-    const mockFetch = jest.fn(() =>
-      Promise.resolve({
-        json: () =>
-          Promise.resolve({
-            status: AUTH_STRINGS.statusCode.ok,
-            weeksToCertify: [0, 1],
-          }),
-      })
-    );
-    global.fetch = mockFetch;
-
+  it("route needing user data, without user data", async () => {
     const wrapper = renderNonTransContent(Component, "StaffViewRoute", {
-      path: "/path",
+      path: "/retroactive-certification/staff-view/claimant-info",
       pageComponent: TestComponent,
       pageProps: {
         userData: {},
         setUserData: () => {},
       },
-      requiresAuthentication: true,
+      computedMatch: {},
     });
-
-    // Test cleanup.
-    sessionStorage.removeItem(AUTH_STRINGS.authToken);
-    global.fetch = undefined;
-
-    expect(mockFetch.mock.calls.length).toBe(1);
-    expect(mockFetch.mock.calls[0]).toEqual([
-      AUTH_STRINGS.apiPath.data,
-      {
-        body: JSON.stringify({ authToken: "TEST_TOKEN" }),
-        headers: {
-          "Content-Type": "application/json",
-        },
-        method: "POST",
-      },
-    ]);
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/client/pages/StaffViewConfirmationPage/index.js
+++ b/src/client/pages/StaffViewConfirmationPage/index.js
@@ -6,7 +6,6 @@ import { useTranslation, Trans } from "react-i18next";
 import { userDataPropType } from "../../commonPropTypes";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header";
-import { clearAuthToken } from "../../components/SessionTimer";
 import ListOfCertifications from "../../components/ListOfCertifications";
 
 function StaffViewConfirmationPage(props) {
@@ -40,9 +39,6 @@ function StaffViewConfirmationPage(props) {
   }
 
   document.title = t("staff-view-confirmation.title");
-
-  // Log out the user since they are done!
-  clearAuthToken();
 
   function handlePrint() {
     window.print();

--- a/src/data/routes.js
+++ b/src/data/routes.js
@@ -31,6 +31,9 @@ const routes = {
   retroCertsCertifyWeek12: "/retroactive-certification/certify/2020-05-02",
   retroCertsCertifyWeek13: "/retroactive-certification/certify/2020-05-09",
   retroCertsConfirmation: "/retroactive-certification/confirmation",
+
+  staffViewAuth: "/retroactive-certification/staff-view",
+  staffViewConfirmation: "/retroactive-certification/staff-view/claimant-info",
 };
 
 module.exports = routes;


### PR DESCRIPTION
This PR adds routes for the Staff View. It creates two new routes for the StaffView views that have already been merged:

`/retroactive-certification/staff-view`
`staffViewConfirmation: "/retroactive-certification/staff-view/claimant-info`

It redirects the new routes to `/retroactive-certification/` on production. A follow-up PR will apply the redirects on staging and/or test based on IP address.

===

Mostly but not completely addresses #515

- [x] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
