### PR TITLE
Enable submit on Staff View auth page

### DIFF
--- a/src/client/App.js
+++ b/src/client/App.js
@@ -41,16 +41,16 @@ export default function App() {
         </Route>
         <Route path="/guide" component={GuidePage} />
         <StaffViewRoute
-          path={routes.staffViewAuth}
-          pageComponent={StaffViewAuthPage}
+          path={routes.staffViewConfirmation}
+          pageComponent={StaffViewConfirmationPage}
           pageProps={{
             userData: retroCertsUserData,
             setUserData: setRetroCertsUserData,
           }}
         />
         <StaffViewRoute
-          path={routes.staffViewConfirmation}
-          pageComponent={StaffViewConfirmationPage}
+          path={routes.staffViewAuth}
+          pageComponent={StaffViewAuthPage}
           pageProps={{
             userData: retroCertsUserData,
             setUserData: setRetroCertsUserData,

--- a/src/client/__snapshots__/App.test.js.snap
+++ b/src/client/__snapshots__/App.test.js.snap
@@ -27,7 +27,7 @@ exports[`<App /> renders application with retro-certs 1`] = `
           },
         }
       }
-      path="/retroactive-certification/staff-view"
+      path="/retroactive-certification/staff-view/claimant-info"
     />
     <StaffViewRoute
       pageComponent={[Function]}
@@ -39,7 +39,7 @@ exports[`<App /> renders application with retro-certs 1`] = `
           },
         }
       }
-      path="/retroactive-certification/staff-view/claimant-info"
+      path="/retroactive-certification/staff-view"
     />
     <RetroCertsRoute
       pageComponent={[Function]}
@@ -126,7 +126,7 @@ exports[`<App /> renders application without retro-certs 1`] = `
           },
         }
       }
-      path="/retroactive-certification/staff-view"
+      path="/retroactive-certification/staff-view/claimant-info"
     />
     <StaffViewRoute
       pageComponent={[Function]}
@@ -138,7 +138,7 @@ exports[`<App /> renders application without retro-certs 1`] = `
           },
         }
       }
-      path="/retroactive-certification/staff-view/claimant-info"
+      path="/retroactive-certification/staff-view"
     />
     <RetroCertsRoute
       pageComponent={[Function]}

