### PR TITLE
Content edits to Staff View

### DIFF
--- a/src/client/pages/StaffViewAuthPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/StaffViewAuthPage/__snapshots__/index.test.js.snap
@@ -438,7 +438,7 @@ exports[`<StaffViewAuthPage /> retro certs auth page with user not found error 1
               }
               variant="danger"
             >
-              This claimant is not found in the database and does not need to retroactively certify.
+              This claimant does not need to retroactively certify.
             </Alert>
           </div>
         </Row>

--- a/src/client/pages/StaffViewConfirmationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/StaffViewConfirmationPage/__snapshots__/index.test.js.snap
@@ -633,34 +633,35 @@ exports[`<StaffViewConfirmationPage /> when claimant completed 1`] = `
             Completed
           </span>
           <p>
-            Claimant Last Name: Taylor
+            <ClaimantLastName>
+              <span>
+                Claimant Last Name: 
+                 
+                <strong>
+                  Taylor
+                </strong>
+              </span>
+            </ClaimantLastName>
             <br />
-            Confirmation Number: 0364833
+            Claimant has completed and submitted their retroactive certification.
+            <br />
+            Confirmation Number: 
+             
+            <strong>
+              0364833
+            </strong>
           </p>
           <p>
             <Trans
-              i18nKey="staff-view-confirmation.completed.p1"
+              i18nKey="staff-view-confirmation.completed.p2"
               t={[Function]}
-              values={
-                Object {
-                  "confirmationNumber": "33a6f278-eaa3-41c5-8d08-276fa0364833",
-                  "shortConfirmationNumber": "0364833",
-                }
-              }
             >
-              Note: The claimant may have seen or saved a much longer confirmation number in the past. If so, it was 
               <strong
-                key="strong-1"
+                key="strong-0"
               >
-                33a6f278-eaa3-41c5-8d08-276fa0364833
+                Note:
               </strong>
-              . If they log in now, they will see 
-              <strong
-                key="strong-3"
-              >
-                0364833
-              </strong>
-               instead, which is the last 7 characters of the original number.
+               Beginning 07/17/20, the 32 character confirmation number was truncated to only display the last 7 characters.
             </Trans>
           </p>
         </CertificationStatus>
@@ -1926,36 +1927,6 @@ exports[`<StaffViewConfirmationPage /> when claimant completed 1`] = `
             </div>
           </AccordionItem>
         </ListOfCertifications>
-        <h2
-          className="h3 font-weight-bold mt-5 mb-3"
-        >
-          Retroactive Certification Application Details
-        </h2>
-        <p>
-          The claimant is shown the following on the Retroactive Certification Application.
-        </p>
-        <ClaimantContent>
-          <div
-            className="subtle-blockquote mb-5"
-          >
-            <p>
-              You’ve been logged out of the system and may close this window.
-            </p>
-            <Trans
-              i18nKey="retrocerts-confirmation.p2"
-              t={[Function]}
-            >
-              If you are still unemployed, continue to certify for benefits every two weeks. The fastest way is to use 
-              <a
-                href="https://edd.ca.gov/Unemployment/UI_Online.htm"
-                key="1"
-              >
-                UI Online
-              </a>
-              .
-            </Trans>
-          </div>
-        </ClaimantContent>
       </div>
     </main>
     <Footer
@@ -3259,7 +3230,17 @@ exports[`<StaffViewConfirmationPage /> when claimant in progress 1`] = `
             In progress
           </span>
           <p>
-            Claimant Xaybz has logged in and begun retroactive certification.
+            <ClaimantLastName>
+              <span>
+                Claimant Last Name: 
+                 
+                <strong>
+                  Taylor
+                </strong>
+              </span>
+            </ClaimantLastName>
+            <br />
+            Claimant has logged in and begun their retroactive certification.
           </p>
         </CertificationStatus>
         <Button
@@ -3666,26 +3647,6 @@ exports[`<StaffViewConfirmationPage /> when claimant in progress 1`] = `
             </Fade>
           </Alert>
         </ListOfWeeks>
-        <h2
-          className="h3 font-weight-bold mt-5 mb-3"
-        >
-          Retroactive Certification Application Details
-        </h2>
-        <p>
-          The claimant is shown the following on the Retroactive Certification Application.
-        </p>
-        <ClaimantContent>
-          <div
-            className="subtle-blockquote mb-5"
-          >
-            <p>
-              Your answers for each completed certification week will save automatically when you continue to the next week. Partially completed weeks are not saved. Try to complete all retroactive certifications in one session.
-            </p>
-            <p>
-              To protect the security of your information, this application will automatically time out after 30 minutes of inactivity. To avoid timing out, select any button every 25 minutes.
-            </p>
-          </div>
-        </ClaimantContent>
       </div>
     </main>
     <Footer
@@ -4988,7 +4949,17 @@ exports[`<StaffViewConfirmationPage /> when claimant not started 1`] = `
             Not started
           </span>
           <p>
-            Claimant Xaybz has never logged in and has not begun retroactive certification.
+            <ClaimantLastName>
+              <span>
+                Claimant Last Name: 
+                 
+                <strong>
+                  Taylor
+                </strong>
+              </span>
+            </ClaimantLastName>
+            <br />
+            Claimant has not logged in and has not begun completing retroactive certification.
           </p>
         </CertificationStatus>
         <Button
@@ -5395,26 +5366,6 @@ exports[`<StaffViewConfirmationPage /> when claimant not started 1`] = `
             </Fade>
           </Alert>
         </ListOfWeeks>
-        <h2
-          className="h3 font-weight-bold mt-5 mb-3"
-        >
-          Retroactive Certification Application Details
-        </h2>
-        <p>
-          The claimant is shown the following on the Retroactive Certification Application.
-        </p>
-        <ClaimantContent>
-          <div
-            className="subtle-blockquote mb-5"
-          >
-            <p>
-              Your answers for each completed certification week will save automatically when you continue to the next week. Partially completed weeks are not saved. Try to complete all retroactive certifications in one session.
-            </p>
-            <p>
-              To protect the security of your information, this application will automatically time out after 30 minutes of inactivity. To avoid timing out, select any button every 25 minutes.
-            </p>
-          </div>
-        </ClaimantContent>
       </div>
     </main>
     <Footer

--- a/src/client/pages/StaffViewConfirmationPage/index.js
+++ b/src/client/pages/StaffViewConfirmationPage/index.js
@@ -47,6 +47,14 @@ function StaffViewConfirmationPage(props) {
   }
 
   function CertificationStatus() {
+    function ClaimantLastName() {
+      return (
+        <span>
+          {t("staff-view-confirmation.last-name")}{" "}
+          <strong>{userData.lastName}</strong>
+        </span>
+      );
+    }
     switch (status) {
       case statuses.NOT_STARTED:
         return (
@@ -54,8 +62,11 @@ function StaffViewConfirmationPage(props) {
             <span className="badge not-started">
               {t("staff-view-confirmation.not-started.status")}
             </span>
-            {/* TODO(kalvin): update with EDD content when received */}
-            <p>{t("staff-view-confirmation.not-started.p1")}</p>
+            <p>
+              <ClaimantLastName />
+              <br />
+              {t("staff-view-confirmation.not-started.p1")}
+            </p>
           </React.Fragment>
         );
       case statuses.IN_PROGRESS:
@@ -64,8 +75,11 @@ function StaffViewConfirmationPage(props) {
             <span className="badge in-progress">
               {t("staff-view-confirmation.in-progress.status")}
             </span>
-            {/* TODO(kalvin): update with EDD content when received */}
-            <p>{t("staff-view-confirmation.in-progress.p1")}</p>
+            <p>
+              <ClaimantLastName />
+              <br />
+              {t("staff-view-confirmation.in-progress.p1")}
+            </p>
           </React.Fragment>
         );
       case statuses.COMPLETED:
@@ -75,46 +89,23 @@ function StaffViewConfirmationPage(props) {
               {t("staff-view-confirmation.completed.status")}
             </span>
             <p>
-              {t("staff-view-confirmation.completed.last-name") +
-                userData.lastName}
+              <ClaimantLastName />
               <br />
-              {t("staff-view-confirmation.completed.confirmation-number") +
-                shortConfirmationNumber}
+              {t("staff-view-confirmation.completed.p1")}
+              <br />
+              {t("staff-view-confirmation.completed.confirmation-number")}{" "}
+              <strong>{shortConfirmationNumber}</strong>
             </p>
             <p>
-              <Trans
-                t={t}
-                i18nKey="staff-view-confirmation.completed.p1"
-                values={{ confirmationNumber, shortConfirmationNumber }}
-              >
-                Note: The claimant may have seen or saved a much longer
-                confirmation number in the past. If so, it was{" "}
-                <strong>adfdsaf</strong>. If they log in now, they will see
-                <strong>adfdsafdfds</strong> instead, which is the last 7
-                characters of the original number.
+              <Trans t={t} i18nKey="staff-view-confirmation.completed.p2">
+                <strong>Note:</strong> Beginning 07/17/20, the 32 character
+                confirmation number was truncated to only display the last 7
+                characters.
               </Trans>
             </p>
           </React.Fragment>
         );
     }
-  }
-
-  function ClaimantContent() {
-    return status === statuses.COMPLETED ? (
-      <div className="subtle-blockquote mb-5">
-        <p>{t("retrocerts-confirmation.p1b")}</p>
-        <Trans t={t} i18nKey="retrocerts-confirmation.p2">
-          If you are still unemployed, continue to certify for benefits every
-          two weeks. The fastest way is to use{" "}
-          <a href={t("links.edd-login")}>UI Online</a>.
-        </Trans>
-      </div>
-    ) : (
-      <div className="subtle-blockquote mb-5">
-        <p>{t("retrocerts-weeks.p3")}</p>
-        <p>{t("retrocerts-weeks.p4")}</p>
-      </div>
-    );
   }
 
   return (
@@ -155,12 +146,6 @@ function StaffViewConfirmationPage(props) {
           ) : (
             <ListOfWeeks weeksToCertify={userData.weeksToCertify} />
           )}
-
-          <h2 className="h3 font-weight-bold mt-5 mb-3">
-            {t("staff-view-confirmation.header4")}
-          </h2>
-          <p>{t("staff-view-confirmation.p2")}</p>
-          <ClaimantContent />
         </div>
       </main>
       <Footer backToTopTag="certification-page" />

--- a/src/data/locales/en/translation.json
+++ b/src/data/locales/en/translation.json
@@ -212,7 +212,7 @@
   "staff-view-login": {
     "header1": "Staff View",
     "instructions": "Enter claimant information below.",
-    "invalid-user-error": "This claimant is not found in the database and does not need to retroactively certify.",
+    "invalid-user-error": "This claimant does not need to retroactively certify.",
     "submit": "Search"
   },
   "retrocerts-week-list-item": "<strong>Week {{weekForUser}}</strong>: Sunday, {{startDate}} – Saturday, {{endDate}}",
@@ -375,27 +375,26 @@
     "header1": "Staff View",
     "button-search": "Search New Claimant",
     "header2": "Certification Status",
+    "last-name": "Claimant Last Name: ",
     "not-started": {
       "status": "Not started",
-      "p1": "Claimant Xaybz has never logged in and has not begun retroactive certification."
+      "p1": "Claimant has not logged in and has not begun completing retroactive certification."
     },
     "in-progress": {
       "status": "In progress",
-      "p1": "Claimant Xaybz has logged in and begun retroactive certification."
+      "p1": "Claimant has logged in and begun their retroactive certification."
     },
     "completed": {
       "status": "Completed",
-      "last-name": "Claimant Last Name: ",
+      "p1": "Claimant has completed and submitted their retroactive certification.",
       "confirmation-number": "Confirmation Number: ",
-      "p1": "Note: The claimant may have seen or saved a much longer confirmation number in the past. If so, it was <strong>{{confirmationNumber}}</strong>. If they log in now, they will see <strong>{{shortConfirmationNumber}}</strong> instead, which is the last 7 characters of the original number."
+      "p2": "<strong>Note:</strong> Beginning 07/17/20, the 32 character confirmation number was truncated to only display the last 7 characters."
     },
     "button-print": "Print",
     "header3": "Certification Weeks",
     "button-show-all": "Show all",
     "button-hide-all": "Hide all",
-    "aria-show-details": "Show details for this week",
-    "header4": "Retroactive Certification Application Details",
-    "p2": "The claimant is shown the following on the Retroactive Certification Application."
+    "aria-show-details": "Show details for this week"
   },
   "generic-validation-error-message": "There are one or more errors on this page. Review and correct them to continue. Complete all fields and try again.",
   "timeout-modal": {

--- a/src/data/locales/es/translation.json
+++ b/src/data/locales/es/translation.json
@@ -374,27 +374,26 @@
     "header1": "Staff View",
     "button-search": "Search New Claimant",
     "header2": "Certification Status",
+    "last-name": "Claimant Last Name: ",
     "not-started": {
       "status": "Not started",
-      "p1": "Claimant Xaybz has never logged in and has not begun retroactive certification."
+      "p1": "Claimant has not logged in and has not begun completing retroactive certification."
     },
     "in-progress": {
       "status": "In progress",
-      "p1": "Claimant Xaybz has logged in and begun retroactive certification."
+      "p1": "Claimant has logged in and begun their retroactive certification."
     },
     "completed": {
       "status": "Completed",
-      "last-name": "Claimant Last Name: ",
+      "p1": "Claimant has completed and submitted their retroactive certification.",
       "confirmation-number": "Confirmation Number: ",
-      "p1": "Note: The claimant may have seen or saved a much longer confirmation number in the past. If so, it was <strong>{{confirmationNumber}}</strong>. If they log in now, they will see <strong>{{shortConfirmationNumber}}</strong> instead, which is the last 7 characters of the original number."
+      "p2": "<strong>Note:</strong> Beginning 07/17/20, the 32 character confirmation number was truncated to only display the last 7 characters."
     },
     "button-print": "Print",
     "header3": "Certification Weeks",
     "button-show-all": "Show all",
     "button-hide-all": "Hide all",
-    "aria-show-details": "Show details for this week",
-    "header4": "Retroactive Certification Application Details",
-    "p2": "The claimant is shown the following on the Retroactive Certification Application."
+    "aria-show-details": "Show details for this week"
   },
   "generic-validation-error-message": "Hay más de un error en esta página. Revise y corrija los errores para continuar. Complete todo los campos e intente de nuevo.",
   "timeout-modal": {


### PR DESCRIPTION
This PR makes the content edits to Staff View that we received from UIB 

<h1>Not started</h1>

![image](https://user-images.githubusercontent.com/82277/89804401-21b2b980-db02-11ea-9ea4-7221b0a57f5b.png)

<h1>In Progress</h1>

![image](https://user-images.githubusercontent.com/82277/89804404-22e3e680-db02-11ea-95db-73ccef63a773.png)

<h1>Completed</h1>

![image](https://user-images.githubusercontent.com/82277/89804416-24adaa00-db02-11ea-9535-c88ef680b581.png)


===

- [x] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
