### PR TITLE
Countdown on timeout warning modal

### DIFF
--- a/src/client/components/SessionTimer/__snapshots__/index.test.js.snap
+++ b/src/client/components/SessionTimer/__snapshots__/index.test.js.snap
@@ -17,7 +17,15 @@ exports[`<SessionTimer /> clear 1`] = `
     </ModalTitle>
   </ModalHeader>
   <ModalBody>
-    To protect your information, you will be logged out in 5 minutes if you do not continue working. Any unsaved changes will be lost.
+    <Trans
+      i18nKey="timeout-modal.warning"
+      t={[Function]}
+      values={
+        Object {
+          "numberOfMinutes": undefined,
+        }
+      }
+    />
   </ModalBody>
   <ModalFooter
     className="border-0"
@@ -52,7 +60,15 @@ exports[`<SessionTimer /> startOrUpdate 1`] = `
     </ModalTitle>
   </ModalHeader>
   <ModalBody>
-    To protect your information, you will be logged out in 5 minutes if you do not continue working. Any unsaved changes will be lost.
+    <Trans
+      i18nKey="timeout-modal.warning"
+      t={[Function]}
+      values={
+        Object {
+          "numberOfMinutes": undefined,
+        }
+      }
+    />
   </ModalBody>
   <ModalFooter
     className="border-0"