--- a/src/client/pages/StaffViewAuthPage/index.js
+++ b/src/client/pages/StaffViewAuthPage/index.js
@@ -75,7 +75,7 @@ function StaffViewAuthPage(props) {
     const month = dobMonth.length < 2 ? "0" + dobMonth : dobMonth;
     const day = dobDay.length < 2 ? "0" + dobDay : dobDay;
 
-    fetch(AUTH_STRINGS.apiPath.login, {
+    fetch(AUTH_STRINGS.staffView.login, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/src/client/pages/StaffViewAuthPage/index.js
+++ b/src/client/pages/StaffViewAuthPage/index.js
@@ -14,8 +14,6 @@ import routes from "../../../data/routes";
 import { userDataPropType, setUserDataPropType } from "../../commonPropTypes";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header";
-import weeksCompleted from "../../../utils/checkFormData";
-import { fromIndexToPathString } from "../../../utils/retroCertsWeeks";
 import Inputmask from "inputmask";
 import { autoScroll, TOP, BEHAVIOR } from "../../../utils/autoScroll";
 
@@ -91,35 +89,7 @@ function StaffViewAuthPage(props) {
       .then((response) => response.json())
       .then((data) => {
         setUserData(data);
-        if (data.authToken) {
-          // Session storage is destroyed when the tab is closed! That's a bit weird.
-          // If we want to allow the user to use multiple tabs, we could sync the
-          // value across tabs:
-          // https://medium.com/@marciomariani/sharing-sessionstorage-between-tabs-5b6f42c6348c
-          sessionStorage.setItem(AUTH_STRINGS.authToken, data.authToken);
-
-          if (data.confirmationNumber) {
-            // The user has already completed the retro-certs process.
-            history.push(routes.retroCertsConfirmation, { isReturning: true });
-          } else {
-            const completedWeeks = weeksCompleted(
-              data.formData,
-              data.programPlan
-            );
-            if (completedWeeks === 0) {
-              history.push(routes.retroCertsWeeksToCertify);
-            } else {
-              history.push(
-                `${routes.retroCertsCertify}/${fromIndexToPathString(
-                  data.weeksToCertify[
-                    Math.min(completedWeeks, data.weeksToCertify.length - 1)
-                  ]
-                )}`,
-                { returningUser: true }
-              );
-            }
-          }
-        }
+        history.push(routes.staffViewConfirmation);
       })
       .catch((error) => console.error(error));
   };

--- a/src/client/pages/StaffViewConfirmationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/StaffViewConfirmationPage/__snapshots__/index.test.js.snap
@@ -1,280 +1,6112 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<StaffViewConfirmationPage /> when claimant completed 1`] = `
-<div
-  id="overflow-wrapper"
+<StaffViewConfirmationPage
+  setUserData={[Function]}
+  userData={
+    Object {
+      "authToken": "pretendThisIsARealToken",
+      "confirmationNumber": "33a6f278-eaa3-41c5-8d08-276fa0364833",
+      "formData": Array [
+        Object {
+          "couldNotAcceptWork": false,
+          "didYouLook": false,
+          "refuseWork": false,
+          "schoolOrTraining": false,
+          "tooSick": false,
+          "workOrEarn": false,
+        },
+        Object {
+          "couldNotAcceptWork": false,
+          "didYouLook": false,
+          "refuseWork": false,
+          "schoolOrTraining": false,
+          "tooSick": false,
+          "workOrEarn": false,
+        },
+        Object {
+          "couldNotAcceptWork": false,
+          "didYouLook": false,
+          "refuseWork": false,
+          "schoolOrTraining": false,
+          "tooSick": false,
+          "workOrEarn": false,
+        },
+      ],
+      "lastName": "Taylor",
+      "programPlan": Array [
+        "UI full time",
+      ],
+      "status": "ok",
+      "weeksToCertify": Array [
+        0,
+        1,
+        2,
+      ],
+    }
+  }
 >
-  <Header />
-  <main
-    className="pb-5"
-    id="certification-page"
+  <div
+    id="overflow-wrapper"
   >
-    <div
-      className="container p-4"
+    <Header>
+      <header
+        className="header border-bottom border-secondary"
+      >
+        <Navbar
+          bg="primary"
+          className="justify-content-between"
+          collapseOnSelect={false}
+          expand={true}
+          variant="custom"
+        >
+          <nav
+            className="justify-content-between navbar navbar-expand navbar-custom bg-primary"
+          >
+            <NavbarBrand
+              href="https://ca.gov"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <a
+                className="navbar-brand"
+                href="https://ca.gov"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <img
+                  alt="California gov logo"
+                  height="30"
+                  src="images/Ca-Gov-Logo-Gold.svg"
+                  width="30"
+                />
+              </a>
+            </NavbarBrand>
+            <Nav
+              fill={false}
+              justify={false}
+            >
+              <ForwardRef
+                as="div"
+                className="navbar-nav"
+                onSelect={[Function]}
+              >
+                <div
+                  className="navbar-nav"
+                  onKeyDown={[Function]}
+                >
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov"
+                        disabled={false}
+                        href="https://edd.ca.gov"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov"
+                          href="https://edd.ca.gov"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="home icon"
+                            className="icon"
+                            height="15"
+                            src="images/home.svg"
+                            width="15"
+                          />
+                           
+                          <span
+                            className="text"
+                          >
+                            Home
+                          </span>
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/login.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/login.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/login.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/login.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/login.htm"
+                          href="https://edd.ca.gov/login.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <span>
+                            <img
+                              alt="key icon"
+                              className="icon"
+                              height="15"
+                              src="images/key.svg"
+                              width="15"
+                            />
+                             
+                            <span
+                              className="text"
+                            >
+                              Log In
+                            </span>
+                          </span>
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                </div>
+              </ForwardRef>
+            </Nav>
+          </nav>
+        </Navbar>
+        <Navbar
+          collapseOnSelect={true}
+          expand="md"
+          variant="light"
+        >
+          <nav
+            className="navbar navbar-expand-md navbar-light"
+          >
+            <NavbarBrand
+              href="https://edd.ca.gov"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <a
+                className="navbar-brand"
+                href="https://edd.ca.gov"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <img
+                  alt="California gov logo"
+                  className="d-inline-block align-top mr-5"
+                  height="50"
+                  src="images/edd-logo-2-Color.svg"
+                  width="150"
+                />
+              </a>
+            </NavbarBrand>
+            <NavbarToggle
+              aria-controls="responsive-navbar-nav"
+              label="Toggle navigation"
+            >
+              <button
+                aria-controls="responsive-navbar-nav"
+                aria-label="Toggle navigation"
+                className="navbar-toggler collapsed"
+                onClick={[Function]}
+                type="button"
+              >
+                <span
+                  className="navbar-toggler-icon"
+                />
+              </button>
+            </NavbarToggle>
+            <NavbarCollapse
+              className="justify-content-between ml-5 mr-5 pl-5"
+            >
+              <Collapse
+                appear={false}
+                className="justify-content-between ml-5 mr-5 pl-5"
+                dimension="height"
+                getDimensionValue={[Function]}
+                in={false}
+                mountOnEnter={false}
+                timeout={300}
+                unmountOnExit={false}
+              >
+                <Transition
+                  addEndListener={[Function]}
+                  appear={false}
+                  aria-expanded={null}
+                  enter={true}
+                  exit={true}
+                  in={false}
+                  mountOnEnter={false}
+                  onEnter={[Function]}
+                  onEntered={[Function]}
+                  onEntering={[Function]}
+                  onExit={[Function]}
+                  onExited={[Function]}
+                  onExiting={[Function]}
+                  timeout={300}
+                  unmountOnExit={false}
+                >
+                  <div
+                    aria-expanded={null}
+                    className="justify-content-between ml-5 mr-5 pl-5 navbar-collapse collapse"
+                  >
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/jobs.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/jobs.htm"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/jobs.htm"
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/jobs.htm"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Jobs
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/claims.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/claims.htm"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/claims.htm"
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/claims.htm"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Claims
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/employers.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/employers.htm"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/employers.htm"
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/employers.htm"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Employers
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/newsroom.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/newsroom.htm"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/newsroom.htm"
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/newsroom.htm"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Newsroom
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/serp.html?q="
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/serp.html?q="
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/serp.html?q="
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/serp.html?q="
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Search
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                  </div>
+                </Transition>
+              </Collapse>
+            </NavbarCollapse>
+          </nav>
+        </Navbar>
+      </header>
+    </Header>
+    <main
+      className="pb-5"
+      id="certification-page"
     >
-      <h1>
-        Retroactive Certification for Unemployment
-      </h1>
-      <h2
-        className="h3 font-weight-bold mb-3"
+      <div
+        className="container p-4"
       >
-        Staff View
-      </h2>
-      <Button
-        active={false}
-        as={
-          Object {
-            "$$typeof": Symbol(react.forward_ref),
-            "displayName": "Link",
-            "propTypes": Object {
-              "innerRef": [Function],
-              "onClick": [Function],
-              "replace": [Function],
-              "target": [Function],
-              "to": [Function],
-            },
-            "render": [Function],
+        <h1>
+          Retroactive Certification for Unemployment
+        </h1>
+        <h2
+          className="h3 font-weight-bold mb-3"
+        >
+          Staff View
+        </h2>
+        <Button
+          active={false}
+          as={
+            Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "displayName": "Link",
+              "propTypes": Object {
+                "innerRef": [Function],
+                "onClick": [Function],
+                "replace": [Function],
+                "target": [Function],
+                "to": [Function],
+              },
+              "render": [Function],
+            }
           }
-        }
-        className="text-dark bg-light"
-        disabled={false}
-        to="/retroactive-certification"
-        type="button"
-        variant="outline-secondary"
+          className="text-dark bg-light"
+          disabled={false}
+          to="/retroactive-certification"
+          type="button"
+          variant="outline-secondary"
+        >
+          <Link
+            className="text-dark bg-light btn btn-outline-secondary"
+            disabled={false}
+            to="/retroactive-certification"
+          >
+            <LinkAnchor
+              className="text-dark bg-light btn btn-outline-secondary"
+              disabled={false}
+              href="/retroactive-certification"
+              navigate={[Function]}
+            >
+              <a
+                className="text-dark bg-light btn btn-outline-secondary"
+                disabled={false}
+                href="/retroactive-certification"
+                onClick={[Function]}
+              >
+                Search New Claimant
+              </a>
+            </LinkAnchor>
+          </Link>
+        </Button>
+        <h2
+          className="h3 font-weight-bold mt-5 mb-3"
+        >
+          Certification Status
+        </h2>
+        <CertificationStatus>
+          <span
+            className="badge completed"
+          >
+            Completed
+          </span>
+          <p>
+            Claimant Last Name: 
+             + userData.lastName
+            <br />
+            Confirmation Number: 0364833
+          </p>
+          <p>
+            <Trans
+              i18nKey="staff-view-confirmation.completed.p1"
+              t={[Function]}
+              values={
+                Object {
+                  "confirmationNumber": "33a6f278-eaa3-41c5-8d08-276fa0364833",
+                  "shortConfirmationNumber": "0364833",
+                }
+              }
+            >
+              Note: The claimant may have seen or saved a much longer confirmation number in the past. If so, it was 
+              <strong
+                key="strong-1"
+              >
+                33a6f278-eaa3-41c5-8d08-276fa0364833
+              </strong>
+              . If they log in now, they will see 
+              <strong
+                key="strong-3"
+              >
+                0364833
+              </strong>
+               instead, which is the last 7 characters of the original number.
+            </Trans>
+          </p>
+        </CertificationStatus>
+        <Button
+          active={false}
+          className="text-dark bg-light"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+          variant="outline-secondary"
+        >
+          <button
+            className="text-dark bg-light btn btn-outline-secondary"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            Print
+          </button>
+        </Button>
+        <h2
+          className="h3 font-weight-bold mt-5 mb-3"
+        >
+          Certification Weeks
+        </h2>
+        <ListOfCertifications
+          userData={
+            Object {
+              "authToken": "pretendThisIsARealToken",
+              "confirmationNumber": "33a6f278-eaa3-41c5-8d08-276fa0364833",
+              "formData": Array [
+                Object {
+                  "couldNotAcceptWork": false,
+                  "didYouLook": false,
+                  "refuseWork": false,
+                  "schoolOrTraining": false,
+                  "tooSick": false,
+                  "workOrEarn": false,
+                },
+                Object {
+                  "couldNotAcceptWork": false,
+                  "didYouLook": false,
+                  "refuseWork": false,
+                  "schoolOrTraining": false,
+                  "tooSick": false,
+                  "workOrEarn": false,
+                },
+                Object {
+                  "couldNotAcceptWork": false,
+                  "didYouLook": false,
+                  "refuseWork": false,
+                  "schoolOrTraining": false,
+                  "tooSick": false,
+                  "workOrEarn": false,
+                },
+              ],
+              "lastName": "Taylor",
+              "programPlan": Array [
+                "UI full time",
+              ],
+              "status": "ok",
+              "weeksToCertify": Array [
+                0,
+                1,
+                2,
+              ],
+            }
+          }
+        >
+          <Button
+            active={false}
+            className="text-dark bg-light mb-3"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+            variant="outline-secondary"
+          >
+            <button
+              className="text-dark bg-light mb-3 btn btn-outline-secondary"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
+            >
+              Show all
+            </button>
+          </Button>
+          <ListOfWeeksWithDetail
+            showContentArray={
+              Array [
+                false,
+                false,
+                false,
+                false,
+              ]
+            }
+            toggleContent={[Function]}
+            userData={
+              Object {
+                "authToken": "pretendThisIsARealToken",
+                "confirmationNumber": "33a6f278-eaa3-41c5-8d08-276fa0364833",
+                "formData": Array [
+                  Object {
+                    "couldNotAcceptWork": false,
+                    "didYouLook": false,
+                    "refuseWork": false,
+                    "schoolOrTraining": false,
+                    "tooSick": false,
+                    "workOrEarn": false,
+                  },
+                  Object {
+                    "couldNotAcceptWork": false,
+                    "didYouLook": false,
+                    "refuseWork": false,
+                    "schoolOrTraining": false,
+                    "tooSick": false,
+                    "workOrEarn": false,
+                  },
+                  Object {
+                    "couldNotAcceptWork": false,
+                    "didYouLook": false,
+                    "refuseWork": false,
+                    "schoolOrTraining": false,
+                    "tooSick": false,
+                    "workOrEarn": false,
+                  },
+                ],
+                "lastName": "Taylor",
+                "programPlan": Array [
+                  "UI full time",
+                ],
+                "status": "ok",
+                "weeksToCertify": Array [
+                  0,
+                  1,
+                  2,
+                ],
+              }
+            }
+          >
+            <WeekWithDetail
+              index={0}
+              key="0"
+              showContentArray={
+                Array [
+                  false,
+                  false,
+                  false,
+                  false,
+                ]
+              }
+              toggleContent={[Function]}
+              weekData={
+                Object {
+                  "couldNotAcceptWork": false,
+                  "didYouLook": false,
+                  "refuseWork": false,
+                  "schoolOrTraining": false,
+                  "tooSick": false,
+                  "workOrEarn": false,
+                }
+              }
+              weekIndex={0}
+              weekProgramPlan="UI full time"
+            >
+              <AccordionItem
+                content={
+                  <WeekConfirmationDetails
+                    questionAnswers={
+                      Array [
+                        "No",
+                        false,
+                        "No",
+                        "No",
+                        "No",
+                        "No",
+                        "No",
+                      ]
+                    }
+                    questionKeys={
+                      Array [
+                        "retrocerts-certification.questions.ui-full-time.tooSick",
+                        "retrocerts-certification.questions.ui-full-time.tooSickNumberOfDays",
+                        "retrocerts-certification.questions.ui-full-time.couldNotAcceptWork",
+                        "retrocerts-certification.questions.ui-full-time.didYouLook",
+                        "retrocerts-certification.questions.ui-full-time.refuseWork",
+                        "retrocerts-certification.questions.ui-full-time.schoolOrTraining",
+                        "retrocerts-certification.questions.ui-full-time.workOrEarn",
+                      ]
+                    }
+                    weekString="02/02/2020 - 02/08/2020"
+                  />
+                }
+                header={
+                  <Trans
+                    i18nKey="retrocerts-week-list-item"
+                    t={[Function]}
+                    values={
+                      Object {
+                        "endDate": "02/08/2020",
+                        "startDate": "02/02/2020",
+                        "weekForUser": 1,
+                      }
+                    }
+                  />
+                }
+                showContent={false}
+                toggleContent={[Function]}
+              >
+                <Alert
+                  className="d-flex toggleAccordion"
+                  closeLabel="Close alert"
+                  onClick={[Function]}
+                  show={true}
+                  transition={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "defaultProps": Object {
+                        "appear": false,
+                        "in": false,
+                        "mountOnEnter": false,
+                        "timeout": 300,
+                        "unmountOnExit": false,
+                      },
+                      "displayName": "Fade",
+                      "render": [Function],
+                    }
+                  }
+                  variant="secondary"
+                >
+                  <Fade
+                    appear={false}
+                    in={true}
+                    mountOnEnter={false}
+                    onClick={[Function]}
+                    timeout={300}
+                    unmountOnExit={true}
+                  >
+                    <Transition
+                      addEndListener={[Function]}
+                      appear={false}
+                      enter={true}
+                      exit={true}
+                      in={true}
+                      mountOnEnter={false}
+                      onClick={[Function]}
+                      onEnter={[Function]}
+                      onEntered={[Function]}
+                      onEntering={[Function]}
+                      onExit={[Function]}
+                      onExited={[Function]}
+                      onExiting={[Function]}
+                      timeout={300}
+                      unmountOnExit={true}
+                    >
+                      <div
+                        className="fade d-flex toggleAccordion alert alert-secondary show"
+                        onClick={[Function]}
+                        role="alert"
+                      >
+                        <button
+                          aria-label="Show details for this week"
+                        >
+                          <div
+                            className="flex-fill"
+                          >
+                            <span
+                              className="toggleCharacter"
+                            >
+                              +
+                            </span>
+                            <Trans
+                              i18nKey="retrocerts-week-list-item"
+                              t={[Function]}
+                              values={
+                                Object {
+                                  "endDate": "02/08/2020",
+                                  "startDate": "02/02/2020",
+                                  "weekForUser": 1,
+                                }
+                              }
+                            >
+                              <strong
+                                key="strong-0"
+                              >
+                                Week 1
+                              </strong>
+                              : Sunday, 02/02/2020 – Saturday, 02/08/2020
+                            </Trans>
+                          </div>
+                        </button>
+                      </div>
+                    </Transition>
+                  </Fade>
+                </Alert>
+                <div
+                  className="detail"
+                  style={
+                    Object {
+                      "display": "none",
+                    }
+                  }
+                >
+                  <WeekConfirmationDetails
+                    questionAnswers={
+                      Array [
+                        "No",
+                        false,
+                        "No",
+                        "No",
+                        "No",
+                        "No",
+                        "No",
+                      ]
+                    }
+                    questionKeys={
+                      Array [
+                        "retrocerts-certification.questions.ui-full-time.tooSick",
+                        "retrocerts-certification.questions.ui-full-time.tooSickNumberOfDays",
+                        "retrocerts-certification.questions.ui-full-time.couldNotAcceptWork",
+                        "retrocerts-certification.questions.ui-full-time.didYouLook",
+                        "retrocerts-certification.questions.ui-full-time.refuseWork",
+                        "retrocerts-certification.questions.ui-full-time.schoolOrTraining",
+                        "retrocerts-certification.questions.ui-full-time.workOrEarn",
+                      ]
+                    }
+                    weekString="02/02/2020 - 02/08/2020"
+                  >
+                    <p>
+                      1. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.tooSick"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/02/2020 - 02/08/2020",
+                          }
+                        }
+                      >
+                        Were you too sick or injured to work?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      2. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.couldNotAcceptWork"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/02/2020 - 02/08/2020",
+                          }
+                        }
+                      >
+                        Was there any reason (other than sickness or injury) that you could not have accepted full-time work 
+                        <strong
+                          key="strong-1"
+                        >
+                          each workday
+                        </strong>
+                        ?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      3. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.didYouLook"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/02/2020 - 02/08/2020",
+                          }
+                        }
+                      >
+                        Did you look for work?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      4. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.refuseWork"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/02/2020 - 02/08/2020",
+                          }
+                        }
+                      >
+                        Did you refuse any work?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      5. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.schoolOrTraining"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/02/2020 - 02/08/2020",
+                          }
+                        }
+                      >
+                        Did you 
+                        <strong
+                          key="strong-1"
+                        >
+                          begin
+                        </strong>
+                         attending any kind of school or training? Select 
+                        <strong
+                          key="strong-3"
+                        >
+                          Yes
+                        </strong>
+                         only if you began attending school between 02/02/2020 - 02/08/2020.
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      6. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.workOrEarn"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/02/2020 - 02/08/2020",
+                          }
+                        }
+                      >
+                        Did you work or earn any money, 
+                        <strong
+                          key="strong-1"
+                        >
+                          whether you were paid or not
+                        </strong>
+                        ?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                  </WeekConfirmationDetails>
+                </div>
+              </AccordionItem>
+            </WeekWithDetail>
+            <WeekWithDetail
+              index={1}
+              key="1"
+              showContentArray={
+                Array [
+                  false,
+                  false,
+                  false,
+                  false,
+                ]
+              }
+              toggleContent={[Function]}
+              weekData={
+                Object {
+                  "couldNotAcceptWork": false,
+                  "didYouLook": false,
+                  "refuseWork": false,
+                  "schoolOrTraining": false,
+                  "tooSick": false,
+                  "workOrEarn": false,
+                }
+              }
+              weekIndex={1}
+              weekProgramPlan="UI full time"
+            >
+              <AccordionItem
+                content={
+                  <WeekConfirmationDetails
+                    questionAnswers={
+                      Array [
+                        "No",
+                        false,
+                        "No",
+                        "No",
+                        "No",
+                        "No",
+                        "No",
+                      ]
+                    }
+                    questionKeys={
+                      Array [
+                        "retrocerts-certification.questions.ui-full-time.tooSick",
+                        "retrocerts-certification.questions.ui-full-time.tooSickNumberOfDays",
+                        "retrocerts-certification.questions.ui-full-time.couldNotAcceptWork",
+                        "retrocerts-certification.questions.ui-full-time.didYouLook",
+                        "retrocerts-certification.questions.ui-full-time.refuseWork",
+                        "retrocerts-certification.questions.ui-full-time.schoolOrTraining",
+                        "retrocerts-certification.questions.ui-full-time.workOrEarn",
+                      ]
+                    }
+                    weekString="02/09/2020 - 02/15/2020"
+                  />
+                }
+                header={
+                  <Trans
+                    i18nKey="retrocerts-week-list-item"
+                    t={[Function]}
+                    values={
+                      Object {
+                        "endDate": "02/15/2020",
+                        "startDate": "02/09/2020",
+                        "weekForUser": 2,
+                      }
+                    }
+                  />
+                }
+                showContent={false}
+                toggleContent={[Function]}
+              >
+                <Alert
+                  className="d-flex toggleAccordion"
+                  closeLabel="Close alert"
+                  onClick={[Function]}
+                  show={true}
+                  transition={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "defaultProps": Object {
+                        "appear": false,
+                        "in": false,
+                        "mountOnEnter": false,
+                        "timeout": 300,
+                        "unmountOnExit": false,
+                      },
+                      "displayName": "Fade",
+                      "render": [Function],
+                    }
+                  }
+                  variant="secondary"
+                >
+                  <Fade
+                    appear={false}
+                    in={true}
+                    mountOnEnter={false}
+                    onClick={[Function]}
+                    timeout={300}
+                    unmountOnExit={true}
+                  >
+                    <Transition
+                      addEndListener={[Function]}
+                      appear={false}
+                      enter={true}
+                      exit={true}
+                      in={true}
+                      mountOnEnter={false}
+                      onClick={[Function]}
+                      onEnter={[Function]}
+                      onEntered={[Function]}
+                      onEntering={[Function]}
+                      onExit={[Function]}
+                      onExited={[Function]}
+                      onExiting={[Function]}
+                      timeout={300}
+                      unmountOnExit={true}
+                    >
+                      <div
+                        className="fade d-flex toggleAccordion alert alert-secondary show"
+                        onClick={[Function]}
+                        role="alert"
+                      >
+                        <button
+                          aria-label="Show details for this week"
+                        >
+                          <div
+                            className="flex-fill"
+                          >
+                            <span
+                              className="toggleCharacter"
+                            >
+                              +
+                            </span>
+                            <Trans
+                              i18nKey="retrocerts-week-list-item"
+                              t={[Function]}
+                              values={
+                                Object {
+                                  "endDate": "02/15/2020",
+                                  "startDate": "02/09/2020",
+                                  "weekForUser": 2,
+                                }
+                              }
+                            >
+                              <strong
+                                key="strong-0"
+                              >
+                                Week 2
+                              </strong>
+                              : Sunday, 02/09/2020 – Saturday, 02/15/2020
+                            </Trans>
+                          </div>
+                        </button>
+                      </div>
+                    </Transition>
+                  </Fade>
+                </Alert>
+                <div
+                  className="detail"
+                  style={
+                    Object {
+                      "display": "none",
+                    }
+                  }
+                >
+                  <WeekConfirmationDetails
+                    questionAnswers={
+                      Array [
+                        "No",
+                        false,
+                        "No",
+                        "No",
+                        "No",
+                        "No",
+                        "No",
+                      ]
+                    }
+                    questionKeys={
+                      Array [
+                        "retrocerts-certification.questions.ui-full-time.tooSick",
+                        "retrocerts-certification.questions.ui-full-time.tooSickNumberOfDays",
+                        "retrocerts-certification.questions.ui-full-time.couldNotAcceptWork",
+                        "retrocerts-certification.questions.ui-full-time.didYouLook",
+                        "retrocerts-certification.questions.ui-full-time.refuseWork",
+                        "retrocerts-certification.questions.ui-full-time.schoolOrTraining",
+                        "retrocerts-certification.questions.ui-full-time.workOrEarn",
+                      ]
+                    }
+                    weekString="02/09/2020 - 02/15/2020"
+                  >
+                    <p>
+                      1. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.tooSick"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/09/2020 - 02/15/2020",
+                          }
+                        }
+                      >
+                        Were you too sick or injured to work?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      2. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.couldNotAcceptWork"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/09/2020 - 02/15/2020",
+                          }
+                        }
+                      >
+                        Was there any reason (other than sickness or injury) that you could not have accepted full-time work 
+                        <strong
+                          key="strong-1"
+                        >
+                          each workday
+                        </strong>
+                        ?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      3. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.didYouLook"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/09/2020 - 02/15/2020",
+                          }
+                        }
+                      >
+                        Did you look for work?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      4. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.refuseWork"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/09/2020 - 02/15/2020",
+                          }
+                        }
+                      >
+                        Did you refuse any work?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      5. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.schoolOrTraining"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/09/2020 - 02/15/2020",
+                          }
+                        }
+                      >
+                        Did you 
+                        <strong
+                          key="strong-1"
+                        >
+                          begin
+                        </strong>
+                         attending any kind of school or training? Select 
+                        <strong
+                          key="strong-3"
+                        >
+                          Yes
+                        </strong>
+                         only if you began attending school between 02/09/2020 - 02/15/2020.
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      6. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.workOrEarn"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/09/2020 - 02/15/2020",
+                          }
+                        }
+                      >
+                        Did you work or earn any money, 
+                        <strong
+                          key="strong-1"
+                        >
+                          whether you were paid or not
+                        </strong>
+                        ?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                  </WeekConfirmationDetails>
+                </div>
+              </AccordionItem>
+            </WeekWithDetail>
+            <WeekWithDetail
+              index={2}
+              key="2"
+              showContentArray={
+                Array [
+                  false,
+                  false,
+                  false,
+                  false,
+                ]
+              }
+              toggleContent={[Function]}
+              weekData={
+                Object {
+                  "couldNotAcceptWork": false,
+                  "didYouLook": false,
+                  "refuseWork": false,
+                  "schoolOrTraining": false,
+                  "tooSick": false,
+                  "workOrEarn": false,
+                }
+              }
+              weekIndex={2}
+              weekProgramPlan="UI full time"
+            >
+              <AccordionItem
+                content={
+                  <WeekConfirmationDetails
+                    questionAnswers={
+                      Array [
+                        "No",
+                        false,
+                        "No",
+                        "No",
+                        "No",
+                        "No",
+                        "No",
+                      ]
+                    }
+                    questionKeys={
+                      Array [
+                        "retrocerts-certification.questions.ui-full-time.tooSick",
+                        "retrocerts-certification.questions.ui-full-time.tooSickNumberOfDays",
+                        "retrocerts-certification.questions.ui-full-time.couldNotAcceptWork",
+                        "retrocerts-certification.questions.ui-full-time.didYouLook",
+                        "retrocerts-certification.questions.ui-full-time.refuseWork",
+                        "retrocerts-certification.questions.ui-full-time.schoolOrTraining",
+                        "retrocerts-certification.questions.ui-full-time.workOrEarn",
+                      ]
+                    }
+                    weekString="02/16/2020 - 02/22/2020"
+                  />
+                }
+                header={
+                  <Trans
+                    i18nKey="retrocerts-week-list-item"
+                    t={[Function]}
+                    values={
+                      Object {
+                        "endDate": "02/22/2020",
+                        "startDate": "02/16/2020",
+                        "weekForUser": 3,
+                      }
+                    }
+                  />
+                }
+                showContent={false}
+                toggleContent={[Function]}
+              >
+                <Alert
+                  className="d-flex toggleAccordion"
+                  closeLabel="Close alert"
+                  onClick={[Function]}
+                  show={true}
+                  transition={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "defaultProps": Object {
+                        "appear": false,
+                        "in": false,
+                        "mountOnEnter": false,
+                        "timeout": 300,
+                        "unmountOnExit": false,
+                      },
+                      "displayName": "Fade",
+                      "render": [Function],
+                    }
+                  }
+                  variant="secondary"
+                >
+                  <Fade
+                    appear={false}
+                    in={true}
+                    mountOnEnter={false}
+                    onClick={[Function]}
+                    timeout={300}
+                    unmountOnExit={true}
+                  >
+                    <Transition
+                      addEndListener={[Function]}
+                      appear={false}
+                      enter={true}
+                      exit={true}
+                      in={true}
+                      mountOnEnter={false}
+                      onClick={[Function]}
+                      onEnter={[Function]}
+                      onEntered={[Function]}
+                      onEntering={[Function]}
+                      onExit={[Function]}
+                      onExited={[Function]}
+                      onExiting={[Function]}
+                      timeout={300}
+                      unmountOnExit={true}
+                    >
+                      <div
+                        className="fade d-flex toggleAccordion alert alert-secondary show"
+                        onClick={[Function]}
+                        role="alert"
+                      >
+                        <button
+                          aria-label="Show details for this week"
+                        >
+                          <div
+                            className="flex-fill"
+                          >
+                            <span
+                              className="toggleCharacter"
+                            >
+                              +
+                            </span>
+                            <Trans
+                              i18nKey="retrocerts-week-list-item"
+                              t={[Function]}
+                              values={
+                                Object {
+                                  "endDate": "02/22/2020",
+                                  "startDate": "02/16/2020",
+                                  "weekForUser": 3,
+                                }
+                              }
+                            >
+                              <strong
+                                key="strong-0"
+                              >
+                                Week 3
+                              </strong>
+                              : Sunday, 02/16/2020 – Saturday, 02/22/2020
+                            </Trans>
+                          </div>
+                        </button>
+                      </div>
+                    </Transition>
+                  </Fade>
+                </Alert>
+                <div
+                  className="detail"
+                  style={
+                    Object {
+                      "display": "none",
+                    }
+                  }
+                >
+                  <WeekConfirmationDetails
+                    questionAnswers={
+                      Array [
+                        "No",
+                        false,
+                        "No",
+                        "No",
+                        "No",
+                        "No",
+                        "No",
+                      ]
+                    }
+                    questionKeys={
+                      Array [
+                        "retrocerts-certification.questions.ui-full-time.tooSick",
+                        "retrocerts-certification.questions.ui-full-time.tooSickNumberOfDays",
+                        "retrocerts-certification.questions.ui-full-time.couldNotAcceptWork",
+                        "retrocerts-certification.questions.ui-full-time.didYouLook",
+                        "retrocerts-certification.questions.ui-full-time.refuseWork",
+                        "retrocerts-certification.questions.ui-full-time.schoolOrTraining",
+                        "retrocerts-certification.questions.ui-full-time.workOrEarn",
+                      ]
+                    }
+                    weekString="02/16/2020 - 02/22/2020"
+                  >
+                    <p>
+                      1. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.tooSick"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/16/2020 - 02/22/2020",
+                          }
+                        }
+                      >
+                        Were you too sick or injured to work?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      2. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.couldNotAcceptWork"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/16/2020 - 02/22/2020",
+                          }
+                        }
+                      >
+                        Was there any reason (other than sickness or injury) that you could not have accepted full-time work 
+                        <strong
+                          key="strong-1"
+                        >
+                          each workday
+                        </strong>
+                        ?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      3. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.didYouLook"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/16/2020 - 02/22/2020",
+                          }
+                        }
+                      >
+                        Did you look for work?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      4. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.refuseWork"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/16/2020 - 02/22/2020",
+                          }
+                        }
+                      >
+                        Did you refuse any work?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      5. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.schoolOrTraining"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/16/2020 - 02/22/2020",
+                          }
+                        }
+                      >
+                        Did you 
+                        <strong
+                          key="strong-1"
+                        >
+                          begin
+                        </strong>
+                         attending any kind of school or training? Select 
+                        <strong
+                          key="strong-3"
+                        >
+                          Yes
+                        </strong>
+                         only if you began attending school between 02/16/2020 - 02/22/2020.
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      6. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.workOrEarn"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/16/2020 - 02/22/2020",
+                          }
+                        }
+                      >
+                        Did you work or earn any money, 
+                        <strong
+                          key="strong-1"
+                        >
+                          whether you were paid or not
+                        </strong>
+                        ?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                  </WeekConfirmationDetails>
+                </div>
+              </AccordionItem>
+            </WeekWithDetail>
+          </ListOfWeeksWithDetail>
+          <AccordionItem
+            content={
+              <AcknowledgementDetail
+                className="detail"
+              />
+            }
+            header={
+              <strong>
+                Acknowledgement
+              </strong>
+            }
+            showContent={false}
+            toggleContent={[Function]}
+          >
+            <Alert
+              className="d-flex toggleAccordion"
+              closeLabel="Close alert"
+              onClick={[Function]}
+              show={true}
+              transition={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "defaultProps": Object {
+                    "appear": false,
+                    "in": false,
+                    "mountOnEnter": false,
+                    "timeout": 300,
+                    "unmountOnExit": false,
+                  },
+                  "displayName": "Fade",
+                  "render": [Function],
+                }
+              }
+              variant="secondary"
+            >
+              <Fade
+                appear={false}
+                in={true}
+                mountOnEnter={false}
+                onClick={[Function]}
+                timeout={300}
+                unmountOnExit={true}
+              >
+                <Transition
+                  addEndListener={[Function]}
+                  appear={false}
+                  enter={true}
+                  exit={true}
+                  in={true}
+                  mountOnEnter={false}
+                  onClick={[Function]}
+                  onEnter={[Function]}
+                  onEntered={[Function]}
+                  onEntering={[Function]}
+                  onExit={[Function]}
+                  onExited={[Function]}
+                  onExiting={[Function]}
+                  timeout={300}
+                  unmountOnExit={true}
+                >
+                  <div
+                    className="fade d-flex toggleAccordion alert alert-secondary show"
+                    onClick={[Function]}
+                    role="alert"
+                  >
+                    <button
+                      aria-label="Show details for this week"
+                    >
+                      <div
+                        className="flex-fill"
+                      >
+                        <span
+                          className="toggleCharacter"
+                        >
+                          +
+                        </span>
+                        <strong>
+                          Acknowledgement
+                        </strong>
+                      </div>
+                    </button>
+                  </div>
+                </Transition>
+              </Fade>
+            </Alert>
+            <div
+              className="detail"
+              style={
+                Object {
+                  "display": "none",
+                }
+              }
+            >
+              <AcknowledgementDetail
+                className="detail"
+              >
+                <ul>
+                  <li>
+                    I understand the questions I answered through this automated system.
+                  </li>
+                  <li>
+                    I know the law provides penalties if I make false statements or withhold facts to receive benefits; and my answers are true and correct.
+                  </li>
+                  <li>
+                    I declare under penalty of perjury that I am a US Citizen or National; or an Alien in satisfactory immigration status and permitted to work by the United States Citizenship and Immigration Service.
+                  </li>
+                  <li>
+                    I understand when submitting my request for benefits my submission is considered the same as my written signature.
+                  </li>
+                </ul>
+                <input
+                  checked={true}
+                  disabled={true}
+                  type="checkbox"
+                />
+                You must indicate your acceptance of the statement by checking the box before your certification can be submitted.
+              </AcknowledgementDetail>
+            </div>
+          </AccordionItem>
+        </ListOfCertifications>
+        <h2
+          className="h3 font-weight-bold mt-5 mb-3"
+        >
+          Retroactive Certification Application Details
+        </h2>
+        <p>
+          The claimant is shown the following on the Retroactive Certification Application.
+        </p>
+        <ClaimantContent>
+          <div
+            className="subtle-blockquote mb-5"
+          >
+            <p>
+              You’ve been logged out of the system and may close this window.
+            </p>
+            <Trans
+              i18nKey="retrocerts-confirmation.p2"
+              t={[Function]}
+            >
+              If you are still unemployed, continue to certify for benefits every two weeks. The fastest way is to use 
+              <a
+                href="https://edd.ca.gov/Unemployment/UI_Online.htm"
+                key="1"
+              >
+                UI Online
+              </a>
+              .
+            </Trans>
+          </div>
+        </ClaimantContent>
+      </div>
+    </main>
+    <Footer
+      backToTopTag="certification-page"
+    >
+      <footer
+        className="footer"
       >
