### PR TITLE
Allows IP ranges

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -103,7 +103,7 @@ function init() {
 
     if (process.env.ALLOWED_IP_RANGES) {
       process.env.ALLOWED_IP_RANGES.split(" ").forEach((ipRange) => {
-        allowedIps.push([ipRange.split("-")[0], ipRange.split("-")[1]]);
+        allowedIps.push(ipRange.split("-"));
       });
     }
 

--- a/src/app.js
+++ b/src/app.js
@@ -93,14 +93,23 @@ function init() {
   };
 
   if (process.env.NODE_ENV !== "development") {
+    const allowedIps = [];
+
+    if (process.env.INDIVIDUAL_ALLOWED_IPS) {
+      process.env.INDIVIDUAL_ALLOWED_IPS.split(" ").forEach((ip) =>
+        allowedIps.push(ip)
+      );
+    }
+
+    if (process.env.ALLOWED_IP_RANGES) {
+      process.env.ALLOWED_IP_RANGES.split(" ").forEach((ipRange) => {
+        allowedIps.push([ipRange.split("-")[0], ipRange.split("-")[1]]);
+      });
+    }
+
     app.use(
       AUTH_STRINGS.staffView.login,
-      ipfilter(
-        process.env.STAFF_VIEW_ALLOWED_IPS
-          ? process.env.STAFF_VIEW_ALLOWED_IPS.split(" ")
-          : [],
-        { mode: "allow", detectIp: clientIp }
-      )
+      ipfilter(allowedIps, { mode: "allow", detectIp: clientIp })
     );
   }
 


### PR DESCRIPTION
EDD gave us IP ranges to allow, not individual IP addressses. 

Given environment variables in this format:
INDIVIDUAL_ALLOWED_IPS=x.x.x.x x.x.x.x x.x.x.x
ALLOWED_IP_RANGES=x.x.0.0-x.x.255.255 x.x.0.0-x.x.255.255 x.x.0.0-x.x.255.255

This PR updates the allowedIps to look like 
[ 'x.x.x.x',
  'x.x.x.x',
  'x.x.x.x',
  [ 'x.x.0.0', 'x.x.255.255' ],
  [ 'x.x.0.0', 'x.x.255.255' ],
  [ 'x.x.0.0', 'x.x.255.255' ] 
]

===

Resolves #XXX

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