--- a/src/client/components/SessionTimer/index.js
+++ b/src/client/components/SessionTimer/index.js
@@ -27,9 +27,10 @@ function SessionTimer(props) {
 
   useEffect(() => {
     if (showWarningModal) {
-      setTimeout(() => {
+      const timer = setTimeout(() => {
         setNumberOfMinutes(numberOfMinutes - 1);
       }, 60 * 1000);
+      return () => clearTimeout(timer);
     }
   });
 

--- a/src/client/components/SessionTimer/index.js
+++ b/src/client/components/SessionTimer/index.js
@@ -3,7 +3,7 @@ import { useHistory } from "react-router-dom";
 import PropTypes from "prop-types";
 import Modal from "react-bootstrap/Modal";
 import Button from "react-bootstrap/Button";
-import { useTranslation } from "react-i18next";
+import { useTranslation, Trans } from "react-i18next";
 import { setUserDataPropType } from "../../commonPropTypes";
 import AUTH_STRINGS from "../../../data/authStrings";
 import routes from "../../../data/routes";
@@ -16,11 +16,12 @@ const TIMEOUT_KEY = "timeout";
 function SessionTimer(props) {
   const { t } = useTranslation();
   const TIMEOUT_MS = 30 * 60 * 1000;
-  const TIMEOUT_WARNING_MS = TIMEOUT_MS - 5 * 60 * 1000;
+  const TIMEOUT_WARNING_MS = 2;
   const history = useHistory();
   const { action, setUserData } = props;
 
   const [showWarningModal, setShowWarningModal] = useState();
+  const [numberOfMinutes, setNumberOfMinutes] = useState();
 
   function closeWarningModal() {
     setShowWarningModal(false);
@@ -51,6 +52,7 @@ function SessionTimer(props) {
     warningTimerId = setTimeout(() => {
       if (sessionStorage.getItem(AUTH_STRINGS.authToken)) {
         setShowWarningModal(true);
+        setNumberOfMinutes(5);
       }
     }, TIMEOUT_WARNING_MS);
     timeOutTimerId = setTimeout(() => {
@@ -83,7 +85,13 @@ function SessionTimer(props) {
           <strong>{t("timeout-modal.header")}</strong>
         </Modal.Title>
       </Modal.Header>
-      <Modal.Body>{t("timeout-modal.warning")}</Modal.Body>
+      <Modal.Body>
+        <Trans
+            t={t}
+            i18nKey="timeout-modal.warning"
+            values={{ numberOfMinutes }}
+          />
+      </Modal.Body>
       <Modal.Footer className="border-0">
         <Button variant="secondary" onClick={closeWarningModal}>
           {t("timeout-modal.button")}

--- a/src/client/components/SessionTimer/index.js
+++ b/src/client/components/SessionTimer/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useHistory } from "react-router-dom";
 import PropTypes from "prop-types";
 import Modal from "react-bootstrap/Modal";
@@ -16,12 +16,22 @@ const TIMEOUT_KEY = "timeout";
 function SessionTimer(props) {
   const { t } = useTranslation();
   const TIMEOUT_MS = 30 * 60 * 1000;
-  const TIMEOUT_WARNING_MS = 2;
+  const TIMEOUT_DISPLAY_TIME_IN_MINUTES = 5;
+  const TIMEOUT_WARNING_MS =
+    TIMEOUT_MS - TIMEOUT_DISPLAY_TIME_IN_MINUTES * 60 * 1000;
   const history = useHistory();
   const { action, setUserData } = props;
 
   const [showWarningModal, setShowWarningModal] = useState();
   const [numberOfMinutes, setNumberOfMinutes] = useState();
+
+  useEffect(() => {
+    if (showWarningModal) {
+      setTimeout(() => {
+        setNumberOfMinutes(numberOfMinutes - 1);
+      }, 60 * 1000);
+    }
+  });
 
   function closeWarningModal() {
     setShowWarningModal(false);
@@ -52,7 +62,7 @@ function SessionTimer(props) {
     warningTimerId = setTimeout(() => {
       if (sessionStorage.getItem(AUTH_STRINGS.authToken)) {
         setShowWarningModal(true);
-        setNumberOfMinutes(5);
+        setNumberOfMinutes(TIMEOUT_DISPLAY_TIME_IN_MINUTES);
       }
     }, TIMEOUT_WARNING_MS);
     timeOutTimerId = setTimeout(() => {
@@ -87,10 +97,10 @@ function SessionTimer(props) {
       </Modal.Header>
       <Modal.Body>
         <Trans
-            t={t}
-            i18nKey="timeout-modal.warning"
-            values={{ numberOfMinutes }}
-          />
+          t={t}
+          i18nKey="timeout-modal.warning"
+          values={{ numberOfMinutes }}
+        />
       </Modal.Body>
       <Modal.Footer className="border-0">
         <Button variant="secondary" onClick={closeWarningModal}>

--- a/src/client/components/SessionTimer/index.js
+++ b/src/client/components/SessionTimer/index.js
@@ -62,8 +62,8 @@ function SessionTimer(props) {
     clear();
     warningTimerId = setTimeout(() => {
       if (sessionStorage.getItem(AUTH_STRINGS.authToken)) {
-        setShowWarningModal(true);
         setNumberOfMinutes(TIMEOUT_DISPLAY_TIME_IN_MINUTES);
+        setShowWarningModal(true);
       }
     }, TIMEOUT_WARNING_MS);
     timeOutTimerId = setTimeout(() => {

--- a/src/data/locales/en/translation.json
+++ b/src/data/locales/en/translation.json
@@ -399,7 +399,7 @@
   "generic-validation-error-message": "There are one or more errors on this page. Review and correct them to continue. Complete all fields and try again.",
   "timeout-modal": {
     "header": "Your Session Will End Soon",
-    "warning": "To protect your information, you will be logged out in 5 minutes if you do not continue working. Any unsaved changes will be lost.",
+    "warning": "To protect your information, you will be logged out in {{numberOfMinutes}} minutes if you do not continue working. Any unsaved changes will be lost.",
     "button": "Continue Working"
   }
 }

--- a/src/data/locales/es/translation.json
+++ b/src/data/locales/es/translation.json
@@ -398,7 +398,7 @@
   "generic-validation-error-message": "Hay más de un error en esta página. Revise y corrija los errores para continuar. Complete todo los campos e intente de nuevo.",
   "timeout-modal": {
     "header": "Su sesión cerrara pronto",
-    "warning": "Para proteger su información, se cerrará su sesión en 5 minutos si no continúa teniendo actividad en su cuenta. Se perderá cualquier cambio que no haya sido guardado.",
+    "warning": "Para proteger su información, se cerrará su sesión en {{numberOfMinutes}} minutos si no continúa teniendo actividad en su cuenta. Se perderá cualquier cambio que no haya sido guardado.",
     "button": "Continuar actividad en su cuenta"
   }
 }


### PR DESCRIPTION
The number of minutes in the timeout warning modal counts down from 5 to 1.

<img width="1276" alt="Screen Shot 2020-08-14 at 3 42 39 PM" src="https://user-images.githubusercontent.com/4306128/90286939-d28fc000-de44-11ea-8739-baaddc93fbb8.png">



===

Resolves #519

- [x] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