-        Search New Claimant
-      </Button>
-      <h2
-        className="h3 font-weight-bold mt-5 mb-3"
-      >
-        Certification Status
-      </h2>
-      <CertificationStatus />
-      <Button
-        active={false}
-        className="text-dark bg-light"
-        disabled={false}
-        onClick={[Function]}
-        type="button"
-        variant="outline-secondary"
-      >
-        Print
-      </Button>
-      <h2
-        className="h3 font-weight-bold mt-5 mb-3"
-      >
-        Certification Weeks
-      </h2>
-      <ListOfWeeks
-        weeksToCertify={
-          Array [
-            0,
-            1,
-            2,
-            5,
-            6,
-          ]
-        }
-      />
-      <h2
-        className="h3 font-weight-bold mt-5 mb-3"
-      >
-        Retroactive Certification Application Details
-      </h2>
-      <p>
-        The claimant is shown the following on the Retroactive Certification Application.
-      </p>
-      <ClaimantContent />
-    </div>
-  </main>
-  <Footer
-    backToTopTag="certification-page"
-  />
-</div>
+        <Navbar
+          bg="dark"
+          className="justify-content-between"
+          collapseOnSelect={false}
+          expand={true}
+          variant="custom"
+        >
+          <nav
+            className="justify-content-between navbar navbar-expand navbar-custom bg-dark"
+          >
+            <Nav
+              className="flex-wrap"
+              fill={false}
+              justify={false}
+            >
+              <ForwardRef
+                as="div"
+                className="flex-wrap navbar-nav"
+                onSelect={[Function]}
+              >
+                <div
+                  className="flex-wrap navbar-nav"
+                  onKeyDown={[Function]}
+                >
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="/#certification-page"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="/#certification-page"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="/#certification-page"
+                        disabled={false}
+                        href="/#certification-page"
+                        onClick={[Function]}
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="/#certification-page"
+                          href="/#certification-page"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                        >
+                          Back to Top
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/"
+                          href="https://edd.ca.gov/about_edd/"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          About EDD
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/contact_edd.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/contact_edd.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/contact_edd.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/contact_edd.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/contact_edd.htm"
+                          href="https://edd.ca.gov/about_edd/contact_edd.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Contact EDD
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                          href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Conditions of Use
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                          href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Privacy Policy
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/accessibility.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/accessibility.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/accessibility.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/accessibility.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/accessibility.htm"
+                          href="https://edd.ca.gov/about_edd/accessibility.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Accessibility
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/sitemap.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/sitemap.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/sitemap.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/sitemap.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/sitemap.htm"
+                          href="https://edd.ca.gov/sitemap.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Site Map
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                </div>
+              </ForwardRef>
+            </Nav>
+            <Nav
+              className="flex-wrap"
+              fill={false}
+              justify={false}
+            >
+              <ForwardRef
+                as="div"
+                className="flex-wrap navbar-nav"
+                onSelect={[Function]}
+              >
+                <div
+                  className="flex-wrap navbar-nav"
+                  onKeyDown={[Function]}
+                >
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://www.facebook.com/californiaedd/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://www.facebook.com/californiaedd/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://www.facebook.com/californiaedd/"
+                        disabled={false}
+                        href="https://www.facebook.com/californiaedd/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://www.facebook.com/californiaedd/"
+                          href="https://www.facebook.com/californiaedd/"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="Facebook icon"
+                            height="15"
+                            src="images/facebook.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://twitter.com/CA_EDD"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://twitter.com/CA_EDD"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://twitter.com/CA_EDD"
+                        disabled={false}
+                        href="https://twitter.com/CA_EDD"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://twitter.com/CA_EDD"
+                          href="https://twitter.com/CA_EDD"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="Twitter icon"
+                            height="15"
+                            src="images/twitter.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://www.linkedin.com/company/californiaedd/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://www.linkedin.com/company/californiaedd/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://www.linkedin.com/company/californiaedd/"
+                        disabled={false}
+                        href="https://www.linkedin.com/company/californiaedd/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://www.linkedin.com/company/californiaedd/"
+                          href="https://www.linkedin.com/company/californiaedd/"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="LinkedIn icon"
+                            height="15"
+                            src="images/linkedin.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://www.instagram.com/ca_edd/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://www.instagram.com/ca_edd/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://www.instagram.com/ca_edd/"
+                        disabled={false}
+                        href="https://www.instagram.com/ca_edd/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://www.instagram.com/ca_edd/"
+                          href="https://www.instagram.com/ca_edd/"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="Instagram icon"
+                            height="15"
+                            src="images/instagram.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://www.youtube.com/user/CaliforniaEDD"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://www.youtube.com/user/CaliforniaEDD"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://www.youtube.com/user/CaliforniaEDD"
+                        disabled={false}
+                        href="https://www.youtube.com/user/CaliforniaEDD"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://www.youtube.com/user/CaliforniaEDD"
+                          href="https://www.youtube.com/user/CaliforniaEDD"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="YouTube icon"
+                            height="15"
+                            src="images/youtube.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                </div>
+              </ForwardRef>
+            </Nav>
+          </nav>
+        </Navbar>
+        <div
+          className="bg-light secondary-footer"
+        >
+          <Container
+            fluid={false}
+          >
+            <div
+              className="container"
+            >
+              Copyright © 2020 State of California
+            </div>
+          </Container>
+        </div>
+      </footer>
+    </Footer>
+  </div>
+</StaffViewConfirmationPage>
 `;
 
 exports[`<StaffViewConfirmationPage /> when claimant in progress 1`] = `
