### PR TITLE
Block non-EDD IPs from staff view

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@
  */
 const express = require("express");
 const ipfilter = require("express-ipfilter").IpFilter;
+const IpDeniedError = require("express-ipfilter").IpDeniedError;
 const helmet = require("helmet");
 const createRouter = require("./routes");
 const AUTH_STRINGS = require("./data/authStrings");
@@ -108,13 +109,23 @@ function init() {
     }
 
     app.use(
-      AUTH_STRINGS.staffView.login,
+      AUTH_STRINGS.staffView.root,
       ipfilter(allowedIps, { mode: "allow", detectIp: clientIp })
     );
   }
 
   // Setup our routes
   app.use("/", createRouter());
+
+  // If a non-EDD IP address tries to access staff view, log and redirect to home
+  app.use((err, req, res, next) => {
+    console.error("Express error handler", err);
+    if (err instanceof IpDeniedError) {
+      console.error("Access to staff view from non-EDD IP address denied");
+      res.redirect("/");
+    }
+    next(err);
+  });
 
   return app;
 }

--- a/src/app.js
+++ b/src/app.js
@@ -106,6 +106,12 @@ function init() {
       process.env.ALLOWED_IP_RANGES.split(" ").forEach((ipRange) => {
         allowedIps.push(ipRange.split("-"));
       });
+    } else {
+      // This needs to be set on all non-development environments for Staff View
+      console.error(
+        "process.env.ALLOWED_IP_RANGES has not been set on " +
+          process.env.NODE_ENV
+      );
     }
 
     app.use(

--- a/src/data/authStrings.js
+++ b/src/data/authStrings.js
@@ -12,6 +12,7 @@ const AUTH_STRINGS = {
     save: retroCertsBasePath + "/api/save",
   },
   staffView: {
+    root: retroCertsBasePath + "/staff-view",
     login: retroCertsBasePath + "/staff-view/api/login",
   },
   statusCode: {


### PR DESCRIPTION
This PR updates the paths blocked to all paths containing /staff-view, and redirects attempted access from non-approved IPs, to the homepage instead (the Guide).

It does this on all non-development environments (test/staging/prod). 

A follow-up PR should:
- [ ] add unit tests 
- [ ] make isProdEnvironment a util function (from other PR)

===

Along with #537, resolves #515