### PR TITLE
Make it easier to reference the dev/prod environment from the client

### DIFF
--- a/src/client/i18n.js
+++ b/src/client/i18n.js
@@ -2,8 +2,7 @@ import HttpApi from "i18next-http-backend/cjs";
 import LanguageDetector from "i18next-browser-languagedetector";
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
-
-const isDev = process.env.NODE_ENV === "development";
+import { isDevEnv } from "./utils";
 
 i18n
   // load translation using http -> see /public/locales (i.e. https://github.com/i18next/react-i18next/tree/master/example/react/public/locales)
@@ -18,7 +17,7 @@ i18n
   // for all options read: https://www.i18next.com/overview/configuration-options
   .init({
     fallbackLng: "en",
-    debug: isDev,
+    debug: isDevEnv,
     interpolation: {
       escapeValue: false, // not needed for react as it escapes by default
     },
@@ -28,7 +27,7 @@ i18n
     },
   });
 
-if (isDev) {
+if (isDevEnv) {
   const { applyClientHMR } = require("i18next-hmr");
   applyClientHMR(i18n);
 }

--- a/src/client/test-helpers/i18nForTests.js
+++ b/src/client/test-helpers/i18nForTests.js
@@ -6,6 +6,7 @@
 import englishLocale from "../../data/locales/en/translation.json";
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
+import { isDevEnv } from "../utils";
 
 const defaultLanguage = "en"; // English
 const resources = {
@@ -15,7 +16,7 @@ const resources = {
 i18n
   .use(initReactI18next) // passes the i18n instance to react-i18next which will make it available for all the components via the context api.
   .init({
-    debug: process.env.NODE_ENV === "development",
+    debug: isDevEnv,
     fallbackLng: defaultLanguage,
     interpolation: {
       escapeValue: false, // react already escapes values

--- a/src/client/utils.js
+++ b/src/client/utils.js
@@ -39,3 +39,14 @@ export function logError(errorMessage) {
   const appInsights = getAppInsights();
   appInsights.trackException({ exception: new Error(errorMessage) });
 }
+
+// Our app is only built once on the staging environment, so
+// process.env.NODE_ENV never equals "production". Therefore, we
+// check for the window URL as a workaround.
+export function isProdEnv() {
+  return window.location.hostname !== "unemployment.edd.ca.gov";
+}
+
+export function isDevEnv() {
+  return process.env.NODE_ENV === "development";
+}

--- a/src/services/azureApplicationInsights.js
+++ b/src/services/azureApplicationInsights.js
@@ -1,6 +1,7 @@
 // From: https://github.com/Azure-Samples/application-insights-react-demo/blob/master/src/TelemetryService.js
 import { ApplicationInsights } from "@microsoft/applicationinsights-web";
 import { ReactPlugin } from "@microsoft/applicationinsights-react-js";
+import { isProdEnv } from "../client/utils";
 
 let reactPlugin = null;
 let appInsights = null;
@@ -43,10 +44,7 @@ const createTelemetryService = () => {
     });
 
     appInsights.loadAppInsights();
-    if (
-      process.env.NODE_ENV === "development" ||
-      window.location.hostname !== "unemployment.edd.ca.gov"
-    ) {
+    if (!isProdEnv) {
       // Normally metrics are sent as batches. In development mode, send immediately.
       // https://docs.microsoft.com/en-us/azure/azure-monitor/app/api-custom-events-metrics#debug
       appInsights.config.maxBatchSizeInBytes = 0;


### PR DESCRIPTION
This PR extracts all client references to process.env.NODE_ENV, a variable from Node injected by webpack into the client. Tony [suggested this improvement](https://github.com/cagov/unemployment/pull/537#discussion_r467140965) to reduce the likelihood of errors when referencing the environment.

There are several references to NODE_ENV in Node files as well, but since that would require creating a separate CJS compatible module, and we never reference production anyway, I'll just wait until we update to Node 14 to change those...