-<div
-  id="overflow-wrapper"
+<StaffViewConfirmationPage
+  setUserData={[Function]}
+  userData={
+    Object {
+      "authToken": "pretendThisIsARealToken",
+      "lastName": "Taylor",
+      "programPlan": Array [
+        "UI full time",
+      ],
+      "status": "ok",
+      "weeksToCertify": Array [
+        0,
+        1,
+        2,
+        5,
+        6,
+      ],
+    }
+  }
 >
-  <Header />
-  <main
-    className="pb-5"
-    id="certification-page"
+  <div
+    id="overflow-wrapper"
   >
-    <div
-      className="container p-4"
+    <Header>
+      <header
+        className="header border-bottom border-secondary"
+      >
+        <Navbar
+          bg="primary"
+          className="justify-content-between"
+          collapseOnSelect={false}
+          expand={true}
+          variant="custom"
+        >
+          <nav
+            className="justify-content-between navbar navbar-expand navbar-custom bg-primary"
+          >
+            <NavbarBrand
+              href="https://ca.gov"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <a
+                className="navbar-brand"
+                href="https://ca.gov"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <img
+                  alt="California gov logo"
+                  height="30"
+                  src="images/Ca-Gov-Logo-Gold.svg"
+                  width="30"
+                />
+              </a>
+            </NavbarBrand>
+            <Nav
+              fill={false}
+              justify={false}
+            >
+              <ForwardRef
+                as="div"
+                className="navbar-nav"
+                onSelect={[Function]}
+              >
+                <div
+                  className="navbar-nav"
+                  onKeyDown={[Function]}
+                >
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov"
+                        disabled={false}
+                        href="https://edd.ca.gov"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov"
+                          href="https://edd.ca.gov"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="home icon"
+                            className="icon"
+                            height="15"
+                            src="images/home.svg"
+                            width="15"
+                          />
+                           
+                          <span
+                            className="text"
+                          >
+                            Home
+                          </span>
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/login.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/login.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/login.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/login.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/login.htm"
+                          href="https://edd.ca.gov/login.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <span>
+                            <img
+                              alt="key icon"
+                              className="icon"
+                              height="15"
+                              src="images/key.svg"
+                              width="15"
+                            />
+                             
+                            <span
+                              className="text"
+                            >
+                              Log In
+                            </span>
+                          </span>
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                </div>
+              </ForwardRef>
+            </Nav>
+          </nav>
+        </Navbar>
+        <Navbar
+          collapseOnSelect={true}
+          expand="md"
+          variant="light"
+        >
+          <nav
+            className="navbar navbar-expand-md navbar-light"
+          >
+            <NavbarBrand
+              href="https://edd.ca.gov"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <a
+                className="navbar-brand"
+                href="https://edd.ca.gov"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <img
+                  alt="California gov logo"
+                  className="d-inline-block align-top mr-5"
+                  height="50"
+                  src="images/edd-logo-2-Color.svg"
+                  width="150"
+                />
+              </a>
+            </NavbarBrand>
+            <NavbarToggle
+              aria-controls="responsive-navbar-nav"
+              label="Toggle navigation"
+            >
+              <button
+                aria-controls="responsive-navbar-nav"
+                aria-label="Toggle navigation"
+                className="navbar-toggler collapsed"
+                onClick={[Function]}
+                type="button"
+              >
+                <span
+                  className="navbar-toggler-icon"
+                />
+              </button>
+            </NavbarToggle>
+            <NavbarCollapse
+              className="justify-content-between ml-5 mr-5 pl-5"
+            >
+              <Collapse
+                appear={false}
+                className="justify-content-between ml-5 mr-5 pl-5"
+                dimension="height"
+                getDimensionValue={[Function]}
+                in={false}
+                mountOnEnter={false}
+                timeout={300}
+                unmountOnExit={false}
+              >
+                <Transition
+                  addEndListener={[Function]}
+                  appear={false}
+                  aria-expanded={null}
+                  enter={true}
+                  exit={true}
+                  in={false}
+                  mountOnEnter={false}
+                  onEnter={[Function]}
+                  onEntered={[Function]}
+                  onEntering={[Function]}
+                  onExit={[Function]}
+                  onExited={[Function]}
+                  onExiting={[Function]}
+                  timeout={300}
+                  unmountOnExit={false}
+                >
+                  <div
+                    aria-expanded={null}
+                    className="justify-content-between ml-5 mr-5 pl-5 navbar-collapse collapse"
+                  >
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/jobs.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/jobs.htm"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/jobs.htm"
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/jobs.htm"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Jobs
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/claims.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/claims.htm"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/claims.htm"
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/claims.htm"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Claims
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/employers.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/employers.htm"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/employers.htm"
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/employers.htm"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Employers
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/newsroom.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/newsroom.htm"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/newsroom.htm"
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/newsroom.htm"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Newsroom
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/serp.html?q="
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/serp.html?q="
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/serp.html?q="
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/serp.html?q="
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Search
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                  </div>
+                </Transition>
+              </Collapse>
+            </NavbarCollapse>
+          </nav>
+        </Navbar>
+      </header>
+    </Header>
+    <main
+      className="pb-5"
+      id="certification-page"
     >
