### PR TITLE
Update Certification Status badge on Staff View confirmation

### DIFF
--- a/src/app.test.js
+++ b/src/app.test.js
@@ -22,7 +22,7 @@ describe("Router: Single page app", () => {
     }
   });
 
-  it("404 for pages that don't exist", async () => {
+  it("404s for pages that don't exist", async () => {
     const testPaths = ["/does-not-exist", "/guide/"];
 
     for (const testPath of testPaths) {
@@ -44,8 +44,10 @@ describe("Router: Single page app", () => {
 
     const env = Object.assign({}, process.env);
     env.ENABLE_RETRO_CERTS = "1";
-    env.ALLOWED_IP_RANGES = "192.168.2.1-192.168.2.100"; // these are EDD IPs in production
-    env.INDIVIDUAL_ALLOWED_IPS = "10.83.44.22 10.83.44.21"; // these are Nava team IPs in production
+    // in staging/production, these are EDD IPs
+    env.ALLOWED_IP_RANGES = "192.168.2.1-192.168.2.100";
+    // in staging/production, these are Nava team IPs
+    env.INDIVIDUAL_ALLOWED_IPS = "10.83.44.22 10.83.44.21";
     const server = init(env);
 
     it("redirects to retrocert login when staff view is accessed via public IP", async () => {

--- a/src/client/pages/StaffViewConfirmationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/StaffViewConfirmationPage/__snapshots__/index.test.js.snap
@@ -621,36 +621,37 @@ exports[`<StaffViewConfirmationPage /> when claimant completed 1`] = `
             </LinkAnchor>
           </Link>
         </Button>
-        <h2
-          className="h3 font-weight-bold mt-5 mb-3"
-        >
-          Certification Status
-        </h2>
         <CertificationStatus>
-          <span
-            className="badge completed"
-          >
-            Completed
-          </span>
-          <p>
-            <ClaimantLastName>
-              <span>
-                Claimant Last Name: 
-                 
-                <strong>
-                  Taylor
-                </strong>
+          <HeaderWithBadge>
+            <h2
+              className="h3 font-weight-bold mt-5 mb-3"
+            >
+              Certification Status: 
+               
+              <span
+                className="badge completed"
+              >
+                Completed
               </span>
-            </ClaimantLastName>
-            <br />
-            Claimant has completed and submitted their retroactive certification.
-            <br />
-            Confirmation Number: 
-             
-            <strong>
-              0364833
-            </strong>
-          </p>
+            </h2>
+          </HeaderWithBadge>
+          <ClaimantInfo>
+            <p>
+              Claimant Last Name: 
+               
+              <strong>
+                Taylor
+              </strong>
+              <br />
+              Claimant has completed and submitted their retroactive certification.
+              <br />
+              Confirmation Number: 
+               
+              <strong>
+                0364833
+              </strong>
+            </p>
+          </ClaimantInfo>
           <p>
             <Trans
               i18nKey="staff-view-confirmation.completed.p2"
@@ -3218,30 +3219,31 @@ exports[`<StaffViewConfirmationPage /> when claimant in progress 1`] = `
             </LinkAnchor>
           </Link>
         </Button>
-        <h2
-          className="h3 font-weight-bold mt-5 mb-3"
-        >
-          Certification Status
-        </h2>
         <CertificationStatus>
-          <span
-            className="badge in-progress"
-          >
-            In progress
-          </span>
-          <p>
-            <ClaimantLastName>
-              <span>
-                Claimant Last Name: 
-                 
-                <strong>
-                  Taylor
-                </strong>
+          <HeaderWithBadge>
+            <h2
+              className="h3 font-weight-bold mt-5 mb-3"
+            >
+              Certification Status: 
+               
+              <span
+                className="badge in-progress"
+              >
+                In progress
               </span>
-            </ClaimantLastName>
-            <br />
-            Claimant has logged in and begun their retroactive certification.
-          </p>
+            </h2>
+          </HeaderWithBadge>
+          <ClaimantInfo>
+            <p>
+              Claimant Last Name: 
+               
+              <strong>
+                Taylor
+              </strong>
+              <br />
+              Claimant has logged in and begun their retroactive certification.
+            </p>
+          </ClaimantInfo>
         </CertificationStatus>
         <Button
           active={false}
@@ -4937,30 +4939,31 @@ exports[`<StaffViewConfirmationPage /> when claimant not started 1`] = `
             </LinkAnchor>
           </Link>
         </Button>
-        <h2
-          className="h3 font-weight-bold mt-5 mb-3"
-        >
-          Certification Status
-        </h2>
         <CertificationStatus>
-          <span
-            className="badge not-started"
-          >
-            Not started
-          </span>
-          <p>
-            <ClaimantLastName>
-              <span>
-                Claimant Last Name: 
-                 
-                <strong>
-                  Taylor
-                </strong>
+          <HeaderWithBadge>
+            <h2
+              className="h3 font-weight-bold mt-5 mb-3"
+            >
+              Certification Status: 
+               
+              <span
+                className="badge not-started"
+              >
+                Not started
               </span>
-            </ClaimantLastName>
-            <br />
-            Claimant has not logged in and has not begun completing their retroactive certification.
-          </p>
+            </h2>
+          </HeaderWithBadge>
+          <ClaimantInfo>
+            <p>
+              Claimant Last Name: 
+               
+              <strong>
+                Taylor
+              </strong>
+              <br />
+              Claimant has not logged in and has not begun completing their retroactive certification.
+            </p>
+          </ClaimantInfo>
         </CertificationStatus>
         <Button
           active={false}

--- a/src/client/pages/StaffViewConfirmationPage/index.js
+++ b/src/client/pages/StaffViewConfirmationPage/index.js
@@ -3,6 +3,7 @@ import React from "react";
 import { Link } from "react-router-dom";
 import routes from "../../../data/routes";
 import { useTranslation, Trans } from "react-i18next";
+import PropTypes from "prop-types";
 import { userDataPropType } from "../../commonPropTypes";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header";
@@ -47,55 +48,72 @@ function StaffViewConfirmationPage(props) {
   }
 
   function CertificationStatus() {
-    function ClaimantLastName() {
+    function HeaderWithBadge(props) {
       return (
-        <span>
-          {t("staff-view-confirmation.last-name")}{" "}
-          <strong>{userData.lastName}</strong>
-        </span>
+        <h2 className="h3 font-weight-bold mt-5 mb-3">
+          {t("staff-view-confirmation.header2")} {props.children}
+        </h2>
       );
     }
+    HeaderWithBadge.propTypes = {
+      children: PropTypes.element.isRequired,
+    };
+
+    function ClaimantInfo(props) {
+      return (
+        <p>
+          {t("staff-view-confirmation.last-name")}{" "}
+          <strong>{userData.lastName}</strong>
+          <br />
+          {props.children}
+        </p>
+      );
+    }
+    ClaimantInfo.propTypes = {
+      children: PropTypes.element.isRequired,
+    };
+
     switch (status) {
       case statuses.NOT_STARTED:
         return (
           <React.Fragment>
-            <span className="badge not-started">
-              {t("staff-view-confirmation.not-started.status")}
-            </span>
-            <p>
-              <ClaimantLastName />
-              <br />
+            <HeaderWithBadge>
+              <span className="badge not-started">
+                {t("staff-view-confirmation.not-started.status")}
+              </span>
+            </HeaderWithBadge>
+            <ClaimantInfo>
               {t("staff-view-confirmation.not-started.p1")}
-            </p>
+            </ClaimantInfo>
           </React.Fragment>
         );
       case statuses.IN_PROGRESS:
         return (
           <React.Fragment>
-            <span className="badge in-progress">
-              {t("staff-view-confirmation.in-progress.status")}
-            </span>
-            <p>
-              <ClaimantLastName />
-              <br />
+            <HeaderWithBadge>
+              <span className="badge in-progress">
+                {t("staff-view-confirmation.in-progress.status")}
+              </span>
+            </HeaderWithBadge>
+            <ClaimantInfo>
               {t("staff-view-confirmation.in-progress.p1")}
-            </p>
+            </ClaimantInfo>
           </React.Fragment>
         );
       case statuses.COMPLETED:
         return (
           <React.Fragment>
-            <span className="badge completed">
-              {t("staff-view-confirmation.completed.status")}
-            </span>
-            <p>
-              <ClaimantLastName />
-              <br />
+            <HeaderWithBadge>
+              <span className="badge completed">
+                {t("staff-view-confirmation.completed.status")}
+              </span>
+            </HeaderWithBadge>
+            <ClaimantInfo>
               {t("staff-view-confirmation.completed.p1")}
               <br />
               {t("staff-view-confirmation.completed.confirmation-number")}{" "}
               <strong>{shortConfirmationNumber}</strong>
-            </p>
+            </ClaimantInfo>
             <p>
               <Trans t={t} i18nKey="staff-view-confirmation.completed.p2">
                 <strong>Note:</strong> Beginning 07/17/20, the 32 character
@@ -125,10 +143,6 @@ function StaffViewConfirmationPage(props) {
           >
             {t("staff-view-confirmation.button-search")}
           </Button>
-
-          <h2 className="h3 font-weight-bold mt-5 mb-3">
-            {t("staff-view-confirmation.header2")}
-          </h2>
           <CertificationStatus />
           <Button
             variant="outline-secondary"

--- a/src/client/utils.js
+++ b/src/client/utils.js
@@ -40,7 +40,7 @@ export function logError(errorMessage) {
   appInsights.trackException({ exception: new Error(errorMessage) });
 }
 
-// Our app is only built once on the staging environment, so
+// This app is only built once on the staging environment, so
 // process.env.NODE_ENV never equals "production". Therefore, we
 // check for the window URL as a workaround.
 export const isProdEnv = window.location.hostname === "unemployment.edd.ca.gov";

--- a/src/data/locales/en/translation.json
+++ b/src/data/locales/en/translation.json
@@ -374,7 +374,7 @@
     "title": "Retroactive Certification for Unemployment",
     "header1": "Staff View",
     "button-search": "Search New Claimant",
-    "header2": "Certification Status",
+    "header2": "Certification Status: ",
     "last-name": "Claimant Last Name: ",
     "not-started": {
       "status": "Not started",

--- a/src/data/locales/es/translation.json
+++ b/src/data/locales/es/translation.json
@@ -373,7 +373,7 @@
     "title": "Retroactive Certification for Unemployment",
     "header1": "Staff View",
     "button-search": "Search New Claimant",
-    "header2": "Certification Status",
+    "header2": "Certification Status: ",
     "last-name": "Claimant Last Name: ",
     "not-started": {
       "status": "Not started",


### PR DESCRIPTION
This PR updates the Certification Status badge on the Staff View confirmation page to be on the same line as the header, per EDD feedback.

![image](https://user-images.githubusercontent.com/82277/90149194-3a191300-dd52-11ea-8ba0-e1e6ce80b825.png)

===

- [x] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