-      <h1>
-        Retroactive Certification for Unemployment
-      </h1>
-      <h2
-        className="h3 font-weight-bold mb-3"
+      <div
+        className="container p-4"
       >
-        Staff View
-      </h2>
-      <Button
-        active={false}
-        as={
-          Object {
-            "$$typeof": Symbol(react.forward_ref),
-            "displayName": "Link",
-            "propTypes": Object {
-              "innerRef": [Function],
-              "onClick": [Function],
-              "replace": [Function],
-              "target": [Function],
-              "to": [Function],
-            },
-            "render": [Function],
+        <h1>
+          Retroactive Certification for Unemployment
+        </h1>
+        <h2
+          className="h3 font-weight-bold mb-3"
+        >
+          Staff View
+        </h2>
+        <Button
+          active={false}
+          as={
+            Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "displayName": "Link",
+              "propTypes": Object {
+                "innerRef": [Function],
+                "onClick": [Function],
+                "replace": [Function],
+                "target": [Function],
+                "to": [Function],
+              },
+              "render": [Function],
+            }
           }
-        }
-        className="text-dark bg-light"
-        disabled={false}
-        to="/retroactive-certification"
-        type="button"
-        variant="outline-secondary"
+          className="text-dark bg-light"
+          disabled={false}
+          to="/retroactive-certification"
+          type="button"
+          variant="outline-secondary"
+        >
+          <Link
+            className="text-dark bg-light btn btn-outline-secondary"
+            disabled={false}
+            to="/retroactive-certification"
+          >
+            <LinkAnchor
+              className="text-dark bg-light btn btn-outline-secondary"
+              disabled={false}
+              href="/retroactive-certification"
+              navigate={[Function]}
+            >
+              <a
+                className="text-dark bg-light btn btn-outline-secondary"
+                disabled={false}
+                href="/retroactive-certification"
+                onClick={[Function]}
+              >
+                Search New Claimant
+              </a>
+            </LinkAnchor>
+          </Link>
+        </Button>
+        <h2
+          className="h3 font-weight-bold mt-5 mb-3"
+        >
+          Certification Status
+        </h2>
+        <CertificationStatus>
+          <span
+            className="badge in-progress"
+          >
+            In progress
+          </span>
+          <p>
+            Claimant Xaybz has logged in and begun retroactive certification.
+          </p>
+        </CertificationStatus>
+        <Button
+          active={false}
+          className="text-dark bg-light"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+          variant="outline-secondary"
+        >
+          <button
+            className="text-dark bg-light btn btn-outline-secondary"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            Print
+          </button>
+        </Button>
+        <h2
+          className="h3 font-weight-bold mt-5 mb-3"
+        >
+          Certification Weeks
+        </h2>
+        <ListOfWeeks
+          weeksToCertify={
+            Array [
+              0,
+              1,
+              2,
+              5,
+              6,
+            ]
+          }
+        >
+          <Alert
+            className="d-flex"
+            closeLabel="Close alert"
+            key="weekToCertify0"
+            show={true}
+            transition={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "defaultProps": Object {
+                  "appear": false,
+                  "in": false,
+                  "mountOnEnter": false,
+                  "timeout": 300,
+                  "unmountOnExit": false,
+                },
+                "displayName": "Fade",
+                "render": [Function],
+              }
+            }
+            variant="secondary"
+          >
+            <Fade
+              appear={false}
+              in={true}
+              mountOnEnter={false}
+              timeout={300}
+              unmountOnExit={true}
+            >
+              <Transition
+                addEndListener={[Function]}
+                appear={false}
+                enter={true}
+                exit={true}
+                in={true}
+                mountOnEnter={false}
+                onEnter={[Function]}
+                onEntered={[Function]}
+                onEntering={[Function]}
+                onExit={[Function]}
+                onExited={[Function]}
+                onExiting={[Function]}
+                timeout={300}
+                unmountOnExit={true}
+              >
+                <div
+                  className="fade d-flex alert alert-secondary show"
+                  role="alert"
+                >
+                  <div
+                    className="flex-fill"
+                  >
+                    <Trans
+                      i18nKey="retrocerts-week-list-item"
+                      t={[Function]}
+                      values={
+                        Object {
+                          "endDate": "02/08/2020",
+                          "startDate": "02/02/2020",
+                          "weekForUser": 1,
+                        }
+                      }
+                    >
+                      <strong
+                        key="strong-0"
+                      >
+                        Week 1
+                      </strong>
+                      : Sunday, 02/02/2020 – Saturday, 02/08/2020
+                    </Trans>
+                  </div>
+                </div>
+              </Transition>
+            </Fade>
+          </Alert>
+          <Alert
+            className="d-flex"
+            closeLabel="Close alert"
+            key="weekToCertify1"
+            show={true}
+            transition={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "defaultProps": Object {
+                  "appear": false,
+                  "in": false,
+                  "mountOnEnter": false,
+                  "timeout": 300,
+                  "unmountOnExit": false,
+                },
+                "displayName": "Fade",
+                "render": [Function],
+              }
+            }
+            variant="secondary"
+          >
+            <Fade
+              appear={false}
+              in={true}
+              mountOnEnter={false}
+              timeout={300}
+              unmountOnExit={true}
+            >
+              <Transition
+                addEndListener={[Function]}
+                appear={false}
+                enter={true}
+                exit={true}
+                in={true}
+                mountOnEnter={false}
+                onEnter={[Function]}
+                onEntered={[Function]}
+                onEntering={[Function]}
+                onExit={[Function]}
+                onExited={[Function]}
+                onExiting={[Function]}
+                timeout={300}
+                unmountOnExit={true}
+              >
+                <div
+                  className="fade d-flex alert alert-secondary show"
+                  role="alert"
+                >
+                  <div
+                    className="flex-fill"
+                  >
+                    <Trans
+                      i18nKey="retrocerts-week-list-item"
+                      t={[Function]}
+                      values={
+                        Object {
+                          "endDate": "02/15/2020",
+                          "startDate": "02/09/2020",
+                          "weekForUser": 2,
+                        }
+                      }
+                    >
+                      <strong
+                        key="strong-0"
+                      >
+                        Week 2
+                      </strong>
+                      : Sunday, 02/09/2020 – Saturday, 02/15/2020
+                    </Trans>
+                  </div>
+                </div>
+              </Transition>
+            </Fade>
+          </Alert>
+          <Alert
+            className="d-flex"
+            closeLabel="Close alert"
+            key="weekToCertify2"
+            show={true}
+            transition={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "defaultProps": Object {
+                  "appear": false,
+                  "in": false,
+                  "mountOnEnter": false,
+                  "timeout": 300,
+                  "unmountOnExit": false,
+                },
+                "displayName": "Fade",
+                "render": [Function],
+              }
+            }
+            variant="secondary"
+          >
+            <Fade
+              appear={false}
+              in={true}
+              mountOnEnter={false}
+              timeout={300}
+              unmountOnExit={true}
+            >
+              <Transition
+                addEndListener={[Function]}
+                appear={false}
+                enter={true}
+                exit={true}
+                in={true}
+                mountOnEnter={false}
+                onEnter={[Function]}
+                onEntered={[Function]}
+                onEntering={[Function]}
+                onExit={[Function]}
+                onExited={[Function]}
+                onExiting={[Function]}
+                timeout={300}
+                unmountOnExit={true}
+              >
+                <div
+                  className="fade d-flex alert alert-secondary show"
+                  role="alert"
+                >
+                  <div
+                    className="flex-fill"
+                  >
+                    <Trans
+                      i18nKey="retrocerts-week-list-item"
+                      t={[Function]}
+                      values={
+                        Object {
+                          "endDate": "02/22/2020",
+                          "startDate": "02/16/2020",
+                          "weekForUser": 3,
+                        }
+                      }
+                    >
+                      <strong
+                        key="strong-0"
+                      >
+                        Week 3
+                      </strong>
+                      : Sunday, 02/16/2020 – Saturday, 02/22/2020
+                    </Trans>
+                  </div>
+                </div>
+              </Transition>
+            </Fade>
+          </Alert>
+          <Alert
+            className="d-flex"
+            closeLabel="Close alert"
+            key="weekToCertify5"
+            show={true}
+            transition={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "defaultProps": Object {
+                  "appear": false,
+                  "in": false,
+                  "mountOnEnter": false,
+                  "timeout": 300,
+                  "unmountOnExit": false,
+                },
+                "displayName": "Fade",
+                "render": [Function],
+              }
+            }
+            variant="secondary"
+          >
+            <Fade
+              appear={false}
+              in={true}
+              mountOnEnter={false}
+              timeout={300}
+              unmountOnExit={true}
+            >
+              <Transition
+                addEndListener={[Function]}
+                appear={false}
+                enter={true}
+                exit={true}
+                in={true}
+                mountOnEnter={false}
+                onEnter={[Function]}
+                onEntered={[Function]}
+                onEntering={[Function]}
+                onExit={[Function]}
+                onExited={[Function]}
+                onExiting={[Function]}
+                timeout={300}
+                unmountOnExit={true}
+              >
+                <div
+                  className="fade d-flex alert alert-secondary show"
+                  role="alert"
+                >
+                  <div
+                    className="flex-fill"
+                  >
+                    <Trans
+                      i18nKey="retrocerts-week-list-item"
+                      t={[Function]}
+                      values={
+                        Object {
+                          "endDate": "03/14/2020",
+                          "startDate": "03/08/2020",
+                          "weekForUser": 4,
+                        }
+                      }
+                    >
+                      <strong
+                        key="strong-0"
+                      >
+                        Week 4
+                      </strong>
+                      : Sunday, 03/08/2020 – Saturday, 03/14/2020
+                    </Trans>
+                  </div>
+                </div>
+              </Transition>
+            </Fade>
+          </Alert>
+          <Alert
+            className="d-flex"
+            closeLabel="Close alert"
+            key="weekToCertify6"
+            show={true}
+            transition={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "defaultProps": Object {
+                  "appear": false,
+                  "in": false,
+                  "mountOnEnter": false,
+                  "timeout": 300,
+                  "unmountOnExit": false,
+                },
+                "displayName": "Fade",
+                "render": [Function],
+              }
+            }
+            variant="secondary"
+          >
+            <Fade
+              appear={false}
+              in={true}
+              mountOnEnter={false}
+              timeout={300}
+              unmountOnExit={true}
+            >
+              <Transition
+                addEndListener={[Function]}
+                appear={false}
+                enter={true}
+                exit={true}
+                in={true}
+                mountOnEnter={false}
+                onEnter={[Function]}
+                onEntered={[Function]}
+                onEntering={[Function]}
+                onExit={[Function]}
+                onExited={[Function]}
+                onExiting={[Function]}
+                timeout={300}
+                unmountOnExit={true}
+              >
+                <div
+                  className="fade d-flex alert alert-secondary show"
+                  role="alert"
+                >
+                  <div
+                    className="flex-fill"
+                  >
+                    <Trans
+                      i18nKey="retrocerts-week-list-item"
+                      t={[Function]}
+                      values={
+                        Object {
+                          "endDate": "03/21/2020",
+                          "startDate": "03/15/2020",
+                          "weekForUser": 5,
+                        }
+                      }
+                    >
+                      <strong
+                        key="strong-0"
+                      >
+                        Week 5
+                      </strong>
+                      : Sunday, 03/15/2020 – Saturday, 03/21/2020
+                    </Trans>
+                  </div>
+                </div>
+              </Transition>
+            </Fade>
+          </Alert>
+        </ListOfWeeks>
+        <h2
+          className="h3 font-weight-bold mt-5 mb-3"
+        >
+          Retroactive Certification Application Details
+        </h2>
+        <p>
+          The claimant is shown the following on the Retroactive Certification Application.
+        </p>
+        <ClaimantContent>
+          <div
+            className="subtle-blockquote mb-5"
+          >
+            <p>
+              Your answers for each completed certification week will save automatically when you continue to the next week. Partially completed weeks are not saved. Try to complete all retroactive certifications in one session.
+            </p>
+            <p>
+              To protect the security of your information, this application will automatically time out after 30 minutes of inactivity. To avoid timing out, select any button every 25 minutes.
+            </p>
+          </div>
+        </ClaimantContent>
+      </div>
+    </main>
+    <Footer
+      backToTopTag="certification-page"
+    >
+      <footer
+        className="footer"
       >
-        Search New Claimant
-      </Button>
-      <h2
-        className="h3 font-weight-bold mt-5 mb-3"
-      >
-        Certification Status
-      </h2>
-      <CertificationStatus />
-      <Button
-        active={false}
-        className="text-dark bg-light"
-        disabled={false}
-        onClick={[Function]}
-        type="button"
-        variant="outline-secondary"
-      >
-        Print
-      </Button>
-      <h2
-        className="h3 font-weight-bold mt-5 mb-3"
-      >
-        Certification Weeks
-      </h2>
-      <ListOfWeeks
-        weeksToCertify={
-          Array [
-            0,
-            1,
-            2,
-            5,
-            6,
-          ]
-        }
-      />
-      <h2
-        className="h3 font-weight-bold mt-5 mb-3"
-      >
-        Retroactive Certification Application Details
-      </h2>
-      <p>
-        The claimant is shown the following on the Retroactive Certification Application.
-      </p>
-      <ClaimantContent />
-    </div>
-  </main>
-  <Footer
-    backToTopTag="certification-page"
-  />
-</div>
+        <Navbar
+          bg="dark"
+          className="justify-content-between"
+          collapseOnSelect={false}
+          expand={true}
+          variant="custom"
+        >
+          <nav
+            className="justify-content-between navbar navbar-expand navbar-custom bg-dark"
+          >
+            <Nav
+              className="flex-wrap"
+              fill={false}
+              justify={false}
+            >
+              <ForwardRef
+                as="div"
+                className="flex-wrap navbar-nav"
+                onSelect={[Function]}
+              >
+                <div
+                  className="flex-wrap navbar-nav"
+                  onKeyDown={[Function]}
+                >
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="/#certification-page"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="/#certification-page"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="/#certification-page"
+                        disabled={false}
+                        href="/#certification-page"
+                        onClick={[Function]}
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="/#certification-page"
+                          href="/#certification-page"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                        >
+                          Back to Top
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/"
+                          href="https://edd.ca.gov/about_edd/"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          About EDD
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/contact_edd.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/contact_edd.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/contact_edd.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/contact_edd.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/contact_edd.htm"
+                          href="https://edd.ca.gov/about_edd/contact_edd.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Contact EDD
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                          href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Conditions of Use
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                          href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Privacy Policy
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/accessibility.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/accessibility.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/accessibility.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/accessibility.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/accessibility.htm"
+                          href="https://edd.ca.gov/about_edd/accessibility.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Accessibility
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/sitemap.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/sitemap.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/sitemap.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/sitemap.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/sitemap.htm"
+                          href="https://edd.ca.gov/sitemap.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Site Map
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                </div>
+              </ForwardRef>
+            </Nav>
+            <Nav
+              className="flex-wrap"
+              fill={false}
+              justify={false}
+            >
+              <ForwardRef
+                as="div"
+                className="flex-wrap navbar-nav"
+                onSelect={[Function]}
+              >
+                <div
+                  className="flex-wrap navbar-nav"
+                  onKeyDown={[Function]}
+                >
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://www.facebook.com/californiaedd/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://www.facebook.com/californiaedd/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://www.facebook.com/californiaedd/"
+                        disabled={false}
+                        href="https://www.facebook.com/californiaedd/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://www.facebook.com/californiaedd/"
+                          href="https://www.facebook.com/californiaedd/"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="Facebook icon"
+                            height="15"
+                            src="images/facebook.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://twitter.com/CA_EDD"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://twitter.com/CA_EDD"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://twitter.com/CA_EDD"
+                        disabled={false}
+                        href="https://twitter.com/CA_EDD"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://twitter.com/CA_EDD"
+                          href="https://twitter.com/CA_EDD"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="Twitter icon"
+                            height="15"
+                            src="images/twitter.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://www.linkedin.com/company/californiaedd/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://www.linkedin.com/company/californiaedd/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://www.linkedin.com/company/californiaedd/"
+                        disabled={false}
+                        href="https://www.linkedin.com/company/californiaedd/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://www.linkedin.com/company/californiaedd/"
+                          href="https://www.linkedin.com/company/californiaedd/"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="LinkedIn icon"
+                            height="15"
+                            src="images/linkedin.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://www.instagram.com/ca_edd/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://www.instagram.com/ca_edd/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://www.instagram.com/ca_edd/"
+                        disabled={false}
+                        href="https://www.instagram.com/ca_edd/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://www.instagram.com/ca_edd/"
+                          href="https://www.instagram.com/ca_edd/"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="Instagram icon"
+                            height="15"
+                            src="images/instagram.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://www.youtube.com/user/CaliforniaEDD"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://www.youtube.com/user/CaliforniaEDD"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://www.youtube.com/user/CaliforniaEDD"
+                        disabled={false}
+                        href="https://www.youtube.com/user/CaliforniaEDD"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://www.youtube.com/user/CaliforniaEDD"
+                          href="https://www.youtube.com/user/CaliforniaEDD"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="YouTube icon"
+                            height="15"
+                            src="images/youtube.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                </div>
+              </ForwardRef>
+            </Nav>
+          </nav>
+        </Navbar>
+        <div
+          className="bg-light secondary-footer"
+        >
+          <Container
+            fluid={false}
+          >
+            <div
+              className="container"
+            >
+              Copyright © 2020 State of California
+            </div>
+          </Container>
+        </div>
+      </footer>
+    </Footer>
+  </div>
+</StaffViewConfirmationPage>
 `;
 
 exports[`<StaffViewConfirmationPage /> when claimant not started 1`] = `
-<div
-  id="overflow-wrapper"
+<StaffViewConfirmationPage
+  setUserData={[Function]}
+  userData={
+    Object {
+      "lastName": "Taylor",
+      "programPlan": Array [
+        "PUA full time",
+      ],
+      "status": "ok",
+      "weeksToCertify": Array [
+        0,
+        1,
+        2,
+        5,
+        6,
+      ],
+    }
+  }
 >
-  <Header />
-  <main
-    className="pb-5"
-    id="certification-page"
+  <div
+    id="overflow-wrapper"
   >
-    <div
-      className="container p-4"
+    <Header>
+      <header
+        className="header border-bottom border-secondary"
+      >
+        <Navbar
+          bg="primary"
+          className="justify-content-between"
+          collapseOnSelect={false}
+          expand={true}
+          variant="custom"
+        >
+          <nav
+            className="justify-content-between navbar navbar-expand navbar-custom bg-primary"
+          >
+            <NavbarBrand
+              href="https://ca.gov"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <a
+                className="navbar-brand"
+                href="https://ca.gov"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <img
+                  alt="California gov logo"
+                  height="30"
+                  src="images/Ca-Gov-Logo-Gold.svg"
+                  width="30"
+                />
+              </a>
+            </NavbarBrand>
+            <Nav
+              fill={false}
+              justify={false}
+            >
+              <ForwardRef
+                as="div"
+                className="navbar-nav"
+                onSelect={[Function]}
+              >
+                <div
+                  className="navbar-nav"
+                  onKeyDown={[Function]}
+                >
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov"
+                        disabled={false}
+                        href="https://edd.ca.gov"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov"
+                          href="https://edd.ca.gov"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="home icon"
+                            className="icon"
+                            height="15"
+                            src="images/home.svg"
+                            width="15"
+                          />
+                           
+                          <span
+                            className="text"
+                          >
+                            Home
+                          </span>
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/login.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/login.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/login.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/login.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/login.htm"
+                          href="https://edd.ca.gov/login.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <span>
+                            <img
+                              alt="key icon"
+                              className="icon"
+                              height="15"
+                              src="images/key.svg"
+                              width="15"
+                            />
+                             
+                            <span
+                              className="text"
+                            >
+                              Log In
+                            </span>
+                          </span>
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                </div>
+              </ForwardRef>
+            </Nav>
+          </nav>
+        </Navbar>
+        <Navbar
+          collapseOnSelect={true}
+          expand="md"
+          variant="light"
+        >
+          <nav
+            className="navbar navbar-expand-md navbar-light"
+          >
+            <NavbarBrand
+              href="https://edd.ca.gov"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <a
+                className="navbar-brand"
+                href="https://edd.ca.gov"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <img
+                  alt="California gov logo"
+                  className="d-inline-block align-top mr-5"
+                  height="50"
+                  src="images/edd-logo-2-Color.svg"
+                  width="150"
+                />
+              </a>
+            </NavbarBrand>
+            <NavbarToggle
+              aria-controls="responsive-navbar-nav"
+              label="Toggle navigation"
+            >
+              <button
+                aria-controls="responsive-navbar-nav"
+                aria-label="Toggle navigation"
+                className="navbar-toggler collapsed"
+                onClick={[Function]}
+                type="button"
+              >
+                <span
+                  className="navbar-toggler-icon"
+                />
+              </button>
+            </NavbarToggle>
+            <NavbarCollapse
+              className="justify-content-between ml-5 mr-5 pl-5"
+            >
+              <Collapse
+                appear={false}
+                className="justify-content-between ml-5 mr-5 pl-5"
+                dimension="height"
+                getDimensionValue={[Function]}
+                in={false}
+                mountOnEnter={false}
+                timeout={300}
+                unmountOnExit={false}
+              >
+                <Transition
+                  addEndListener={[Function]}
+                  appear={false}
+                  aria-expanded={null}
+                  enter={true}
+                  exit={true}
+                  in={false}
+                  mountOnEnter={false}
+                  onEnter={[Function]}
+                  onEntered={[Function]}
+                  onEntering={[Function]}
+                  onExit={[Function]}
+                  onExited={[Function]}
+                  onExiting={[Function]}
+                  timeout={300}
+                  unmountOnExit={false}
+                >
+                  <div
+                    aria-expanded={null}
+                    className="justify-content-between ml-5 mr-5 pl-5 navbar-collapse collapse"
+                  >
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/jobs.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/jobs.htm"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/jobs.htm"
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/jobs.htm"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Jobs
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/claims.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/claims.htm"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/claims.htm"
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/claims.htm"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Claims
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/employers.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/employers.htm"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/employers.htm"
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/employers.htm"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Employers
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/newsroom.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/newsroom.htm"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/newsroom.htm"
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/newsroom.htm"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Newsroom
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/serp.html?q="
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/serp.html?q="
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/serp.html?q="
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/serp.html?q="
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Search
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                  </div>
+                </Transition>
+              </Collapse>
+            </NavbarCollapse>
+          </nav>
+        </Navbar>
+      </header>
+    </Header>
+    <main
+      className="pb-5"
+      id="certification-page"
     >
-      <h1>
-        Retroactive Certification for Unemployment
-      </h1>
-      <h2
-        className="h3 font-weight-bold mb-3"
+      <div
+        className="container p-4"
       >
-        Staff View
-      </h2>
-      <Button
-        active={false}
-        as={
-          Object {
-            "$$typeof": Symbol(react.forward_ref),
-            "displayName": "Link",
-            "propTypes": Object {
-              "innerRef": [Function],
-              "onClick": [Function],
-              "replace": [Function],
-              "target": [Function],
-              "to": [Function],
-            },
-            "render": [Function],
+        <h1>
+          Retroactive Certification for Unemployment
+        </h1>
+        <h2
+          className="h3 font-weight-bold mb-3"
+        >
+          Staff View
+        </h2>
+        <Button
+          active={false}
+          as={
+            Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "displayName": "Link",
+              "propTypes": Object {
+                "innerRef": [Function],
+                "onClick": [Function],
+                "replace": [Function],
+                "target": [Function],
+                "to": [Function],
+              },
+              "render": [Function],
+            }
           }
-        }
-        className="text-dark bg-light"
-        disabled={false}
-        to="/retroactive-certification"
-        type="button"
-        variant="outline-secondary"
+          className="text-dark bg-light"
+          disabled={false}
+          to="/retroactive-certification"
+          type="button"
+          variant="outline-secondary"
+        >
+          <Link
+            className="text-dark bg-light btn btn-outline-secondary"
+            disabled={false}
+            to="/retroactive-certification"
+          >
+            <LinkAnchor
+              className="text-dark bg-light btn btn-outline-secondary"
+              disabled={false}
+              href="/retroactive-certification"
+              navigate={[Function]}
+            >
+              <a
+                className="text-dark bg-light btn btn-outline-secondary"
+                disabled={false}
+                href="/retroactive-certification"
+                onClick={[Function]}
+              >
+                Search New Claimant
+              </a>
+            </LinkAnchor>
+          </Link>
+        </Button>
+        <h2
+          className="h3 font-weight-bold mt-5 mb-3"
+        >
+          Certification Status
+        </h2>
+        <CertificationStatus>
+          <span
+            className="badge not-started"
+          >
+            Not started
+          </span>
+          <p>
+            Claimant Xaybz has never logged in and has not begun retroactive certification.
+          </p>
+        </CertificationStatus>
+        <Button
+          active={false}
+          className="text-dark bg-light"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+          variant="outline-secondary"
+        >
+          <button
+            className="text-dark bg-light btn btn-outline-secondary"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            Print
+          </button>
+        </Button>
+        <h2
+          className="h3 font-weight-bold mt-5 mb-3"
+        >
+          Certification Weeks
+        </h2>
+        <ListOfWeeks
+          weeksToCertify={
+            Array [
+              0,
+              1,
+              2,
+              5,
+              6,
+            ]
+          }
+        >
+          <Alert
+            className="d-flex"
+            closeLabel="Close alert"
+            key="weekToCertify0"
+            show={true}
+            transition={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "defaultProps": Object {
+                  "appear": false,
+                  "in": false,
+                  "mountOnEnter": false,
+                  "timeout": 300,
+                  "unmountOnExit": false,
+                },
+                "displayName": "Fade",
+                "render": [Function],
+              }
+            }
+            variant="secondary"
+          >
+            <Fade
+              appear={false}
+              in={true}
+              mountOnEnter={false}
+              timeout={300}
+              unmountOnExit={true}
+            >
+              <Transition
+                addEndListener={[Function]}
+                appear={false}
+                enter={true}
+                exit={true}
+                in={true}
+                mountOnEnter={false}
+                onEnter={[Function]}
+                onEntered={[Function]}
+                onEntering={[Function]}
+                onExit={[Function]}
+                onExited={[Function]}
+                onExiting={[Function]}
+                timeout={300}
+                unmountOnExit={true}
+              >
+                <div
+                  className="fade d-flex alert alert-secondary show"
+                  role="alert"
+                >
+                  <div
+                    className="flex-fill"
+                  >
+                    <Trans
+                      i18nKey="retrocerts-week-list-item"
+                      t={[Function]}
+                      values={
+                        Object {
+                          "endDate": "02/08/2020",
+                          "startDate": "02/02/2020",
+                          "weekForUser": 1,
+                        }
+                      }
+                    >
+                      <strong
+                        key="strong-0"
+                      >
+                        Week 1
+                      </strong>
+                      : Sunday, 02/02/2020 – Saturday, 02/08/2020
+                    </Trans>
+                  </div>
+                </div>
+              </Transition>
+            </Fade>
+          </Alert>
+          <Alert
+            className="d-flex"
+            closeLabel="Close alert"
+            key="weekToCertify1"
+            show={true}
+            transition={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "defaultProps": Object {
+                  "appear": false,
+                  "in": false,
+                  "mountOnEnter": false,
+                  "timeout": 300,
+                  "unmountOnExit": false,
+                },
+                "displayName": "Fade",
+                "render": [Function],
+              }
+            }
+            variant="secondary"
+          >
+            <Fade
+              appear={false}
+              in={true}
+              mountOnEnter={false}
+              timeout={300}
+              unmountOnExit={true}
+            >
+              <Transition
+                addEndListener={[Function]}
+                appear={false}
+                enter={true}
+                exit={true}
+                in={true}
+                mountOnEnter={false}
+                onEnter={[Function]}
+                onEntered={[Function]}
+                onEntering={[Function]}
+                onExit={[Function]}
+                onExited={[Function]}
+                onExiting={[Function]}
+                timeout={300}
+                unmountOnExit={true}
+              >
+                <div
+                  className="fade d-flex alert alert-secondary show"
+                  role="alert"
+                >
+                  <div
+                    className="flex-fill"
+                  >
+                    <Trans
+                      i18nKey="retrocerts-week-list-item"
+                      t={[Function]}
+                      values={
+                        Object {
+                          "endDate": "02/15/2020",
+                          "startDate": "02/09/2020",
+                          "weekForUser": 2,
+                        }
+                      }
+                    >
+                      <strong
+                        key="strong-0"
+                      >
+                        Week 2
+                      </strong>
+                      : Sunday, 02/09/2020 – Saturday, 02/15/2020
+                    </Trans>
+                  </div>
+                </div>
+              </Transition>
+            </Fade>
+          </Alert>
+          <Alert
+            className="d-flex"
+            closeLabel="Close alert"
+            key="weekToCertify2"
+            show={true}
+            transition={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "defaultProps": Object {
+                  "appear": false,
+                  "in": false,
+                  "mountOnEnter": false,
+                  "timeout": 300,
+                  "unmountOnExit": false,
+                },
+                "displayName": "Fade",
+                "render": [Function],
+              }
+            }
+            variant="secondary"
+          >
+            <Fade
+              appear={false}
+              in={true}
+              mountOnEnter={false}
+              timeout={300}
+              unmountOnExit={true}
+            >
+              <Transition
+                addEndListener={[Function]}
+                appear={false}
+                enter={true}
+                exit={true}
+                in={true}
+                mountOnEnter={false}
+                onEnter={[Function]}
+                onEntered={[Function]}
+                onEntering={[Function]}
+                onExit={[Function]}
+                onExited={[Function]}
+                onExiting={[Function]}
+                timeout={300}
+                unmountOnExit={true}
+              >
+                <div
+                  className="fade d-flex alert alert-secondary show"
+                  role="alert"
+                >
+                  <div
+                    className="flex-fill"
+                  >
+                    <Trans
+                      i18nKey="retrocerts-week-list-item"
+                      t={[Function]}
+                      values={
+                        Object {
+                          "endDate": "02/22/2020",
+                          "startDate": "02/16/2020",
+                          "weekForUser": 3,
+                        }
+                      }
+                    >
+                      <strong
+                        key="strong-0"
+                      >
+                        Week 3
+                      </strong>
+                      : Sunday, 02/16/2020 – Saturday, 02/22/2020
+                    </Trans>
+                  </div>
+                </div>
+              </Transition>
+            </Fade>
+          </Alert>
+          <Alert
+            className="d-flex"
+            closeLabel="Close alert"
+            key="weekToCertify5"
+            show={true}
+            transition={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "defaultProps": Object {
+                  "appear": false,
+                  "in": false,
+                  "mountOnEnter": false,
+                  "timeout": 300,
+                  "unmountOnExit": false,
+                },
+                "displayName": "Fade",
+                "render": [Function],
+              }
+            }
+            variant="secondary"
+          >
+            <Fade
+              appear={false}
+              in={true}
+              mountOnEnter={false}
+              timeout={300}
+              unmountOnExit={true}
+            >
+              <Transition
+                addEndListener={[Function]}
+                appear={false}
+                enter={true}
+                exit={true}
+                in={true}
+                mountOnEnter={false}
+                onEnter={[Function]}
+                onEntered={[Function]}
+                onEntering={[Function]}
+                onExit={[Function]}
+                onExited={[Function]}
+                onExiting={[Function]}
+                timeout={300}
+                unmountOnExit={true}
+              >
+                <div
+                  className="fade d-flex alert alert-secondary show"
+                  role="alert"
+                >
+                  <div
+                    className="flex-fill"
+                  >
+                    <Trans
+                      i18nKey="retrocerts-week-list-item"
+                      t={[Function]}
+                      values={
+                        Object {
+                          "endDate": "03/14/2020",
+                          "startDate": "03/08/2020",
+                          "weekForUser": 4,
+                        }
+                      }
+                    >
+                      <strong
+                        key="strong-0"
+                      >
+                        Week 4
+                      </strong>
+                      : Sunday, 03/08/2020 – Saturday, 03/14/2020
+                    </Trans>
+                  </div>
+                </div>
+              </Transition>
+            </Fade>
+          </Alert>
+          <Alert
+            className="d-flex"
+            closeLabel="Close alert"
+            key="weekToCertify6"
+            show={true}
+            transition={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "defaultProps": Object {
+                  "appear": false,
+                  "in": false,
+                  "mountOnEnter": false,
+                  "timeout": 300,
+                  "unmountOnExit": false,
+                },
+                "displayName": "Fade",
+                "render": [Function],
+              }
+            }
+            variant="secondary"
+          >
+            <Fade
+              appear={false}
+              in={true}
+              mountOnEnter={false}
+              timeout={300}
+              unmountOnExit={true}
+            >
+              <Transition
+                addEndListener={[Function]}
+                appear={false}
+                enter={true}
+                exit={true}
+                in={true}
+                mountOnEnter={false}
+                onEnter={[Function]}
+                onEntered={[Function]}
+                onEntering={[Function]}
+                onExit={[Function]}
+                onExited={[Function]}
+                onExiting={[Function]}
+                timeout={300}
+                unmountOnExit={true}
+              >
+                <div
+                  className="fade d-flex alert alert-secondary show"
+                  role="alert"
+                >
+                  <div
+                    className="flex-fill"
+                  >
+                    <Trans
+                      i18nKey="retrocerts-week-list-item"
+                      t={[Function]}
+                      values={
+                        Object {
+                          "endDate": "03/21/2020",
+                          "startDate": "03/15/2020",
+                          "weekForUser": 5,
+                        }
+                      }
+                    >
+                      <strong
+                        key="strong-0"
+                      >
+                        Week 5
+                      </strong>
+                      : Sunday, 03/15/2020 – Saturday, 03/21/2020
+                    </Trans>
+                  </div>
+                </div>
+              </Transition>
+            </Fade>
+          </Alert>
+        </ListOfWeeks>
+        <h2
+          className="h3 font-weight-bold mt-5 mb-3"
+        >
+          Retroactive Certification Application Details
+        </h2>
+        <p>
+          The claimant is shown the following on the Retroactive Certification Application.
+        </p>
+        <ClaimantContent>
+          <div
+            className="subtle-blockquote mb-5"
+          >
+            <p>
+              Your answers for each completed certification week will save automatically when you continue to the next week. Partially completed weeks are not saved. Try to complete all retroactive certifications in one session.
+            </p>
+            <p>
+              To protect the security of your information, this application will automatically time out after 30 minutes of inactivity. To avoid timing out, select any button every 25 minutes.
+            </p>
+          </div>
+        </ClaimantContent>
+      </div>
+    </main>
+    <Footer
+      backToTopTag="certification-page"
+    >
+      <footer
+        className="footer"
       >
-        Search New Claimant
-      </Button>
-      <h2
-        className="h3 font-weight-bold mt-5 mb-3"
-      >
-        Certification Status
-      </h2>
-      <CertificationStatus />
-      <Button
-        active={false}
-        className="text-dark bg-light"
-        disabled={false}
-        onClick={[Function]}
-        type="button"
-        variant="outline-secondary"
-      >
-        Print
-      </Button>
-      <h2
-        className="h3 font-weight-bold mt-5 mb-3"
-      >
-        Certification Weeks
-      </h2>
-      <ListOfWeeks
-        weeksToCertify={
-          Array [
-            0,
-            1,
-            2,
-            5,
-            6,
-          ]
-        }
-      />
-      <h2
-        className="h3 font-weight-bold mt-5 mb-3"
-      >
-        Retroactive Certification Application Details
-      </h2>
-      <p>
-        The claimant is shown the following on the Retroactive Certification Application.
-      </p>
-      <ClaimantContent />
-    </div>
-  </main>
-  <Footer
-    backToTopTag="certification-page"
-  />
-</div>
+        <Navbar
+          bg="dark"
+          className="justify-content-between"
+          collapseOnSelect={false}
+          expand={true}
+          variant="custom"
+        >
+          <nav
+            className="justify-content-between navbar navbar-expand navbar-custom bg-dark"
+          >
+            <Nav
+              className="flex-wrap"
+              fill={false}
+              justify={false}
+            >
+              <ForwardRef
+                as="div"
+                className="flex-wrap navbar-nav"
+                onSelect={[Function]}
+              >
+                <div
+                  className="flex-wrap navbar-nav"
+                  onKeyDown={[Function]}
+                >
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="/#certification-page"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="/#certification-page"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="/#certification-page"
+                        disabled={false}
+                        href="/#certification-page"
+                        onClick={[Function]}
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="/#certification-page"
+                          href="/#certification-page"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                        >
+                          Back to Top
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/"
+                          href="https://edd.ca.gov/about_edd/"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          About EDD
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/contact_edd.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/contact_edd.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/contact_edd.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/contact_edd.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/contact_edd.htm"
+                          href="https://edd.ca.gov/about_edd/contact_edd.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Contact EDD
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                          href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Conditions of Use
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                          href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Privacy Policy
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/accessibility.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/accessibility.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/accessibility.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/accessibility.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/accessibility.htm"
+                          href="https://edd.ca.gov/about_edd/accessibility.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Accessibility
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/sitemap.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/sitemap.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/sitemap.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/sitemap.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/sitemap.htm"
+                          href="https://edd.ca.gov/sitemap.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Site Map
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                </div>
+              </ForwardRef>
+            </Nav>
+            <Nav
+              className="flex-wrap"
+              fill={false}
+              justify={false}
+            >
+              <ForwardRef
+                as="div"
+                className="flex-wrap navbar-nav"
+                onSelect={[Function]}
+              >
+                <div
+                  className="flex-wrap navbar-nav"
+                  onKeyDown={[Function]}
+                >
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://www.facebook.com/californiaedd/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://www.facebook.com/californiaedd/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://www.facebook.com/californiaedd/"
+                        disabled={false}
+                        href="https://www.facebook.com/californiaedd/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://www.facebook.com/californiaedd/"
+                          href="https://www.facebook.com/californiaedd/"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="Facebook icon"
+                            height="15"
+                            src="images/facebook.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://twitter.com/CA_EDD"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://twitter.com/CA_EDD"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://twitter.com/CA_EDD"
+                        disabled={false}
+                        href="https://twitter.com/CA_EDD"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://twitter.com/CA_EDD"
+                          href="https://twitter.com/CA_EDD"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="Twitter icon"
+                            height="15"
+                            src="images/twitter.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://www.linkedin.com/company/californiaedd/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://www.linkedin.com/company/californiaedd/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://www.linkedin.com/company/californiaedd/"
+                        disabled={false}
+                        href="https://www.linkedin.com/company/californiaedd/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://www.linkedin.com/company/californiaedd/"
+                          href="https://www.linkedin.com/company/californiaedd/"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="LinkedIn icon"
+                            height="15"
+                            src="images/linkedin.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://www.instagram.com/ca_edd/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://www.instagram.com/ca_edd/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://www.instagram.com/ca_edd/"
+                        disabled={false}
+                        href="https://www.instagram.com/ca_edd/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://www.instagram.com/ca_edd/"
+                          href="https://www.instagram.com/ca_edd/"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="Instagram icon"
+                            height="15"
+                            src="images/instagram.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://www.youtube.com/user/CaliforniaEDD"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://www.youtube.com/user/CaliforniaEDD"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://www.youtube.com/user/CaliforniaEDD"
+                        disabled={false}
+                        href="https://www.youtube.com/user/CaliforniaEDD"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://www.youtube.com/user/CaliforniaEDD"
+                          href="https://www.youtube.com/user/CaliforniaEDD"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="YouTube icon"
+                            height="15"
+                            src="images/youtube.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                </div>
+              </ForwardRef>
+            </Nav>
+          </nav>
+        </Navbar>
+        <div
+          className="bg-light secondary-footer"
+        >
+          <Container
+            fluid={false}
+          >
+            <div
+              className="container"
+            >
+              Copyright © 2020 State of California
+            </div>
+          </Container>
+        </div>
+      </footer>
+    </Footer>
+  </div>
+</StaffViewConfirmationPage>
 `;

--- a/src/client/pages/StaffViewConfirmationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/StaffViewConfirmationPage/__snapshots__/index.test.js.snap
@@ -633,8 +633,7 @@ exports[`<StaffViewConfirmationPage /> when claimant completed 1`] = `
             Completed
           </span>
           <p>
-            Claimant Last Name: 
-             + userData.lastName
+            Claimant Last Name: Taylor
             <br />
             Confirmation Number: 0364833
           </p>

--- a/src/client/pages/StaffViewConfirmationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/StaffViewConfirmationPage/__snapshots__/index.test.js.snap
@@ -65,22 +65,15 @@ exports[`<StaffViewConfirmationPage /> when claimant completed 1`] = `
       >
         Certification Weeks
       </h2>
-      <ListOfCertifications
-        userData={
-          Object {
-            "confirmationNumber": "33a6f278-eaa3-41c5-8d08-276fa0364833",
-            "programPlan": Array [
-              "UI full time",
-            ],
-            "status": "ok",
-            "weeksToCertify": Array [
-              0,
-              1,
-              2,
-              5,
-              6,
-            ],
-          }
+      <ListOfWeeks
+        weeksToCertify={
+          Array [
+            0,
+            1,
+            2,
+            5,
+            6,
+          ]
         }
       />
       <h2
@@ -165,22 +158,15 @@ exports[`<StaffViewConfirmationPage /> when claimant in progress 1`] = `
       >
         Certification Weeks
       </h2>
-      <ListOfCertifications
-        userData={
-          Object {
-            "hasLoggedIn": true,
-            "programPlan": Array [
-              "UI full time",
-            ],
-            "status": "ok",
-            "weeksToCertify": Array [
-              0,
-              1,
-              2,
-              5,
-              6,
-            ],
-          }
+      <ListOfWeeks
+        weeksToCertify={
+          Array [
+            0,
+            1,
+            2,
+            5,
+            6,
+          ]
         }
       />
       <h2
@@ -265,23 +251,15 @@ exports[`<StaffViewConfirmationPage /> when claimant not started 1`] = `
       >
         Certification Weeks
       </h2>
-      <ListOfCertifications
-        userData={
-          Object {
-            "confirmationNumber": "CONFIRMATION_NUMBER",
-            "hasLoggedIn": false,
-            "programPlan": Array [
-              "PUA full time",
-            ],
-            "status": "ok",
-            "weeksToCertify": Array [
-              0,
-              1,
-              2,
-              5,
-              6,
-            ],
-          }
+      <ListOfWeeks
+        weeksToCertify={
+          Array [
+            0,
+            1,
+            2,
+            5,
+            6,
+          ]
         }
       />
       <h2

--- a/src/client/pages/StaffViewConfirmationPage/index.js
+++ b/src/client/pages/StaffViewConfirmationPage/index.js
@@ -75,8 +75,8 @@ function StaffViewConfirmationPage(props) {
               {t("staff-view-confirmation.completed.status")}
             </span>
             <p>
-              {t("staff-view-confirmation.completed.last-name")} +
-              userData.lastName
+              {t("staff-view-confirmation.completed.last-name") +
+                userData.lastName}
               <br />
               {t("staff-view-confirmation.completed.confirmation-number") +
                 shortConfirmationNumber}

--- a/src/client/pages/StaffViewConfirmationPage/index.js
+++ b/src/client/pages/StaffViewConfirmationPage/index.js
@@ -7,6 +7,7 @@ import { userDataPropType } from "../../commonPropTypes";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header";
 import ListOfCertifications from "../../components/ListOfCertifications";
+import ListOfWeeks from "../../components/ListOfWeeks";
 
 function StaffViewConfirmationPage(props) {
   const { t } = useTranslation();
@@ -31,10 +32,11 @@ function StaffViewConfirmationPage(props) {
     shortConfirmationNumber = confirmationNumber
       .substr(startIndex)
       .toUpperCase();
-  } else if (userData.hasLoggedIn) {
-    // TODO(kalvin): make hasLoggedIn real
+  } else if (userData.formData && userData.formData.authToken) {
+    // user has logged in before
     status = statuses.IN_PROGRESS;
   } else {
+    // user has never logged in
     status = statuses.NOT_STARTED;
   }
 
@@ -72,9 +74,9 @@ function StaffViewConfirmationPage(props) {
             <span className="badge completed">
               {t("staff-view-confirmation.completed.status")}
             </span>
-            {/* TODO(kalvin): make last name real */}
             <p>
-              {t("staff-view-confirmation.completed.last-name")}
+              {t("staff-view-confirmation.completed.last-name")} +
+              userData.lastName
               <br />
               {t("staff-view-confirmation.completed.confirmation-number") +
                 shortConfirmationNumber}
@@ -115,6 +117,8 @@ function StaffViewConfirmationPage(props) {
     );
   }
 
+  const userHasCompletedCertification =
+    userData.formData && userData.formData.confirmationNumber;
   return (
     <div id="overflow-wrapper">
       <Header />
@@ -148,7 +152,11 @@ function StaffViewConfirmationPage(props) {
           <h2 className="h3 font-weight-bold mt-5 mb-3">
             {t("staff-view-confirmation.header3")}
           </h2>
-          <ListOfCertifications userData={userData} />
+          {userHasCompletedCertification ? (
+            <ListOfCertifications userData={userData} />
+          ) : (
+            <ListOfWeeks weeksToCertify={userData.weeksToCertify} />
+          )}
 
           <h2 className="h3 font-weight-bold mt-5 mb-3">
             {t("staff-view-confirmation.header4")}

--- a/src/client/pages/StaffViewConfirmationPage/index.js
+++ b/src/client/pages/StaffViewConfirmationPage/index.js
@@ -32,7 +32,7 @@ function StaffViewConfirmationPage(props) {
     shortConfirmationNumber = confirmationNumber
       .substr(startIndex)
       .toUpperCase();
-  } else if (userData.formData && userData.formData.authToken) {
+  } else if (userData.authToken) {
     // user has logged in before
     status = statuses.IN_PROGRESS;
   } else {
@@ -117,8 +117,6 @@ function StaffViewConfirmationPage(props) {
     );
   }
 
-  const userHasCompletedCertification =
-    userData.formData && userData.formData.confirmationNumber;
   return (
     <div id="overflow-wrapper">
       <Header />
@@ -152,7 +150,7 @@ function StaffViewConfirmationPage(props) {
           <h2 className="h3 font-weight-bold mt-5 mb-3">
             {t("staff-view-confirmation.header3")}
           </h2>
-          {userHasCompletedCertification ? (
+          {userData.confirmationNumber ? (
             <ListOfCertifications userData={userData} />
           ) : (
             <ListOfWeeks weeksToCertify={userData.weeksToCertify} />

--- a/src/client/pages/StaffViewConfirmationPage/index.test.js
+++ b/src/client/pages/StaffViewConfirmationPage/index.test.js
@@ -1,59 +1,59 @@
-import renderNonTransContent from "../../test-helpers/renderNonTransContent";
+import renderTransContent from "../../test-helpers/renderTransContent";
 import Component from "./index";
 import AUTH_STRINGS from "../../../data/authStrings";
 
 describe("<StaffViewConfirmationPage />", () => {
   it("when claimant not started", async () => {
-    const wrapper = renderNonTransContent(
-      Component,
-      "StaffViewConfirmationPage",
-      {
-        userData: {
-          hasLoggedIn: false,
-          status: AUTH_STRINGS.statusCode.ok,
-          weeksToCertify: [0, 1, 2, 5, 6],
-          confirmationNumber: "CONFIRMATION_NUMBER",
-          programPlan: ["PUA full time"],
-        },
-        setUserData: () => {},
-      }
-    );
+    const wrapper = renderTransContent(Component, {
+      userData: {
+        status: AUTH_STRINGS.statusCode.ok,
+        weeksToCertify: [0, 1, 2, 5, 6],
+        programPlan: ["PUA full time"],
+        lastName: "Taylor",
+      },
+      setUserData: () => {},
+    });
 
     expect(wrapper).toMatchSnapshot();
   });
 
   it("when claimant in progress", async () => {
-    const wrapper = renderNonTransContent(
-      Component,
-      "StaffViewConfirmationPage",
-      {
-        userData: {
-          hasLoggedIn: true,
-          status: AUTH_STRINGS.statusCode.ok,
-          weeksToCertify: [0, 1, 2, 5, 6],
-          programPlan: ["UI full time"],
-        },
-        setUserData: () => {},
-      }
-    );
+    const wrapper = renderTransContent(Component, {
+      userData: {
+        authToken: "pretendThisIsARealToken",
+        status: AUTH_STRINGS.statusCode.ok,
+        weeksToCertify: [0, 1, 2, 5, 6],
+        programPlan: ["UI full time"],
+        lastName: "Taylor",
+      },
+      setUserData: () => {},
+    });
 
     expect(wrapper).toMatchSnapshot();
   });
 
   it("when claimant completed", async () => {
-    const wrapper = renderNonTransContent(
-      Component,
-      "StaffViewConfirmationPage",
-      {
-        userData: {
-          confirmationNumber: "33a6f278-eaa3-41c5-8d08-276fa0364833",
-          status: AUTH_STRINGS.statusCode.ok,
-          weeksToCertify: [0, 1, 2, 5, 6],
-          programPlan: ["UI full time"],
-        },
-        setUserData: () => {},
-      }
-    );
+    const weekOfAnswers = {
+      tooSick: false,
+      couldNotAcceptWork: false,
+      didYouLook: false,
+      refuseWork: false,
+      schoolOrTraining: false,
+      workOrEarn: false,
+    };
+
+    const wrapper = renderTransContent(Component, {
+      userData: {
+        authToken: "pretendThisIsARealToken",
+        confirmationNumber: "33a6f278-eaa3-41c5-8d08-276fa0364833",
+        status: AUTH_STRINGS.statusCode.ok,
+        weeksToCertify: [0, 1, 2],
+        programPlan: ["UI full time"],
+        lastName: "Taylor",
+        formData: [weekOfAnswers, weekOfAnswers, weekOfAnswers],
+      },
+      setUserData: () => {},
+    });
 
     expect(wrapper).toMatchSnapshot();
   });


### PR DESCRIPTION
This PR connects the Staff View auth page to the new POST request, and updates the Staff View confirmation page to use actual data. Staff View works!

===

Resolves #XXX

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
