### PR TITLE
Update tests to render contents of all Trans components properly

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -106,7 +106,7 @@ function init(env = process.env) {
       env.ALLOWED_IP_RANGES.split(" ").forEach((ipRange) => {
         allowedIps.push(ipRange.split("-"));
       });
-    } else if (env.NODE_ENV !== "testing") {
+    } else if (env.NODE_ENV !== "test") {
       // This needs to be set on all non-development environments for Staff View
       console.error(
         "env.ALLOWED_IP_RANGES has not been set on " + env.NODE_ENV

--- a/src/client/components/AccordionItem/index.test.js
+++ b/src/client/components/AccordionItem/index.test.js
@@ -4,7 +4,7 @@ import Component from "./index";
 
 describe("<AccordionItem />", () => {
   it("renders the component", async () => {
-    const wrapper = renderNonTransContent(Component, "AccordionItem", {
+    const wrapper = renderNonTransContent(Component, {
       header: <div>header react element</div>,
       content: <div>detailed body react element</div>,
       showContent: true,

--- a/src/client/components/BPOButton/index.test.js
+++ b/src/client/components/BPOButton/index.test.js
@@ -3,7 +3,7 @@ import Component from "./index";
 
 describe("<BPOButton />", () => {
   it("renders the component", async () => {
-    const wrapper = renderNonTransContent(Component, "BPOButton");
+    const wrapper = renderNonTransContent(Component);
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/client/components/DaysSickQuestion/index.test.js
+++ b/src/client/components/DaysSickQuestion/index.test.js
@@ -3,7 +3,7 @@ import Component from "./index";
 
 describe("<DaysSickQuestion />", () => {
   it("renders the component", async () => {
-    const wrapper = renderNonTransContent(Component, "DaysSickQuestion", {
+    const wrapper = renderNonTransContent(Component, {
       onChange: () => {},
       questionText:
         "If Yes, enter the number of days (1 - 7) you were unable to work.",

--- a/src/client/components/DisasterQuestion/index.test.js
+++ b/src/client/components/DisasterQuestion/index.test.js
@@ -3,7 +3,7 @@ import Component from "./index";
 
 describe("<DisasterQuestion />", () => {
   it("renders the component", async () => {
-    const wrapper = renderNonTransContent(Component, "DisasterQuestion", {
+    const wrapper = renderNonTransContent(Component, {
       onChange: () => {},
     });
 

--- a/src/client/components/EmployersQuestions/__snapshots__/index.test.js.snap
+++ b/src/client/components/EmployersQuestions/__snapshots__/index.test.js.snap
@@ -1,221 +1,3637 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<EmployersQuestions /> renders the component 1`] = `
-<div>
-  <div
-    key="employerData00000000"
-  >
-    <hr />
-    <Row
-      className="align-items-baseline"
-      noGutters={false}
+<EmployersQuestions
+  onChange={[Function]}
+>
+  <div>
+    <div
+      key="employerData00000000"
     >
-      <Col
-        md="auto"
+      <hr />
+      <Row
+        className="align-items-baseline"
+        noGutters={false}
       >
-        <h3>
-          <Trans
-            i18nKey="retrocerts-certification.employers.heading"
-            t={[Function]}
-            values={
-              Object {
-                "incomeNumber": 1,
-              }
-            }
-          />
-        </h3>
-      </Col>
-    </Row>
-    <EmployerQuestions
-      employerData={
-        Object {
-          "address1": "",
-          "address2": "",
-          "city": "",
-          "employerName": "",
-          "grossEarnings": "",
-          "id": "00000000",
-          "lastDateWorked": "",
-          "moreDetails": "",
-          "reason": "still-working",
-          "state": "",
-          "totalHoursWorked": "",
-          "zipcode": "",
-        }
-      }
-      onChange={[Function]}
-    />
-  </div>
-  <hr />
-  <Row
-    noGutters={false}
-  >
-    <Col
-      md="auto"
-    >
-      <NavLink
-        as={
+        <div
+          className="align-items-baseline row"
+        >
+          <Col
+            md="auto"
+          >
+            <div
+              className="col-md-auto"
+            >
+              <h3>
+                <Trans
+                  i18nKey="retrocerts-certification.employers.heading"
+                  t={[Function]}
+                  values={
+                    Object {
+                      "incomeNumber": 1,
+                    }
+                  }
+                >
+                  Employer 1
+                </Trans>
+              </h3>
+            </div>
+          </Col>
+        </div>
+      </Row>
+      <EmployerQuestions
+        employerData={
           Object {
-            "$$typeof": Symbol(react.forward_ref),
-            "displayName": "SafeAnchor",
-            "render": [Function],
+            "address1": "",
+            "address2": "",
+            "city": "",
+            "employerName": "",
+            "grossEarnings": "",
+            "id": "00000000",
+            "lastDateWorked": "",
+            "moreDetails": "",
+            "reason": "still-working",
+            "state": "",
+            "totalHoursWorked": "",
+            "zipcode": "",
           }
         }
-        disabled={false}
-        onClick={[Function]}
+        onChange={[Function]}
       >
-        + Add another employer
-      </NavLink>
-    </Col>
-  </Row>
-</div>
+        <div
+          className="follow-up"
+        >
+          <FormGroup
+            className="mb-3"
+            controlId="00000000employerName"
+          >
+            <div
+              className="mb-3 form-group"
+            >
+              <FormLabel
+                column={false}
+                srOnly={false}
+              >
+                <label
+                  className="form-label"
+                  htmlFor="00000000employerName"
+                >
+                  Employer Name
+                </label>
+              </FormLabel>
+              <FormText
+                className="help-text"
+              >
+                <small
+                  className="help-text form-text"
+                >
+                  <Trans
+                    i18nKey="retrocerts-certification.employers.help-employerName"
+                    t={[Function]}
+                  >
+                    The employer's name that work was performed for this week.
+                  </Trans>
+                </small>
+              </FormText>
+              <FormControl
+                maxLength={500}
+                onChange={[Function]}
+                required={true}
+                type="text"
+                value=""
+              >
+                <input
+                  className="form-control"
+                  id="00000000employerName"
+                  maxLength={500}
+                  onChange={[Function]}
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </FormControl>
+              <Feedback
+                type="invalid"
+              >
+                <div
+                  className="invalid-feedback"
+                >
+                  This field is required.
+                </div>
+              </Feedback>
+            </div>
+          </FormGroup>
+          <FormGroup
+            className="mb-3"
+            controlId="00000000address1"
+          >
+            <div
+              className="mb-3 form-group"
+            >
+              <FormLabel
+                column={false}
+                srOnly={false}
+              >
+                <label
+                  className="form-label"
+                  htmlFor="00000000address1"
+                >
+                  Address Line 1
+                </label>
+              </FormLabel>
+              <FormText
+                className="help-text"
+              >
+                <small
+                  className="help-text form-text"
+                >
+                  <Trans
+                    i18nKey="retrocerts-certification.employers.help-address1"
+                    t={[Function]}
+                  >
+                    The employer's address that work was performed for this week.
+                  </Trans>
+                </small>
+              </FormText>
+              <FormControl
+                maxLength={500}
+                onChange={[Function]}
+                required={true}
+                type="text"
+                value=""
+              >
+                <input
+                  className="form-control"
+                  id="00000000address1"
+                  maxLength={500}
+                  onChange={[Function]}
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </FormControl>
+              <Feedback
+                type="invalid"
+              >
+                <div
+                  className="invalid-feedback"
+                >
+                  This field is required.
+                </div>
+              </Feedback>
+            </div>
+          </FormGroup>
+          <FormGroup
+            className="mb-3"
+            controlId="00000000address2"
+          >
+            <div
+              className="mb-3 form-group"
+            >
+              <FormLabel
+                column={false}
+                srOnly={false}
+              >
+                <label
+                  className="form-label"
+                  htmlFor="00000000address2"
+                >
+                  Address Line 2
+                </label>
+              </FormLabel>
+              <FormText
+                className="help-text"
+              >
+                <small
+                  className="help-text form-text"
+                >
+                  <Trans
+                    i18nKey="retrocerts-certification.employers.help-address2"
+                    t={[Function]}
+                  >
+                    The employer's suite, floor, etc. that work was performed for this week.
+                  </Trans>
+                </small>
+              </FormText>
+              <FormControl
+                maxLength={500}
+                onChange={[Function]}
+                required={false}
+                type="text"
+                value=""
+              >
+                <input
+                  className="form-control"
+                  id="00000000address2"
+                  maxLength={500}
+                  onChange={[Function]}
+                  required={false}
+                  type="text"
+                  value=""
+                />
+              </FormControl>
+              <Feedback
+                type="invalid"
+              >
+                <div
+                  className="invalid-feedback"
+                >
+                  This field is required.
+                </div>
+              </Feedback>
+            </div>
+          </FormGroup>
+          <FormRow>
+            <div
+              className="form-row"
+            >
+              <Col
+                md={8}
+              >
+                <div
+                  className="col-md-8"
+                >
+                  <FormGroup
+                    className="mb-3"
+                    controlId="00000000city"
+                  >
+                    <div
+                      className="mb-3 form-group"
+                    >
+                      <FormLabel
+                        column={false}
+                        srOnly={false}
+                      >
+                        <label
+                          className="form-label"
+                          htmlFor="00000000city"
+                        >
+                          City
+                        </label>
+                      </FormLabel>
+                      <FormText
+                        className="help-text"
+                      >
+                        <small
+                          className="help-text form-text"
+                        >
+                          <Trans
+                            i18nKey="retrocerts-certification.employers.help-city"
+                            t={[Function]}
+                          >
+                            The employer's city where work was performed for this week.
+                          </Trans>
+                        </small>
+                      </FormText>
+                      <FormControl
+                        maxLength={100}
+                        onChange={[Function]}
+                        required={true}
+                        type="text"
+                        value=""
+                      >
+                        <input
+                          className="form-control"
+                          id="00000000city"
+                          maxLength={100}
+                          onChange={[Function]}
+                          required={true}
+                          type="text"
+                          value=""
+                        />
+                      </FormControl>
+                      <Feedback
+                        type="invalid"
+                      >
+                        <div
+                          className="invalid-feedback"
+                        >
+                          This field is required.
+                        </div>
+                      </Feedback>
+                    </div>
+                  </FormGroup>
+                </div>
+              </Col>
+            </div>
+          </FormRow>
+          <FormRow
+            className="mb-3"
+          >
+            <div
+              className="mb-3 form-row"
+            >
+              <FormGroup
+                as={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Col",
+                    "render": [Function],
+                  }
+                }
+                className="col-md-8"
+                controlId="00000000state-select"
+              >
+                <Col
+                  className="col-md-8 form-group"
+                >
+                  <div
+                    className="col-md-8 form-group col"
+                  >
+                    <FormLabel
+                      column={false}
+                      srOnly={false}
+                    >
+                      <label
+                        className="form-label"
+                        htmlFor="00000000state-select"
+                      >
+                        State
+                      </label>
+                    </FormLabel>
+                    <FormText
+                      className="help-text"
+                    >
+                      <small
+                        className="help-text form-text"
+                      >
+                        The employer's state where work was performed for this week.
+                      </small>
+                    </FormText>
+                    <FormControl
+                      as="select"
+                      className="col-md-4"
+                      onChange={[Function]}
+                      required={true}
+                      value=""
+                    >
+                      <select
+                        className="col-md-4 form-control"
+                        id="00000000state-select"
+                        onChange={[Function]}
+                        required={true}
+                        value=""
+                      >
+                        <option />
+                        <option
+                          key="AK"
+                        >
+                          AK
+                        </option>
+                        <option
+                          key="AL"
+                        >
+                          AL
+                        </option>
+                        <option
+                          key="AR"
+                        >
+                          AR
+                        </option>
+                        <option
+                          key="AS"
+                        >
+                          AS
+                        </option>
+                        <option
+                          key="AZ"
+                        >
+                          AZ
+                        </option>
+                        <option
+                          key="CA"
+                        >
+                          CA
+                        </option>
+                        <option
+                          key="CO"
+                        >
+                          CO
+                        </option>
+                        <option
+                          key="CT"
+                        >
+                          CT
+                        </option>
+                        <option
+                          key="DC"
+                        >
+                          DC
+                        </option>
+                        <option
+                          key="DE"
+                        >
+                          DE
+                        </option>
+                        <option
+                          key="FL"
+                        >
+                          FL
+                        </option>
+                        <option
+                          key="FM"
+                        >
+                          FM
+                        </option>
+                        <option
+                          key="GA"
+                        >
+                          GA
+                        </option>
+                        <option
+                          key="GU"
+                        >
+                          GU
+                        </option>
+                        <option
+                          key="HI"
+                        >
+                          HI
+                        </option>
+                        <option
+                          key="IA"
+                        >
+                          IA
+                        </option>
+                        <option
+                          key="ID"
+                        >
+                          ID
+                        </option>
+                        <option
+                          key="IL"
+                        >
+                          IL
+                        </option>
+                        <option
+                          key="IN"
+                        >
+                          IN
+                        </option>
+                        <option
+                          key="KS"
+                        >
+                          KS
+                        </option>
+                        <option
+                          key="KY"
+                        >
+                          KY
+                        </option>
+                        <option
+                          key="LA"
+                        >
+                          LA
+                        </option>
+                        <option
+                          key="MA"
+                        >
+                          MA
+                        </option>
+                        <option
+                          key="MD"
+                        >
+                          MD
+                        </option>
+                        <option
+                          key="ME"
+                        >
+                          ME
+                        </option>
+                        <option
+                          key="MH"
+                        >
+                          MH
+                        </option>
+                        <option
+                          key="MI"
+                        >
+                          MI
+                        </option>
+                        <option
+                          key="MN"
+                        >
+                          MN
+                        </option>
+                        <option
+                          key="MO"
+                        >
+                          MO
+                        </option>
+                        <option
+                          key="MP"
+                        >
+                          MP
+                        </option>
+                        <option
+                          key="MS"
+                        >
+                          MS
+                        </option>
+                        <option
+                          key="MT"
+                        >
+                          MT
+                        </option>
+                        <option
+                          key="NC"
+                        >
+                          NC
+                        </option>
+                        <option
+                          key="ND"
+                        >
+                          ND
+                        </option>
+                        <option
+                          key="NE"
+                        >
+                          NE
+                        </option>
+                        <option
+                          key="NH"
+                        >
+                          NH
+                        </option>
+                        <option
+                          key="NJ"
+                        >
+                          NJ
+                        </option>
+                        <option
+                          key="NM"
+                        >
+                          NM
+                        </option>
+                        <option
+                          key="NV"
+                        >
+                          NV
+                        </option>
+                        <option
+                          key="NY"
+                        >
+                          NY
+                        </option>
+                        <option
+                          key="OH"
+                        >
+                          OH
+                        </option>
+                        <option
+                          key="OK"
+                        >
+                          OK
+                        </option>
+                        <option
+                          key="OR"
+                        >
+                          OR
+                        </option>
+                        <option
+                          key="PA"
+                        >
+                          PA
+                        </option>
+                        <option
+                          key="PR"
+                        >
+                          PR
+                        </option>
+                        <option
+                          key="PW"
+                        >
+                          PW
+                        </option>
+                        <option
+                          key="RI"
+                        >
+                          RI
+                        </option>
+                        <option
+                          key="SC"
+                        >
+                          SC
+                        </option>
+                        <option
+                          key="SD"
+                        >
+                          SD
+                        </option>
+                        <option
+                          key="TN"
+                        >
+                          TN
+                        </option>
+                        <option
+                          key="TX"
+                        >
+                          TX
+                        </option>
+                        <option
+                          key="UT"
+                        >
+                          UT
+                        </option>
+                        <option
+                          key="VA"
+                        >
+                          VA
+                        </option>
+                        <option
+                          key="VI"
+                        >
+                          VI
+                        </option>
+                        <option
+                          key="VT"
+                        >
+                          VT
+                        </option>
+                        <option
+                          key="WA"
+                        >
+                          WA
+                        </option>
+                        <option
+                          key="WI"
+                        >
+                          WI
+                        </option>
+                        <option
+                          key="WV"
+                        >
+                          WV
+                        </option>
+                        <option
+                          key="WY"
+                        >
+                          WY
+                        </option>
+                      </select>
+                    </FormControl>
+                    <Feedback
+                      type="invalid"
+                    >
+                      <div
+                        className="invalid-feedback"
+                      >
+                        This field is required.
+                      </div>
+                    </Feedback>
+                  </div>
+                </Col>
+              </FormGroup>
+            </div>
+          </FormRow>
+          <FormGroup
+            className="mb-3"
+            controlId="00000000zipcode"
+          >
+            <div
+              className="mb-3 form-group"
+            >
+              <FormLabel
+                column={false}
+                srOnly={false}
+              >
+                <label
+                  className="form-label"
+                  htmlFor="00000000zipcode"
+                >
+                  ZIP
+                </label>
+              </FormLabel>
+              <FormText
+                className="help-text"
+              >
+                <small
+                  className="help-text form-text"
+                >
+                  <Trans
+                    i18nKey="retrocerts-certification.employers.help-zipcode"
+                    t={[Function]}
+                  >
+                    The employer's ZIP code where work was performed for this week. 
+                    <p
+                      key="p-1"
+                    >
+                      Enter as ##### or #####-####.
+                    </p>
+                  </Trans>
+                </small>
+              </FormText>
+              <FormControl
+                className="col-md-3"
+                maxLength={10}
+                onChange={[Function]}
+                pattern="\\\\d{5}|\\\\d{5}-\\\\d{4}"
+                required={true}
+                type="text"
+                value=""
+              >
+                <input
+                  className="col-md-3 form-control"
+                  id="00000000zipcode"
+                  maxLength={10}
+                  onChange={[Function]}
+                  pattern="\\\\d{5}|\\\\d{5}-\\\\d{4}"
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </FormControl>
+              <Feedback
+                type="invalid"
+              >
+                <div
+                  className="invalid-feedback"
+                >
+                  This field is required.
+                </div>
+              </Feedback>
+            </div>
+          </FormGroup>
+          <p>
+            Last Date Worked
+          </p>
+          <small
+            className="help-text"
+          >
+            The last day worked in this certification week.
+          </small>
+          <FormRow
+            className="mb-3"
+          >
+            <div
+              className="mb-3 form-row"
+            >
+              <FormGroup
+                as={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Col",
+                    "render": [Function],
+                  }
+                }
+                controlId="00000000lastDateWorked-month-question"
+                md={2}
+              >
+                <Col
+                  className="form-group"
+                  md={2}
+                >
+                  <div
+                    className="form-group col-md-2"
+                  >
+                    <FormLabel
+                      column={false}
+                      srOnly={false}
+                    >
+                      <label
+                        className="form-label"
+                        htmlFor="00000000lastDateWorked-month-question"
+                      >
+                        Month
+                      </label>
+                    </FormLabel>
+                    <FormControl
+                      maxLength={2}
+                      onChange={[Function]}
+                      pattern="(^0[1-9])|(^1[0-2])|(^[1-9]$)"
+                      required={true}
+                      type="text"
+                      value=""
+                    >
+                      <input
+                        className="form-control"
+                        id="00000000lastDateWorked-month-question"
+                        maxLength={2}
+                        onChange={[Function]}
+                        pattern="(^0[1-9])|(^1[0-2])|(^[1-9]$)"
+                        required={true}
+                        type="text"
+                        value=""
+                      />
+                    </FormControl>
+                    <Feedback
+                      type="invalid"
+                    >
+                      <div
+                        className="invalid-feedback"
+                      >
+                        This field is required.
+                      </div>
+                    </Feedback>
+                  </div>
+                </Col>
+              </FormGroup>
+              <FormGroup
+                as={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Col",
+                    "render": [Function],
+                  }
+                }
+                controlId="00000000lastDateWorked-day-question"
+                md={2}
+              >
+                <Col
+                  className="form-group"
+                  md={2}
+                >
+                  <div
+                    className="form-group col-md-2"
+                  >
+                    <FormLabel
+                      column={false}
+                      srOnly={false}
+                    >
+                      <label
+                        className="form-label"
+                        htmlFor="00000000lastDateWorked-day-question"
+                      >
+                        Day
+                      </label>
+                    </FormLabel>
+                    <FormControl
+                      maxLength={2}
+                      onChange={[Function]}
+                      pattern="(^0[1-9])|(^1[0-9])|(^2[0-9])|(^3[0-1])|(^[1-9]$)"
+                      required={true}
+                      type="text"
+                      value=""
+                    >
+                      <input
+                        className="form-control"
+                        id="00000000lastDateWorked-day-question"
+                        maxLength={2}
+                        onChange={[Function]}
+                        pattern="(^0[1-9])|(^1[0-9])|(^2[0-9])|(^3[0-1])|(^[1-9]$)"
+                        required={true}
+                        type="text"
+                        value=""
+                      />
+                    </FormControl>
+                    <Feedback
+                      type="invalid"
+                    >
+                      <div
+                        className="invalid-feedback"
+                      >
+                        This field is required.
+                      </div>
+                    </Feedback>
+                  </div>
+                </Col>
+              </FormGroup>
+              <FormGroup
+                as={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Col",
+                    "render": [Function],
+                  }
+                }
+                md={2}
+              >
+                <Col
+                  className="form-group"
+                  md={2}
+                >
+                  <div
+                    className="form-group col-md-2"
+                  >
+                    <FormLabel
+                      column={false}
+                      srOnly={false}
+                    >
+                      <label
+                        className="form-label"
+                      >
+                        Year
+                      </label>
+                    </FormLabel>
+                    <FormControl
+                      disabled={true}
+                      type="text"
+                      value="2020"
+                    >
+                      <input
+                        className="form-control"
+                        disabled={true}
+                        type="text"
+                        value="2020"
+                      />
+                    </FormControl>
+                  </div>
+                </Col>
+              </FormGroup>
+            </div>
+          </FormRow>
+          <FormGroup
+            className="mb-3"
+            controlId="00000000totalHoursWorked"
+          >
+            <div
+              className="mb-3 form-group"
+            >
+              <FormLabel
+                column={false}
+                srOnly={false}
+              >
+                <label
+                  className="form-label"
+                  htmlFor="00000000totalHoursWorked"
+                >
+                  Total hours worked for this employer
+                </label>
+              </FormLabel>
+              <FormText
+                className="help-text"
+              >
+                <small
+                  className="help-text form-text"
+                >
+                  <Trans
+                    i18nKey="retrocerts-certification.employers.help-totalHoursWorked"
+                    t={[Function]}
+                  >
+                    Report the hours worked in this week for this employer.
+                  </Trans>
+                </small>
+              </FormText>
+              <FormControl
+                className="col-md-2"
+                maxLength={6}
+                onChange={[Function]}
+                pattern="\\\\d+[.]?\\\\d*"
+                required={true}
+                type="text"
+                value=""
+              >
+                <input
+                  className="col-md-2 form-control"
+                  id="00000000totalHoursWorked"
+                  maxLength={6}
+                  onChange={[Function]}
+                  pattern="\\\\d+[.]?\\\\d*"
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </FormControl>
+              <Feedback
+                type="invalid"
+              >
+                <div
+                  className="invalid-feedback"
+                >
+                  This field is required.
+                </div>
+              </Feedback>
+            </div>
+          </FormGroup>
+          <FormGroup
+            className="mb-3"
+            controlId="00000000grossEarnings"
+          >
+            <div
+              className="mb-3 form-group"
+            >
+              <FormLabel
+                column={false}
+                srOnly={false}
+              >
+                <label
+                  className="form-label"
+                  htmlFor="00000000grossEarnings"
+                >
+                  Gross earnings before deductions for this employer (whether you were paid or not)
+                </label>
+              </FormLabel>
+              <FormText
+                className="help-text"
+              >
+                <small
+                  className="help-text form-text"
+                >
+                  <Trans
+                    i18nKey="retrocerts-certification.employers.help-grossEarnings"
+                    t={[Function]}
+                  >
+                    Full earnings without deductions.
+                  </Trans>
+                </small>
+              </FormText>
+              <FormControl
+                className="col-md-2"
+                maxLength={11}
+                onChange={[Function]}
+                pattern="^\\\\$?(([1-9](\\\\d*|\\\\d{0,2}(,\\\\d{3})*))|0)(\\\\.\\\\d{2})?$"
+                required={true}
+                type="text"
+                value=""
+              >
+                <input
+                  className="col-md-2 form-control"
+                  id="00000000grossEarnings"
+                  maxLength={11}
+                  onChange={[Function]}
+                  pattern="^\\\\$?(([1-9](\\\\d*|\\\\d{0,2}(,\\\\d{3})*))|0)(\\\\.\\\\d{2})?$"
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </FormControl>
+              <Feedback
+                type="invalid"
+              >
+                <div
+                  className="invalid-feedback"
+                >
+                  This field is required.
+                </div>
+              </Feedback>
+            </div>
+          </FormGroup>
+          <FormGroup
+            controlId="00000000reason-select"
+          >
+            <div
+              className="form-group"
+            >
+              <FormLabel
+                column={false}
+                srOnly={false}
+              >
+                <label
+                  className="form-label"
+                  htmlFor="00000000reason-select"
+                >
+                  Select the reason you are no longer working:
+                </label>
+              </FormLabel>
+              <FormControl
+                as="select"
+                onChange={[Function]}
+                value="still-working"
+              >
+                <select
+                  className="form-control"
+                  id="00000000reason-select"
+                  onChange={[Function]}
+                  value="still-working"
+                >
+                  <option
+                    key="fired"
+                    value="fired"
+                  >
+                    Terminated or Fired
+                  </option>
+                  <option
+                    key="quit"
+                    value="quit"
+                  >
+                    Quit
+                  </option>
+                  <option
+                    key="laid-off"
+                    value="laid-off"
+                  >
+                    Laid Off
+                  </option>
+                  <option
+                    key="still-working"
+                    value="still-working"
+                  >
+                    Still Working Part Time
+                  </option>
+                </select>
+              </FormControl>
+            </div>
+          </FormGroup>
+        </div>
+      </EmployerQuestions>
+    </div>
+    <hr />
+    <Row
+      noGutters={false}
+    >
+      <div
+        className="row"
+      >
+        <Col
+          md="auto"
+        >
+          <div
+            className="col-md-auto"
+          >
+            <NavLink
+              as={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "displayName": "SafeAnchor",
+                  "render": [Function],
+                }
+              }
+              disabled={false}
+              onClick={[Function]}
+            >
+              <ForwardRef
+                as={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "SafeAnchor",
+                    "render": [Function],
+                  }
+                }
+                className="nav-link"
+                disabled={false}
+                onClick={[Function]}
+              >
+                <SafeAnchor
+                  className="nav-link"
+                  disabled={false}
+                  onClick={[Function]}
+                >
+                  <a
+                    className="nav-link"
+                    href="#"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="button"
+                  >
+                    + Add another employer
+                  </a>
+                </SafeAnchor>
+              </ForwardRef>
+            </NavLink>
+          </div>
+        </Col>
+      </div>
+    </Row>
+  </div>
+</EmployersQuestions>
 `;
 
 exports[`<EmployersQuestions /> renders with 2 income sources 1`] = `
-<div>
-  <div
-    key="employerData12345678"
-  >
-    <hr />
-    <Row
-      className="align-items-baseline"
-      noGutters={false}
+<EmployersQuestions
+  employers={
+    Array [
+      Object {
+        "address1": "e1 - address 1",
+        "address2": "",
+        "city": "city",
+        "employerName": "employer name 1",
+        "grossEarnings": "$200",
+        "id": "12345678",
+        "lastDateWorked": "02/22/2020",
+        "moreDetails": "",
+        "reason": "still-working",
+        "state": "CA",
+        "totalHoursWorked": "10",
+        "zipcode": "94100",
+      },
+      Object {
+        "address1": "e2 - address 1",
+        "address2": "",
+        "city": "city 2",
+        "employerName": "employer name 2",
+        "grossEarnings": "$300",
+        "id": "22222222",
+        "lastDateWorked": "02/24/2020",
+        "moreDetails": "unable to travel",
+        "reason": "quit",
+        "state": "OR",
+        "totalHoursWorked": "12",
+        "zipcode": "97035",
+      },
+    ]
+  }
+  onChange={[Function]}
+>
+  <div>
+    <div
+      key="employerData12345678"
     >
-      <Col
-        md="auto"
+      <hr />
+      <Row
+        className="align-items-baseline"
+        noGutters={false}
       >
-        <h3>
-          <Trans
-            i18nKey="retrocerts-certification.employers.heading"
-            t={[Function]}
-            values={
-              Object {
-                "incomeNumber": 1,
-              }
-            }
-          />
-        </h3>
-      </Col>
-      <Col
-        md="auto"
-      >
-        <NavLink
-          as={
-            Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "displayName": "SafeAnchor",
-              "render": [Function],
-            }
-          }
-          disabled={false}
-          onClick={[Function]}
+        <div
+          className="align-items-baseline row"
         >
-          Remove this employer
-        </NavLink>
-      </Col>
-    </Row>
-    <EmployerQuestions
-      employerData={
-        Object {
-          "address1": "e1 - address 1",
-          "address2": "",
-          "city": "city",
-          "employerName": "employer name 1",
-          "grossEarnings": "$200",
-          "id": "12345678",
-          "lastDateWorked": "02/22/2020",
-          "moreDetails": "",
-          "reason": "still-working",
-          "state": "CA",
-          "totalHoursWorked": "10",
-          "zipcode": "94100",
-        }
-      }
-      onChange={[Function]}
-    />
-  </div>
-  <div
-    key="employerData22222222"
-  >
-    <hr />
-    <Row
-      className="align-items-baseline"
-      noGutters={false}
-    >
-      <Col
-        md="auto"
-      >
-        <h3>
-          <Trans
-            i18nKey="retrocerts-certification.employers.heading"
-            t={[Function]}
-            values={
-              Object {
-                "incomeNumber": 2,
-              }
-            }
-          />
-        </h3>
-      </Col>
-      <Col
-        md="auto"
-      >
-        <NavLink
-          as={
-            Object {
-              "$$typeof": Symbol(react.forward_ref),
-              "displayName": "SafeAnchor",
-              "render": [Function],
-            }
-          }
-          disabled={false}
-          onClick={[Function]}
-        >
-          Remove this employer
-        </NavLink>
-      </Col>
-    </Row>
-    <EmployerQuestions
-      employerData={
-        Object {
-          "address1": "e2 - address 1",
-          "address2": "",
-          "city": "city 2",
-          "employerName": "employer name 2",
-          "grossEarnings": "$300",
-          "id": "22222222",
-          "lastDateWorked": "02/24/2020",
-          "moreDetails": "unable to travel",
-          "reason": "quit",
-          "state": "OR",
-          "totalHoursWorked": "12",
-          "zipcode": "97035",
-        }
-      }
-      onChange={[Function]}
-    />
-  </div>
-  <hr />
-  <Row
-    noGutters={false}
-  >
-    <Col
-      md="auto"
-    >
-      <NavLink
-        as={
+          <Col
+            md="auto"
+          >
+            <div
+              className="col-md-auto"
+            >
+              <h3>
+                <Trans
+                  i18nKey="retrocerts-certification.employers.heading"
+                  t={[Function]}
+                  values={
+                    Object {
+                      "incomeNumber": 1,
+                    }
+                  }
+                >
+                  Employer 1
+                </Trans>
+              </h3>
+            </div>
+          </Col>
+          <Col
+            md="auto"
+          >
+            <div
+              className="col-md-auto"
+            >
+              <NavLink
+                as={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "SafeAnchor",
+                    "render": [Function],
+                  }
+                }
+                disabled={false}
+                onClick={[Function]}
+              >
+                <ForwardRef
+                  as={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "displayName": "SafeAnchor",
+                      "render": [Function],
+                    }
+                  }
+                  className="nav-link"
+                  disabled={false}
+                  onClick={[Function]}
+                >
+                  <SafeAnchor
+                    className="nav-link"
+                    disabled={false}
+                    onClick={[Function]}
+                  >
+                    <a
+                      className="nav-link"
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="button"
+                    >
+                      Remove this employer
+                    </a>
+                  </SafeAnchor>
+                </ForwardRef>
+              </NavLink>
+            </div>
+          </Col>
+        </div>
+      </Row>
+      <EmployerQuestions
+        employerData={
           Object {
-            "$$typeof": Symbol(react.forward_ref),
-            "displayName": "SafeAnchor",
-            "render": [Function],
+            "address1": "e1 - address 1",
+            "address2": "",
+            "city": "city",
+            "employerName": "employer name 1",
+            "grossEarnings": "$200",
+            "id": "12345678",
+            "lastDateWorked": "02/22/2020",
+            "moreDetails": "",
+            "reason": "still-working",
+            "state": "CA",
+            "totalHoursWorked": "10",
+            "zipcode": "94100",
           }
         }
-        disabled={false}
-        onClick={[Function]}
+        onChange={[Function]}
       >
-        + Add another employer
-      </NavLink>
-    </Col>
-  </Row>
-</div>
+        <div
+          className="follow-up"
+        >
+          <FormGroup
+            className="mb-3"
+            controlId="12345678employerName"
+          >
+            <div
+              className="mb-3 form-group"
+            >
+              <FormLabel
+                column={false}
+                srOnly={false}
+              >
+                <label
+                  className="form-label"
+                  htmlFor="12345678employerName"
+                >
+                  Employer Name
+                </label>
+              </FormLabel>
+              <FormText
+                className="help-text"
+              >
+                <small
+                  className="help-text form-text"
+                >
+                  <Trans
+                    i18nKey="retrocerts-certification.employers.help-employerName"
+                    t={[Function]}
+                  >
+                    The employer's name that work was performed for this week.
+                  </Trans>
+                </small>
+              </FormText>
+              <FormControl
+                maxLength={500}
+                onChange={[Function]}
+                required={true}
+                type="text"
+                value="employer name 1"
+              >
+                <input
+                  className="form-control"
+                  id="12345678employerName"
+                  maxLength={500}
+                  onChange={[Function]}
+                  required={true}
+                  type="text"
+                  value="employer name 1"
+                />
+              </FormControl>
+              <Feedback
+                type="invalid"
+              >
+                <div
+                  className="invalid-feedback"
+                >
+                  This field is required.
+                </div>
+              </Feedback>
+            </div>
+          </FormGroup>
+          <FormGroup
+            className="mb-3"
+            controlId="12345678address1"
+          >
+            <div
+              className="mb-3 form-group"
+            >
+              <FormLabel
+                column={false}
+                srOnly={false}
+              >
+                <label
+                  className="form-label"
+                  htmlFor="12345678address1"
+                >
+                  Address Line 1
+                </label>
+              </FormLabel>
+              <FormText
+                className="help-text"
+              >
+                <small
+                  className="help-text form-text"
+                >
+                  <Trans
+                    i18nKey="retrocerts-certification.employers.help-address1"
+                    t={[Function]}
+                  >
+                    The employer's address that work was performed for this week.
+                  </Trans>
+                </small>
+              </FormText>
+              <FormControl
+                maxLength={500}
+                onChange={[Function]}
+                required={true}
+                type="text"
+                value="e1 - address 1"
+              >
+                <input
+                  className="form-control"
+                  id="12345678address1"
+                  maxLength={500}
+                  onChange={[Function]}
+                  required={true}
+                  type="text"
+                  value="e1 - address 1"
+                />
+              </FormControl>
+              <Feedback
+                type="invalid"
+              >
+                <div
+                  className="invalid-feedback"
+                >
+                  This field is required.
+                </div>
+              </Feedback>
+            </div>
+          </FormGroup>
+          <FormGroup
+            className="mb-3"
+            controlId="12345678address2"
+          >
+            <div
+              className="mb-3 form-group"
+            >
+              <FormLabel
+                column={false}
+                srOnly={false}
+              >
+                <label
+                  className="form-label"
+                  htmlFor="12345678address2"
+                >
+                  Address Line 2
+                </label>
+              </FormLabel>
+              <FormText
+                className="help-text"
+              >
+                <small
+                  className="help-text form-text"
+                >
+                  <Trans
+                    i18nKey="retrocerts-certification.employers.help-address2"
+                    t={[Function]}
+                  >
+                    The employer's suite, floor, etc. that work was performed for this week.
+                  </Trans>
+                </small>
+              </FormText>
+              <FormControl
+                maxLength={500}
+                onChange={[Function]}
+                required={false}
+                type="text"
+                value=""
+              >
+                <input
+                  className="form-control"
+                  id="12345678address2"
+                  maxLength={500}
+                  onChange={[Function]}
+                  required={false}
+                  type="text"
+                  value=""
+                />
+              </FormControl>
+              <Feedback
+                type="invalid"
+              >
+                <div
+                  className="invalid-feedback"
+                >
+                  This field is required.
+                </div>
+              </Feedback>
+            </div>
+          </FormGroup>
+          <FormRow>
+            <div
+              className="form-row"
+            >
+              <Col
+                md={8}
+              >
+                <div
+                  className="col-md-8"
+                >
+                  <FormGroup
+                    className="mb-3"
+                    controlId="12345678city"
+                  >
+                    <div
+                      className="mb-3 form-group"
+                    >
+                      <FormLabel
+                        column={false}
+                        srOnly={false}
+                      >
+                        <label
+                          className="form-label"
+                          htmlFor="12345678city"
+                        >
+                          City
+                        </label>
+                      </FormLabel>
+                      <FormText
+                        className="help-text"
+                      >
+                        <small
+                          className="help-text form-text"
+                        >
+                          <Trans
+                            i18nKey="retrocerts-certification.employers.help-city"
+                            t={[Function]}
+                          >
+                            The employer's city where work was performed for this week.
+                          </Trans>
+                        </small>
+                      </FormText>
+                      <FormControl
+                        maxLength={100}
+                        onChange={[Function]}
+                        required={true}
+                        type="text"
+                        value="city"
+                      >
+                        <input
+                          className="form-control"
+                          id="12345678city"
+                          maxLength={100}
+                          onChange={[Function]}
+                          required={true}
+                          type="text"
+                          value="city"
+                        />
+                      </FormControl>
+                      <Feedback
+                        type="invalid"
+                      >
+                        <div
+                          className="invalid-feedback"
+                        >
+                          This field is required.
+                        </div>
+                      </Feedback>
+                    </div>
+                  </FormGroup>
+                </div>
+              </Col>
+            </div>
+          </FormRow>
+          <FormRow
+            className="mb-3"
+          >
+            <div
+              className="mb-3 form-row"
+            >
+              <FormGroup
+                as={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Col",
+                    "render": [Function],
+                  }
+                }
+                className="col-md-8"
+                controlId="12345678state-select"
+              >
+                <Col
+                  className="col-md-8 form-group"
+                >
+                  <div
+                    className="col-md-8 form-group col"
+                  >
+                    <FormLabel
+                      column={false}
+                      srOnly={false}
+                    >
+                      <label
+                        className="form-label"
+                        htmlFor="12345678state-select"
+                      >
+                        State
+                      </label>
+                    </FormLabel>
+                    <FormText
+                      className="help-text"
+                    >
+                      <small
+                        className="help-text form-text"
+                      >
+                        The employer's state where work was performed for this week.
+                      </small>
+                    </FormText>
+                    <FormControl
+                      as="select"
+                      className="col-md-4"
+                      onChange={[Function]}
+                      required={true}
+                      value="CA"
+                    >
+                      <select
+                        className="col-md-4 form-control"
+                        id="12345678state-select"
+                        onChange={[Function]}
+                        required={true}
+                        value="CA"
+                      >
+                        <option />
+                        <option
+                          key="AK"
+                        >
+                          AK
+                        </option>
+                        <option
+                          key="AL"
+                        >
+                          AL
+                        </option>
+                        <option
+                          key="AR"
+                        >
+                          AR
+                        </option>
+                        <option
+                          key="AS"
+                        >
+                          AS
+                        </option>
+                        <option
+                          key="AZ"
+                        >
+                          AZ
+                        </option>
+                        <option
+                          key="CA"
+                        >
+                          CA
+                        </option>
+                        <option
+                          key="CO"
+                        >
+                          CO
+                        </option>
+                        <option
+                          key="CT"
+                        >
+                          CT
+                        </option>
+                        <option
+                          key="DC"
+                        >
+                          DC
+                        </option>
+                        <option
+                          key="DE"
+                        >
+                          DE
+                        </option>
+                        <option
+                          key="FL"
+                        >
+                          FL
+                        </option>
+                        <option
+                          key="FM"
+                        >
+                          FM
+                        </option>
+                        <option
+                          key="GA"
+                        >
+                          GA
+                        </option>
+                        <option
+                          key="GU"
+                        >
+                          GU
+                        </option>
+                        <option
+                          key="HI"
+                        >
+                          HI
+                        </option>
+                        <option
+                          key="IA"
+                        >
+                          IA
+                        </option>
+                        <option
+                          key="ID"
+                        >
+                          ID
+                        </option>
+                        <option
+                          key="IL"
+                        >
+                          IL
+                        </option>
+                        <option
+                          key="IN"
+                        >
+                          IN
+                        </option>
+                        <option
+                          key="KS"
+                        >
+                          KS
+                        </option>
+                        <option
+                          key="KY"
+                        >
+                          KY
+                        </option>
+                        <option
+                          key="LA"
+                        >
+                          LA
+                        </option>
+                        <option
+                          key="MA"
+                        >
+                          MA
+                        </option>
+                        <option
+                          key="MD"
+                        >
+                          MD
+                        </option>
+                        <option
+                          key="ME"
+                        >
+                          ME
+                        </option>
+                        <option
+                          key="MH"
+                        >
+                          MH
+                        </option>
+                        <option
+                          key="MI"
+                        >
+                          MI
+                        </option>
+                        <option
+                          key="MN"
+                        >
+                          MN
+                        </option>
+                        <option
+                          key="MO"
+                        >
+                          MO
+                        </option>
+                        <option
+                          key="MP"
+                        >
+                          MP
+                        </option>
+                        <option
+                          key="MS"
+                        >
+                          MS
+                        </option>
+                        <option
+                          key="MT"
+                        >
+                          MT
+                        </option>
+                        <option
+                          key="NC"
+                        >
+                          NC
+                        </option>
+                        <option
+                          key="ND"
+                        >
+                          ND
+                        </option>
+                        <option
+                          key="NE"
+                        >
+                          NE
+                        </option>
+                        <option
+                          key="NH"
+                        >
+                          NH
+                        </option>
+                        <option
+                          key="NJ"
+                        >
+                          NJ
+                        </option>
+                        <option
+                          key="NM"
+                        >
+                          NM
+                        </option>
+                        <option
+                          key="NV"
+                        >
+                          NV
+                        </option>
+                        <option
+                          key="NY"
+                        >
+                          NY
+                        </option>
+                        <option
+                          key="OH"
+                        >
+                          OH
+                        </option>
+                        <option
+                          key="OK"
+                        >
+                          OK
+                        </option>
+                        <option
+                          key="OR"
+                        >
+                          OR
+                        </option>
+                        <option
+                          key="PA"
+                        >
+                          PA
+                        </option>
+                        <option
+                          key="PR"
+                        >
+                          PR
+                        </option>
+                        <option
+                          key="PW"
+                        >
+                          PW
+                        </option>
+                        <option
+                          key="RI"
+                        >
+                          RI
+                        </option>
+                        <option
+                          key="SC"
+                        >
+                          SC
+                        </option>
+                        <option
+                          key="SD"
+                        >
+                          SD
+                        </option>
+                        <option
+                          key="TN"
+                        >
+                          TN
+                        </option>
+                        <option
+                          key="TX"
+                        >
+                          TX
+                        </option>
+                        <option
+                          key="UT"
+                        >
+                          UT
+                        </option>
+                        <option
+                          key="VA"
+                        >
+                          VA
+                        </option>
+                        <option
+                          key="VI"
+                        >
+                          VI
+                        </option>
+                        <option
+                          key="VT"
+                        >
+                          VT
+                        </option>
+                        <option
+                          key="WA"
+                        >
+                          WA
+                        </option>
+                        <option
+                          key="WI"
+                        >
+                          WI
+                        </option>
+                        <option
+                          key="WV"
+                        >
+                          WV
+                        </option>
+                        <option
+                          key="WY"
+                        >
+                          WY
+                        </option>
+                      </select>
+                    </FormControl>
+                    <Feedback
+                      type="invalid"
+                    >
+                      <div
+                        className="invalid-feedback"
+                      >
+                        This field is required.
+                      </div>
+                    </Feedback>
+                  </div>
+                </Col>
+              </FormGroup>
+            </div>
+          </FormRow>
+          <FormGroup
+            className="mb-3"
+            controlId="12345678zipcode"
+          >
+            <div
+              className="mb-3 form-group"
+            >
+              <FormLabel
+                column={false}
+                srOnly={false}
+              >
+                <label
+                  className="form-label"
+                  htmlFor="12345678zipcode"
+                >
+                  ZIP
+                </label>
+              </FormLabel>
+              <FormText
+                className="help-text"
+              >
+                <small
+                  className="help-text form-text"
+                >
+                  <Trans
+                    i18nKey="retrocerts-certification.employers.help-zipcode"
+                    t={[Function]}
+                  >
+                    The employer's ZIP code where work was performed for this week. 
+                    <p
+                      key="p-1"
+                    >
+                      Enter as ##### or #####-####.
+                    </p>
+                  </Trans>
+                </small>
+              </FormText>
+              <FormControl
+                className="col-md-3"
+                maxLength={10}
+                onChange={[Function]}
+                pattern="\\\\d{5}|\\\\d{5}-\\\\d{4}"
+                required={true}
+                type="text"
+                value="94100"
+              >
+                <input
+                  className="col-md-3 form-control"
+                  id="12345678zipcode"
+                  maxLength={10}
+                  onChange={[Function]}
+                  pattern="\\\\d{5}|\\\\d{5}-\\\\d{4}"
+                  required={true}
+                  type="text"
+                  value="94100"
+                />
+              </FormControl>
+              <Feedback
+                type="invalid"
+              >
+                <div
+                  className="invalid-feedback"
+                >
+                  This field is required.
+                </div>
+              </Feedback>
+            </div>
+          </FormGroup>
+          <p>
+            Last Date Worked
+          </p>
+          <small
+            className="help-text"
+          >
+            The last day worked in this certification week.
+          </small>
+          <FormRow
+            className="mb-3"
+          >
+            <div
+              className="mb-3 form-row"
+            >
+              <FormGroup
+                as={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Col",
+                    "render": [Function],
+                  }
+                }
+                controlId="12345678lastDateWorked-month-question"
+                md={2}
+              >
+                <Col
+                  className="form-group"
+                  md={2}
+                >
+                  <div
+                    className="form-group col-md-2"
+                  >
+                    <FormLabel
+                      column={false}
+                      srOnly={false}
+                    >
+                      <label
+                        className="form-label"
+                        htmlFor="12345678lastDateWorked-month-question"
+                      >
+                        Month
+                      </label>
+                    </FormLabel>
+                    <FormControl
+                      maxLength={2}
+                      onChange={[Function]}
+                      pattern="(^0[1-9])|(^1[0-2])|(^[1-9]$)"
+                      required={true}
+                      type="text"
+                      value="02"
+                    >
+                      <input
+                        className="form-control"
+                        id="12345678lastDateWorked-month-question"
+                        maxLength={2}
+                        onChange={[Function]}
+                        pattern="(^0[1-9])|(^1[0-2])|(^[1-9]$)"
+                        required={true}
+                        type="text"
+                        value="02"
+                      />
+                    </FormControl>
+                    <Feedback
+                      type="invalid"
+                    >
+                      <div
+                        className="invalid-feedback"
+                      >
+                        This field is required.
+                      </div>
+                    </Feedback>
+                  </div>
+                </Col>
+              </FormGroup>
+              <FormGroup
+                as={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Col",
+                    "render": [Function],
+                  }
+                }
+                controlId="12345678lastDateWorked-day-question"
+                md={2}
+              >
+                <Col
+                  className="form-group"
+                  md={2}
+                >
+                  <div
+                    className="form-group col-md-2"
+                  >
+                    <FormLabel
+                      column={false}
+                      srOnly={false}
+                    >
+                      <label
+                        className="form-label"
+                        htmlFor="12345678lastDateWorked-day-question"
+                      >
+                        Day
+                      </label>
+                    </FormLabel>
+                    <FormControl
+                      maxLength={2}
+                      onChange={[Function]}
+                      pattern="(^0[1-9])|(^1[0-9])|(^2[0-9])|(^3[0-1])|(^[1-9]$)"
+                      required={true}
+                      type="text"
+                      value="22"
+                    >
+                      <input
+                        className="form-control"
+                        id="12345678lastDateWorked-day-question"
+                        maxLength={2}
+                        onChange={[Function]}
+                        pattern="(^0[1-9])|(^1[0-9])|(^2[0-9])|(^3[0-1])|(^[1-9]$)"
+                        required={true}
+                        type="text"
+                        value="22"
+                      />
+                    </FormControl>
+                    <Feedback
+                      type="invalid"
+                    >
+                      <div
+                        className="invalid-feedback"
+                      >
+                        This field is required.
+                      </div>
+                    </Feedback>
+                  </div>
+                </Col>
+              </FormGroup>
+              <FormGroup
+                as={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Col",
+                    "render": [Function],
+                  }
+                }
+                md={2}
+              >
+                <Col
+                  className="form-group"
+                  md={2}
+                >
+                  <div
+                    className="form-group col-md-2"
+                  >
+                    <FormLabel
+                      column={false}
+                      srOnly={false}
+                    >
+                      <label
+                        className="form-label"
+                      >
+                        Year
+                      </label>
+                    </FormLabel>
+                    <FormControl
+                      disabled={true}
+                      type="text"
+                      value="2020"
+                    >
+                      <input
+                        className="form-control"
+                        disabled={true}
+                        type="text"
+                        value="2020"
+                      />
+                    </FormControl>
+                  </div>
+                </Col>
+              </FormGroup>
+            </div>
+          </FormRow>
+          <FormGroup
+            className="mb-3"
+            controlId="12345678totalHoursWorked"
+          >
+            <div
+              className="mb-3 form-group"
+            >
+              <FormLabel
+                column={false}
+                srOnly={false}
+              >
+                <label
+                  className="form-label"
+                  htmlFor="12345678totalHoursWorked"
+                >
+                  Total hours worked for this employer
+                </label>
+              </FormLabel>
+              <FormText
+                className="help-text"
+              >
+                <small
+                  className="help-text form-text"
+                >
+                  <Trans
+                    i18nKey="retrocerts-certification.employers.help-totalHoursWorked"
+                    t={[Function]}
+                  >
+                    Report the hours worked in this week for this employer.
+                  </Trans>
+                </small>
+              </FormText>
+              <FormControl
+                className="col-md-2"
+                maxLength={6}
+                onChange={[Function]}
+                pattern="\\\\d+[.]?\\\\d*"
+                required={true}
+                type="text"
+                value="10"
+              >
+                <input
+                  className="col-md-2 form-control"
+                  id="12345678totalHoursWorked"
+                  maxLength={6}
+                  onChange={[Function]}
+                  pattern="\\\\d+[.]?\\\\d*"
+                  required={true}
+                  type="text"
+                  value="10"
+                />
+              </FormControl>
+              <Feedback
+                type="invalid"
+              >
+                <div
+                  className="invalid-feedback"
+                >
+                  This field is required.
+                </div>
+              </Feedback>
+            </div>
+          </FormGroup>
+          <FormGroup
+            className="mb-3"
+            controlId="12345678grossEarnings"
+          >
+            <div
+              className="mb-3 form-group"
+            >
+              <FormLabel
+                column={false}
+                srOnly={false}
+              >
+                <label
+                  className="form-label"
+                  htmlFor="12345678grossEarnings"
+                >
+                  Gross earnings before deductions for this employer (whether you were paid or not)
+                </label>
+              </FormLabel>
+              <FormText
+                className="help-text"
+              >
+                <small
+                  className="help-text form-text"
+                >
+                  <Trans
+                    i18nKey="retrocerts-certification.employers.help-grossEarnings"
+                    t={[Function]}
+                  >
+                    Full earnings without deductions.
+                  </Trans>
+                </small>
+              </FormText>
+              <FormControl
+                className="col-md-2"
+                maxLength={11}
+                onChange={[Function]}
+                pattern="^\\\\$?(([1-9](\\\\d*|\\\\d{0,2}(,\\\\d{3})*))|0)(\\\\.\\\\d{2})?$"
+                required={true}
+                type="text"
+                value="$200"
+              >
+                <input
+                  className="col-md-2 form-control"
+                  id="12345678grossEarnings"
+                  maxLength={11}
+                  onChange={[Function]}
+                  pattern="^\\\\$?(([1-9](\\\\d*|\\\\d{0,2}(,\\\\d{3})*))|0)(\\\\.\\\\d{2})?$"
+                  required={true}
+                  type="text"
+                  value="$200"
+                />
+              </FormControl>
+              <Feedback
+                type="invalid"
+              >
+                <div
+                  className="invalid-feedback"
+                >
+                  This field is required.
+                </div>
+              </Feedback>
+            </div>
+          </FormGroup>
+          <FormGroup
+            controlId="12345678reason-select"
+          >
+            <div
+              className="form-group"
+            >
+              <FormLabel
+                column={false}
+                srOnly={false}
+              >
+                <label
+                  className="form-label"
+                  htmlFor="12345678reason-select"
+                >
+                  Select the reason you are no longer working:
+                </label>
+              </FormLabel>
+              <FormControl
+                as="select"
+                onChange={[Function]}
+                value="still-working"
+              >
+                <select
+                  className="form-control"
+                  id="12345678reason-select"
+                  onChange={[Function]}
+                  value="still-working"
+                >
+                  <option
+                    key="fired"
+                    value="fired"
+                  >
+                    Terminated or Fired
+                  </option>
+                  <option
+                    key="quit"
+                    value="quit"
+                  >
+                    Quit
+                  </option>
+                  <option
+                    key="laid-off"
+                    value="laid-off"
+                  >
+                    Laid Off
+                  </option>
+                  <option
+                    key="still-working"
+                    value="still-working"
+                  >
+                    Still Working Part Time
+                  </option>
+                </select>
+              </FormControl>
+            </div>
+          </FormGroup>
+        </div>
+      </EmployerQuestions>
+    </div>
+    <div
+      key="employerData22222222"
+    >
+      <hr />
+      <Row
+        className="align-items-baseline"
+        noGutters={false}
+      >
+        <div
+          className="align-items-baseline row"
+        >
+          <Col
+            md="auto"
+          >
+            <div
+              className="col-md-auto"
+            >
+              <h3>
+                <Trans
+                  i18nKey="retrocerts-certification.employers.heading"
+                  t={[Function]}
+                  values={
+                    Object {
+                      "incomeNumber": 2,
+                    }
+                  }
+                >
+                  Employer 2
+                </Trans>
+              </h3>
+            </div>
+          </Col>
+          <Col
+            md="auto"
+          >
+            <div
+              className="col-md-auto"
+            >
+              <NavLink
+                as={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "SafeAnchor",
+                    "render": [Function],
+                  }
+                }
+                disabled={false}
+                onClick={[Function]}
+              >
+                <ForwardRef
+                  as={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "displayName": "SafeAnchor",
+                      "render": [Function],
+                    }
+                  }
+                  className="nav-link"
+                  disabled={false}
+                  onClick={[Function]}
+                >
+                  <SafeAnchor
+                    className="nav-link"
+                    disabled={false}
+                    onClick={[Function]}
+                  >
+                    <a
+                      className="nav-link"
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="button"
+                    >
+                      Remove this employer
+                    </a>
+                  </SafeAnchor>
+                </ForwardRef>
+              </NavLink>
+            </div>
+          </Col>
+        </div>
+      </Row>
+      <EmployerQuestions
+        employerData={
+          Object {
+            "address1": "e2 - address 1",
+            "address2": "",
+            "city": "city 2",
+            "employerName": "employer name 2",
+            "grossEarnings": "$300",
+            "id": "22222222",
+            "lastDateWorked": "02/24/2020",
+            "moreDetails": "unable to travel",
+            "reason": "quit",
+            "state": "OR",
+            "totalHoursWorked": "12",
+            "zipcode": "97035",
+          }
+        }
+        onChange={[Function]}
+      >
+        <div
+          className="follow-up"
+        >
+          <FormGroup
+            className="mb-3"
+            controlId="22222222employerName"
+          >
+            <div
+              className="mb-3 form-group"
+            >
+              <FormLabel
+                column={false}
+                srOnly={false}
+              >
+                <label
+                  className="form-label"
+                  htmlFor="22222222employerName"
+                >
+                  Employer Name
+                </label>
+              </FormLabel>
+              <FormText
+                className="help-text"
+              >
+                <small
+                  className="help-text form-text"
+                >
+                  <Trans
+                    i18nKey="retrocerts-certification.employers.help-employerName"
+                    t={[Function]}
+                  >
+                    The employer's name that work was performed for this week.
+                  </Trans>
+                </small>
+              </FormText>
+              <FormControl
+                maxLength={500}
+                onChange={[Function]}
+                required={true}
+                type="text"
+                value="employer name 2"
+              >
+                <input
+                  className="form-control"
+                  id="22222222employerName"
+                  maxLength={500}
+                  onChange={[Function]}
+                  required={true}
+                  type="text"
+                  value="employer name 2"
+                />
+              </FormControl>
+              <Feedback
+                type="invalid"
+              >
+                <div
+                  className="invalid-feedback"
+                >
+                  This field is required.
+                </div>
+              </Feedback>
+            </div>
+          </FormGroup>
+          <FormGroup
+            className="mb-3"
+            controlId="22222222address1"
+          >
+            <div
+              className="mb-3 form-group"
+            >
+              <FormLabel
+                column={false}
+                srOnly={false}
+              >
+                <label
+                  className="form-label"
+                  htmlFor="22222222address1"
+                >
+                  Address Line 1
+                </label>
+              </FormLabel>
+              <FormText
+                className="help-text"
+              >
+                <small
+                  className="help-text form-text"
+                >
+                  <Trans
+                    i18nKey="retrocerts-certification.employers.help-address1"
+                    t={[Function]}
+                  >
+                    The employer's address that work was performed for this week.
+                  </Trans>
+                </small>
+              </FormText>
+              <FormControl
+                maxLength={500}
+                onChange={[Function]}
+                required={true}
+                type="text"
+                value="e2 - address 1"
+              >
+                <input
+                  className="form-control"
+                  id="22222222address1"
+                  maxLength={500}
+                  onChange={[Function]}
+                  required={true}
+                  type="text"
+                  value="e2 - address 1"
+                />
+              </FormControl>
+              <Feedback
+                type="invalid"
+              >
+                <div
+                  className="invalid-feedback"
+                >
+                  This field is required.
+                </div>
+              </Feedback>
+            </div>
+          </FormGroup>
+          <FormGroup
+            className="mb-3"
+            controlId="22222222address2"
+          >
+            <div
+              className="mb-3 form-group"
+            >
+              <FormLabel
+                column={false}
+                srOnly={false}
+              >
+                <label
+                  className="form-label"
+                  htmlFor="22222222address2"
+                >
+                  Address Line 2
+                </label>
+              </FormLabel>
+              <FormText
+                className="help-text"
+              >
+                <small
+                  className="help-text form-text"
+                >
+                  <Trans
+                    i18nKey="retrocerts-certification.employers.help-address2"
+                    t={[Function]}
+                  >
+                    The employer's suite, floor, etc. that work was performed for this week.
+                  </Trans>
+                </small>
+              </FormText>
+              <FormControl
+                maxLength={500}
+                onChange={[Function]}
+                required={false}
+                type="text"
+                value=""
+              >
+                <input
+                  className="form-control"
+                  id="22222222address2"
+                  maxLength={500}
+                  onChange={[Function]}
+                  required={false}
+                  type="text"
+                  value=""
+                />
+              </FormControl>
+              <Feedback
+                type="invalid"
+              >
+                <div
+                  className="invalid-feedback"
+                >
+                  This field is required.
+                </div>
+              </Feedback>
+            </div>
+          </FormGroup>
+          <FormRow>
+            <div
+              className="form-row"
+            >
+              <Col
+                md={8}
+              >
+                <div
+                  className="col-md-8"
+                >
+                  <FormGroup
+                    className="mb-3"
+                    controlId="22222222city"
+                  >
+                    <div
+                      className="mb-3 form-group"
+                    >
+                      <FormLabel
+                        column={false}
+                        srOnly={false}
+                      >
+                        <label
+                          className="form-label"
+                          htmlFor="22222222city"
+                        >
+                          City
+                        </label>
+                      </FormLabel>
+                      <FormText
+                        className="help-text"
+                      >
+                        <small
+                          className="help-text form-text"
+                        >
+                          <Trans
+                            i18nKey="retrocerts-certification.employers.help-city"
+                            t={[Function]}
+                          >
+                            The employer's city where work was performed for this week.
+                          </Trans>
+                        </small>
+                      </FormText>
+                      <FormControl
+                        maxLength={100}
+                        onChange={[Function]}
+                        required={true}
+                        type="text"
+                        value="city 2"
+                      >
+                        <input
+                          className="form-control"
+                          id="22222222city"
+                          maxLength={100}
+                          onChange={[Function]}
+                          required={true}
+                          type="text"
+                          value="city 2"
+                        />
+                      </FormControl>
+                      <Feedback
+                        type="invalid"
+                      >
+                        <div
+                          className="invalid-feedback"
+                        >
+                          This field is required.
+                        </div>
+                      </Feedback>
+                    </div>
+                  </FormGroup>
+                </div>
+              </Col>
+            </div>
+          </FormRow>
+          <FormRow
+            className="mb-3"
+          >
+            <div
+              className="mb-3 form-row"
+            >
+              <FormGroup
+                as={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Col",
+                    "render": [Function],
+                  }
+                }
+                className="col-md-8"
+                controlId="22222222state-select"
+              >
+                <Col
+                  className="col-md-8 form-group"
+                >
+                  <div
+                    className="col-md-8 form-group col"
+                  >
+                    <FormLabel
+                      column={false}
+                      srOnly={false}
+                    >
+                      <label
+                        className="form-label"
+                        htmlFor="22222222state-select"
+                      >
+                        State
+                      </label>
+                    </FormLabel>
+                    <FormText
+                      className="help-text"
+                    >
+                      <small
+                        className="help-text form-text"
+                      >
+                        The employer's state where work was performed for this week.
+                      </small>
+                    </FormText>
+                    <FormControl
+                      as="select"
+                      className="col-md-4"
+                      onChange={[Function]}
+                      required={true}
+                      value="OR"
+                    >
+                      <select
+                        className="col-md-4 form-control"
+                        id="22222222state-select"
+                        onChange={[Function]}
+                        required={true}
+                        value="OR"
+                      >
+                        <option />
+                        <option
+                          key="AK"
+                        >
+                          AK
+                        </option>
+                        <option
+                          key="AL"
+                        >
+                          AL
+                        </option>
+                        <option
+                          key="AR"
+                        >
+                          AR
+                        </option>
+                        <option
+                          key="AS"
+                        >
+                          AS
+                        </option>
+                        <option
+                          key="AZ"
+                        >
+                          AZ
+                        </option>
+                        <option
+                          key="CA"
+                        >
+                          CA
+                        </option>
+                        <option
+                          key="CO"
+                        >
+                          CO
+                        </option>
+                        <option
+                          key="CT"
+                        >
+                          CT
+                        </option>
+                        <option
+                          key="DC"
+                        >
+                          DC
+                        </option>
+                        <option
+                          key="DE"
+                        >
+                          DE
+                        </option>
+                        <option
+                          key="FL"
+                        >
+                          FL
+                        </option>
+                        <option
+                          key="FM"
+                        >
+                          FM
+                        </option>
+                        <option
+                          key="GA"
+                        >
+                          GA
+                        </option>
+                        <option
+                          key="GU"
+                        >
+                          GU
+                        </option>
+                        <option
+                          key="HI"
+                        >
+                          HI
+                        </option>
+                        <option
+                          key="IA"
+                        >
+                          IA
+                        </option>
+                        <option
+                          key="ID"
+                        >
+                          ID
+                        </option>
+                        <option
+                          key="IL"
+                        >
+                          IL
+                        </option>
+                        <option
+                          key="IN"
+                        >
+                          IN
+                        </option>
+                        <option
+                          key="KS"
+                        >
+                          KS
+                        </option>
+                        <option
+                          key="KY"
+                        >
+                          KY
+                        </option>
+                        <option
+                          key="LA"
+                        >
+                          LA
+                        </option>
+                        <option
+                          key="MA"
+                        >
+                          MA
+                        </option>
+                        <option
+                          key="MD"
+                        >
+                          MD
+                        </option>
+                        <option
+                          key="ME"
+                        >
+                          ME
+                        </option>
+                        <option
+                          key="MH"
+                        >
+                          MH
+                        </option>
+                        <option
+                          key="MI"
+                        >
+                          MI
+                        </option>
+                        <option
+                          key="MN"
+                        >
+                          MN
+                        </option>
+                        <option
+                          key="MO"
+                        >
+                          MO
+                        </option>
+                        <option
+                          key="MP"
+                        >
+                          MP
+                        </option>
+                        <option
+                          key="MS"
+                        >
+                          MS
+                        </option>
+                        <option
+                          key="MT"
+                        >
+                          MT
+                        </option>
+                        <option
+                          key="NC"
+                        >
+                          NC
+                        </option>
+                        <option
+                          key="ND"
+                        >
+                          ND
+                        </option>
+                        <option
+                          key="NE"
+                        >
+                          NE
+                        </option>
+                        <option
+                          key="NH"
+                        >
+                          NH
+                        </option>
+                        <option
+                          key="NJ"
+                        >
+                          NJ
+                        </option>
+                        <option
+                          key="NM"
+                        >
+                          NM
+                        </option>
+                        <option
+                          key="NV"
+                        >
+                          NV
+                        </option>
+                        <option
+                          key="NY"
+                        >
+                          NY
+                        </option>
+                        <option
+                          key="OH"
+                        >
+                          OH
+                        </option>
+                        <option
+                          key="OK"
+                        >
+                          OK
+                        </option>
+                        <option
+                          key="OR"
+                        >
+                          OR
+                        </option>
+                        <option
+                          key="PA"
+                        >
+                          PA
+                        </option>
+                        <option
+                          key="PR"
+                        >
+                          PR
+                        </option>
+                        <option
+                          key="PW"
+                        >
+                          PW
+                        </option>
+                        <option
+                          key="RI"
+                        >
+                          RI
+                        </option>
+                        <option
+                          key="SC"
+                        >
+                          SC
+                        </option>
+                        <option
+                          key="SD"
+                        >
+                          SD
+                        </option>
+                        <option
+                          key="TN"
+                        >
+                          TN
+                        </option>
+                        <option
+                          key="TX"
+                        >
+                          TX
+                        </option>
+                        <option
+                          key="UT"
+                        >
+                          UT
+                        </option>
+                        <option
+                          key="VA"
+                        >
+                          VA
+                        </option>
+                        <option
+                          key="VI"
+                        >
+                          VI
+                        </option>
+                        <option
+                          key="VT"
+                        >
+                          VT
+                        </option>
+                        <option
+                          key="WA"
+                        >
+                          WA
+                        </option>
+                        <option
+                          key="WI"
+                        >
+                          WI
+                        </option>
+                        <option
+                          key="WV"
+                        >
+                          WV
+                        </option>
+                        <option
+                          key="WY"
+                        >
+                          WY
+                        </option>
+                      </select>
+                    </FormControl>
+                    <Feedback
+                      type="invalid"
+                    >
+                      <div
+                        className="invalid-feedback"
+                      >
+                        This field is required.
+                      </div>
+                    </Feedback>
+                  </div>
+                </Col>
+              </FormGroup>
+            </div>
+          </FormRow>
+          <FormGroup
+            className="mb-3"
+            controlId="22222222zipcode"
+          >
+            <div
+              className="mb-3 form-group"
+            >
+              <FormLabel
+                column={false}
+                srOnly={false}
+              >
+                <label
+                  className="form-label"
+                  htmlFor="22222222zipcode"
+                >
+                  ZIP
+                </label>
+              </FormLabel>
+              <FormText
+                className="help-text"
+              >
+                <small
+                  className="help-text form-text"
+                >
+                  <Trans
+                    i18nKey="retrocerts-certification.employers.help-zipcode"
+                    t={[Function]}
+                  >
+                    The employer's ZIP code where work was performed for this week. 
+                    <p
+                      key="p-1"
+                    >
+                      Enter as ##### or #####-####.
+                    </p>
+                  </Trans>
+                </small>
+              </FormText>
+              <FormControl
+                className="col-md-3"
+                maxLength={10}
+                onChange={[Function]}
+                pattern="\\\\d{5}|\\\\d{5}-\\\\d{4}"
+                required={true}
+                type="text"
+                value="97035"
+              >
+                <input
+                  className="col-md-3 form-control"
+                  id="22222222zipcode"
+                  maxLength={10}
+                  onChange={[Function]}
+                  pattern="\\\\d{5}|\\\\d{5}-\\\\d{4}"
+                  required={true}
+                  type="text"
+                  value="97035"
+                />
+              </FormControl>
+              <Feedback
+                type="invalid"
+              >
+                <div
+                  className="invalid-feedback"
+                >
+                  This field is required.
+                </div>
+              </Feedback>
+            </div>
+          </FormGroup>
+          <p>
+            Last Date Worked
+          </p>
+          <small
+            className="help-text"
+          >
+            The last day worked in this certification week.
+          </small>
+          <FormRow
+            className="mb-3"
+          >
+            <div
+              className="mb-3 form-row"
+            >
+              <FormGroup
+                as={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Col",
+                    "render": [Function],
+                  }
+                }
+                controlId="22222222lastDateWorked-month-question"
+                md={2}
+              >
+                <Col
+                  className="form-group"
+                  md={2}
+                >
+                  <div
+                    className="form-group col-md-2"
+                  >
+                    <FormLabel
+                      column={false}
+                      srOnly={false}
+                    >
+                      <label
+                        className="form-label"
+                        htmlFor="22222222lastDateWorked-month-question"
+                      >
+                        Month
+                      </label>
+                    </FormLabel>
+                    <FormControl
+                      maxLength={2}
+                      onChange={[Function]}
+                      pattern="(^0[1-9])|(^1[0-2])|(^[1-9]$)"
+                      required={true}
+                      type="text"
+                      value="02"
+                    >
+                      <input
+                        className="form-control"
+                        id="22222222lastDateWorked-month-question"
+                        maxLength={2}
+                        onChange={[Function]}
+                        pattern="(^0[1-9])|(^1[0-2])|(^[1-9]$)"
+                        required={true}
+                        type="text"
+                        value="02"
+                      />
+                    </FormControl>
+                    <Feedback
+                      type="invalid"
+                    >
+                      <div
+                        className="invalid-feedback"
+                      >
+                        This field is required.
+                      </div>
+                    </Feedback>
+                  </div>
+                </Col>
+              </FormGroup>
+              <FormGroup
+                as={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Col",
+                    "render": [Function],
+                  }
+                }
+                controlId="22222222lastDateWorked-day-question"
+                md={2}
+              >
+                <Col
+                  className="form-group"
+                  md={2}
+                >
+                  <div
+                    className="form-group col-md-2"
+                  >
+                    <FormLabel
+                      column={false}
+                      srOnly={false}
+                    >
+                      <label
+                        className="form-label"
+                        htmlFor="22222222lastDateWorked-day-question"
+                      >
+                        Day
+                      </label>
+                    </FormLabel>
+                    <FormControl
+                      maxLength={2}
+                      onChange={[Function]}
+                      pattern="(^0[1-9])|(^1[0-9])|(^2[0-9])|(^3[0-1])|(^[1-9]$)"
+                      required={true}
+                      type="text"
+                      value="24"
+                    >
+                      <input
+                        className="form-control"
+                        id="22222222lastDateWorked-day-question"
+                        maxLength={2}
+                        onChange={[Function]}
+                        pattern="(^0[1-9])|(^1[0-9])|(^2[0-9])|(^3[0-1])|(^[1-9]$)"
+                        required={true}
+                        type="text"
+                        value="24"
+                      />
+                    </FormControl>
+                    <Feedback
+                      type="invalid"
+                    >
+                      <div
+                        className="invalid-feedback"
+                      >
+                        This field is required.
+                      </div>
+                    </Feedback>
+                  </div>
+                </Col>
+              </FormGroup>
+              <FormGroup
+                as={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Col",
+                    "render": [Function],
+                  }
+                }
+                md={2}
+              >
+                <Col
+                  className="form-group"
+                  md={2}
+                >
+                  <div
+                    className="form-group col-md-2"
+                  >
+                    <FormLabel
+                      column={false}
+                      srOnly={false}
+                    >
+                      <label
+                        className="form-label"
+                      >
+                        Year
+                      </label>
+                    </FormLabel>
+                    <FormControl
+                      disabled={true}
+                      type="text"
+                      value="2020"
+                    >
+                      <input
+                        className="form-control"
+                        disabled={true}
+                        type="text"
+                        value="2020"
+                      />
+                    </FormControl>
+                  </div>
+                </Col>
+              </FormGroup>
+            </div>
+          </FormRow>
+          <FormGroup
+            className="mb-3"
+            controlId="22222222totalHoursWorked"
+          >
+            <div
+              className="mb-3 form-group"
+            >
+              <FormLabel
+                column={false}
+                srOnly={false}
+              >
+                <label
+                  className="form-label"
+                  htmlFor="22222222totalHoursWorked"
+                >
+                  Total hours worked for this employer
+                </label>
+              </FormLabel>
+              <FormText
+                className="help-text"
+              >
+                <small
+                  className="help-text form-text"
+                >
+                  <Trans
+                    i18nKey="retrocerts-certification.employers.help-totalHoursWorked"
+                    t={[Function]}
+                  >
+                    Report the hours worked in this week for this employer.
+                  </Trans>
+                </small>
+              </FormText>
+              <FormControl
+                className="col-md-2"
+                maxLength={6}
+                onChange={[Function]}
+                pattern="\\\\d+[.]?\\\\d*"
+                required={true}
+                type="text"
+                value="12"
+              >
+                <input
+                  className="col-md-2 form-control"
+                  id="22222222totalHoursWorked"
+                  maxLength={6}
+                  onChange={[Function]}
+                  pattern="\\\\d+[.]?\\\\d*"
+                  required={true}
+                  type="text"
+                  value="12"
+                />
+              </FormControl>
+              <Feedback
+                type="invalid"
+              >
+                <div
+                  className="invalid-feedback"
+                >
+                  This field is required.
+                </div>
+              </Feedback>
+            </div>
+          </FormGroup>
+          <FormGroup
+            className="mb-3"
+            controlId="22222222grossEarnings"
+          >
+            <div
+              className="mb-3 form-group"
+            >
+              <FormLabel
+                column={false}
+                srOnly={false}
+              >
+                <label
+                  className="form-label"
+                  htmlFor="22222222grossEarnings"
+                >
+                  Gross earnings before deductions for this employer (whether you were paid or not)
+                </label>
+              </FormLabel>
+              <FormText
+                className="help-text"
+              >
+                <small
+                  className="help-text form-text"
+                >
+                  <Trans
+                    i18nKey="retrocerts-certification.employers.help-grossEarnings"
+                    t={[Function]}
+                  >
+                    Full earnings without deductions.
+                  </Trans>
+                </small>
+              </FormText>
+              <FormControl
+                className="col-md-2"
+                maxLength={11}
+                onChange={[Function]}
+                pattern="^\\\\$?(([1-9](\\\\d*|\\\\d{0,2}(,\\\\d{3})*))|0)(\\\\.\\\\d{2})?$"
+                required={true}
+                type="text"
+                value="$300"
+              >
+                <input
+                  className="col-md-2 form-control"
+                  id="22222222grossEarnings"
+                  maxLength={11}
+                  onChange={[Function]}
+                  pattern="^\\\\$?(([1-9](\\\\d*|\\\\d{0,2}(,\\\\d{3})*))|0)(\\\\.\\\\d{2})?$"
+                  required={true}
+                  type="text"
+                  value="$300"
+                />
+              </FormControl>
+              <Feedback
+                type="invalid"
+              >
+                <div
+                  className="invalid-feedback"
+                >
+                  This field is required.
+                </div>
+              </Feedback>
+            </div>
+          </FormGroup>
+          <FormGroup
+            controlId="22222222reason-select"
+          >
+            <div
+              className="form-group"
+            >
+              <FormLabel
+                column={false}
+                srOnly={false}
+              >
+                <label
+                  className="form-label"
+                  htmlFor="22222222reason-select"
+                >
+                  Select the reason you are no longer working:
+                </label>
+              </FormLabel>
+              <FormControl
+                as="select"
+                onChange={[Function]}
+                value="quit"
+              >
+                <select
+                  className="form-control"
+                  id="22222222reason-select"
+                  onChange={[Function]}
+                  value="quit"
+                >
+                  <option
+                    key="fired"
+                    value="fired"
+                  >
+                    Terminated or Fired
+                  </option>
+                  <option
+                    key="quit"
+                    value="quit"
+                  >
+                    Quit
+                  </option>
+                  <option
+                    key="laid-off"
+                    value="laid-off"
+                  >
+                    Laid Off
+                  </option>
+                  <option
+                    key="still-working"
+                    value="still-working"
+                  >
+                    Still Working Part Time
+                  </option>
+                </select>
+              </FormControl>
+            </div>
+          </FormGroup>
+          <FormGroup
+            controlId="22222222reason-details"
+          >
+            <div
+              className="form-group"
+            >
+              <FormLabel
+                column={false}
+                srOnly={false}
+              >
+                <label
+                  className="form-label"
+                  htmlFor="22222222reason-details"
+                >
+                  Provide more details.
+                </label>
+              </FormLabel>
+              <FormText
+                className="help-text"
+              >
+                <small
+                  className="help-text form-text"
+                >
+                  Provide a specific reason why you are no longer working.
+                </small>
+              </FormText>
+              <FormControl
+                as="textarea"
+                maxLength={2000}
+                onChange={[Function]}
+                required={true}
+                rows="3"
+                value="unable to travel"
+              >
+                <textarea
+                  className="form-control"
+                  id="22222222reason-details"
+                  maxLength={2000}
+                  onChange={[Function]}
+                  required={true}
+                  rows="3"
+                  value="unable to travel"
+                />
+              </FormControl>
+            </div>
+          </FormGroup>
+        </div>
+      </EmployerQuestions>
+    </div>
+    <hr />
+    <Row
+      noGutters={false}
+    >
+      <div
+        className="row"
+      >
+        <Col
+          md="auto"
+        >
+          <div
+            className="col-md-auto"
+          >
+            <NavLink
+              as={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "displayName": "SafeAnchor",
+                  "render": [Function],
+                }
+              }
+              disabled={false}
+              onClick={[Function]}
+            >
+              <ForwardRef
+                as={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "SafeAnchor",
+                    "render": [Function],
+                  }
+                }
+                className="nav-link"
+                disabled={false}
+                onClick={[Function]}
+              >
+                <SafeAnchor
+                  className="nav-link"
+                  disabled={false}
+                  onClick={[Function]}
+                >
+                  <a
+                    className="nav-link"
+                    href="#"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="button"
+                  >
+                    + Add another employer
+                  </a>
+                </SafeAnchor>
+              </ForwardRef>
+            </NavLink>
+          </div>
+        </Col>
+      </div>
+    </Row>
+  </div>
+</EmployersQuestions>
 `;

--- a/src/client/components/EmployersQuestions/index.test.js
+++ b/src/client/components/EmployersQuestions/index.test.js
@@ -1,9 +1,9 @@
-import renderNonTransContent from "../../test-helpers/renderNonTransContent";
+import renderTransContent from "../../test-helpers/renderTransContent";
 import Component from "./index";
 
 describe("<EmployersQuestions />", () => {
   it("renders the component", async () => {
-    const wrapper = renderNonTransContent(Component, "EmployersQuestions", {
+    const wrapper = renderTransContent(Component, {
       onChange: () => {},
     });
 
@@ -11,7 +11,7 @@ describe("<EmployersQuestions />", () => {
   });
 
   it("renders with 2 income sources", async () => {
-    const wrapper = renderNonTransContent(Component, "EmployersQuestions", {
+    const wrapper = renderTransContent(Component, {
       onChange: () => {},
       employers: [
         {

--- a/src/client/components/Footer/index.test.js
+++ b/src/client/components/Footer/index.test.js
@@ -3,7 +3,7 @@ import Component from "./index";
 
 describe("<Footer />", () => {
   it("renders the component", async () => {
-    const wrapper = renderNonTransContent(Component, "Footer", {
+    const wrapper = renderNonTransContent(Component, {
       backToTopTag: "back-to-top",
     });
 

--- a/src/client/components/Header/index.test.js
+++ b/src/client/components/Header/index.test.js
@@ -3,7 +3,7 @@ import Component from "./index";
 
 describe("<Header />", () => {
   it("renders the component", async () => {
-    const wrapper = renderNonTransContent(Component, "Header");
+    const wrapper = renderNonTransContent(Component);
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/client/components/LanguageSelector/index.test.js
+++ b/src/client/components/LanguageSelector/index.test.js
@@ -3,7 +3,7 @@ import Component from "./index";
 
 describe("<LanguageSelector />", () => {
   it("renders the component", async () => {
-    const wrapper = renderNonTransContent(Component, "LanguageSelector");
+    const wrapper = renderNonTransContent(Component);
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/client/components/ListOfCertifications/index.test.js
+++ b/src/client/components/ListOfCertifications/index.test.js
@@ -12,7 +12,7 @@ describe("<ListOfCertifications />", () => {
       workOrEarn: false,
     };
 
-    const wrapper = renderNonTransContent(Component, "ListOfCertifications", {
+    const wrapper = renderNonTransContent(Component, {
       userData: {
         formData: [weekOfAnswers, weekOfAnswers, weekOfAnswers],
         weeksToCertify: [1, 2, 3],

--- a/src/client/components/ListOfWeeks/__snapshots__/index.test.js.snap
+++ b/src/client/components/ListOfWeeks/__snapshots__/index.test.js.snap
@@ -1,7 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ListOfWeeks /> renders the component 1`] = `
-Array [
+<ListOfWeeks
+  weeksToCertify={
+    Array [
+      0,
+      5,
+    ]
+  }
+>
   <Alert
     className="d-flex"
     closeLabel="Close alert"
@@ -23,22 +30,59 @@ Array [
     }
     variant="secondary"
   >
-    <div
-      className="flex-fill"
+    <Fade
+      appear={false}
+      in={true}
+      mountOnEnter={false}
+      timeout={300}
+      unmountOnExit={true}
     >
-      <Trans
-        i18nKey="retrocerts-week-list-item"
-        t={[Function]}
-        values={
-          Object {
-            "endDate": "02/08/2020",
-            "startDate": "02/02/2020",
-            "weekForUser": 1,
-          }
-        }
-      />
-    </div>
-  </Alert>,
+      <Transition
+        addEndListener={[Function]}
+        appear={false}
+        enter={true}
+        exit={true}
+        in={true}
+        mountOnEnter={false}
+        onEnter={[Function]}
+        onEntered={[Function]}
+        onEntering={[Function]}
+        onExit={[Function]}
+        onExited={[Function]}
+        onExiting={[Function]}
+        timeout={300}
+        unmountOnExit={true}
+      >
+        <div
+          className="fade d-flex alert alert-secondary show"
+          role="alert"
+        >
+          <div
+            className="flex-fill"
+          >
+            <Trans
+              i18nKey="retrocerts-week-list-item"
+              t={[Function]}
+              values={
+                Object {
+                  "endDate": "02/08/2020",
+                  "startDate": "02/02/2020",
+                  "weekForUser": 1,
+                }
+              }
+            >
+              <strong
+                key="strong-0"
+              >
+                Week 1
+              </strong>
+              : Sunday, 02/02/2020 – Saturday, 02/08/2020
+            </Trans>
+          </div>
+        </div>
+      </Transition>
+    </Fade>
+  </Alert>
   <Alert
     className="d-flex"
     closeLabel="Close alert"
@@ -60,66 +104,149 @@ Array [
     }
     variant="secondary"
   >
-    <div
-      className="flex-fill"
+    <Fade
+      appear={false}
+      in={true}
+      mountOnEnter={false}
+      timeout={300}
+      unmountOnExit={true}
     >
-      <Trans
-        i18nKey="retrocerts-week-list-item"
-        t={[Function]}
-        values={
-          Object {
-            "endDate": "03/14/2020",
-            "startDate": "03/08/2020",
-            "weekForUser": 2,
-          }
-        }
-      />
-    </div>
-  </Alert>,
-]
+      <Transition
+        addEndListener={[Function]}
+        appear={false}
+        enter={true}
+        exit={true}
+        in={true}
+        mountOnEnter={false}
+        onEnter={[Function]}
+        onEntered={[Function]}
+        onEntering={[Function]}
+        onExit={[Function]}
+        onExited={[Function]}
+        onExiting={[Function]}
+        timeout={300}
+        unmountOnExit={true}
+      >
+        <div
+          className="fade d-flex alert alert-secondary show"
+          role="alert"
+        >
+          <div
+            className="flex-fill"
+          >
+            <Trans
+              i18nKey="retrocerts-week-list-item"
+              t={[Function]}
+              values={
+                Object {
+                  "endDate": "03/14/2020",
+                  "startDate": "03/08/2020",
+                  "weekForUser": 2,
+                }
+              }
+            >
+              <strong
+                key="strong-0"
+              >
+                Week 2
+              </strong>
+              : Sunday, 03/08/2020 – Saturday, 03/14/2020
+            </Trans>
+          </div>
+        </div>
+      </Transition>
+    </Fade>
+  </Alert>
+</ListOfWeeks>
 `;
 
 exports[`<ListOfWeeks /> with checks 1`] = `
-<Alert
-  className="d-flex"
-  closeLabel="Close alert"
-  key="weekToCertify1"
-  show={true}
-  transition={
-    Object {
-      "$$typeof": Symbol(react.forward_ref),
-      "defaultProps": Object {
-        "appear": false,
-        "in": false,
-        "mountOnEnter": false,
-        "timeout": 300,
-        "unmountOnExit": false,
-      },
-      "displayName": "Fade",
-      "render": [Function],
-    }
+<ListOfWeeks
+  showChecks={true}
+  weeksToCertify={
+    Array [
+      1,
+    ]
   }
-  variant="secondary"
 >
-  <div
-    className="flex-fill"
-  >
-    <Trans
-      i18nKey="retrocerts-week-list-item"
-      t={[Function]}
-      values={
-        Object {
-          "endDate": "02/15/2020",
-          "startDate": "02/09/2020",
-          "weekForUser": 1,
-        }
+  <Alert
+    className="d-flex"
+    closeLabel="Close alert"
+    key="weekToCertify1"
+    show={true}
+    transition={
+      Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "defaultProps": Object {
+          "appear": false,
+          "in": false,
+          "mountOnEnter": false,
+          "timeout": 300,
+          "unmountOnExit": false,
+        },
+        "displayName": "Fade",
+        "render": [Function],
       }
-    />
-  </div>
-  <img
-    alt="checkmark"
-    className="checkmark"
-    src="/images/check-circle-fill.svg"
-  />
-</Alert>
+    }
+    variant="secondary"
+  >
+    <Fade
+      appear={false}
+      in={true}
+      mountOnEnter={false}
+      timeout={300}
+      unmountOnExit={true}
+    >
+      <Transition
+        addEndListener={[Function]}
+        appear={false}
+        enter={true}
+        exit={true}
+        in={true}
+        mountOnEnter={false}
+        onEnter={[Function]}
+        onEntered={[Function]}
+        onEntering={[Function]}
+        onExit={[Function]}
+        onExited={[Function]}
+        onExiting={[Function]}
+        timeout={300}
+        unmountOnExit={true}
+      >
+        <div
+          className="fade d-flex alert alert-secondary show"
+          role="alert"
+        >
+          <div
+            className="flex-fill"
+          >
+            <Trans
+              i18nKey="retrocerts-week-list-item"
+              t={[Function]}
+              values={
+                Object {
+                  "endDate": "02/15/2020",
+                  "startDate": "02/09/2020",
+                  "weekForUser": 1,
+                }
+              }
+            >
+              <strong
+                key="strong-0"
+              >
+                Week 1
+              </strong>
+              : Sunday, 02/09/2020 – Saturday, 02/15/2020
+            </Trans>
+          </div>
+          <img
+            alt="checkmark"
+            className="checkmark"
+            src="/images/check-circle-fill.svg"
+          />
+        </div>
+      </Transition>
+    </Fade>
+  </Alert>
+</ListOfWeeks>
 `;

--- a/src/client/components/ListOfWeeks/index.test.js
+++ b/src/client/components/ListOfWeeks/index.test.js
@@ -1,9 +1,9 @@
-import renderNonTransContent from "../../test-helpers/renderNonTransContent";
+import renderTransContent from "../../test-helpers/renderTransContent";
 import Component from "./index";
 
 describe("<ListOfWeeks />", () => {
   it("renders the component", async () => {
-    const wrapper = renderNonTransContent(Component, "ListOfWeeks", {
+    const wrapper = renderTransContent(Component, {
       weeksToCertify: [0, 5],
     });
 
@@ -11,7 +11,7 @@ describe("<ListOfWeeks />", () => {
   });
 
   it("with checks", async () => {
-    const wrapper = renderNonTransContent(Component, "ListOfWeeks", {
+    const wrapper = renderTransContent(Component, {
       weeksToCertify: [1],
       showChecks: true,
     });

--- a/src/client/components/ListOfWeeksWithDetail/index.test.js
+++ b/src/client/components/ListOfWeeksWithDetail/index.test.js
@@ -12,7 +12,7 @@ describe("<ListOfWeeksWithDetail />", () => {
       workOrEarn: false,
     };
 
-    const wrapper = renderNonTransContent(Component, "ListOfWeeksWithDetail", {
+    const wrapper = renderNonTransContent(Component, {
       userData: {
         formData: [weekOfAnswers, weekOfAnswers, weekOfAnswers],
         weeksToCertify: [1, 2, 3],

--- a/src/client/components/PerjuryCheckbox/__snapshots__/index.test.js.snap
+++ b/src/client/components/PerjuryCheckbox/__snapshots__/index.test.js.snap
@@ -1,23 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<PerjuryCheckbox /> renders the component 1`] = `
-<PerjuryCheckbox
-  0="P"
-  1="e"
-  10="c"
-  11="k"
-  12="b"
-  13="o"
-  14="x"
-  2="r"
-  3="j"
-  4="u"
-  5="r"
-  6="y"
-  7="C"
-  8="h"
-  9="e"
->
+<PerjuryCheckbox>
   <FormGroup
     className="unchecked"
     controlId="perjury-checkbox"

--- a/src/client/components/PerjuryCheckbox/__snapshots__/index.test.js.snap
+++ b/src/client/components/PerjuryCheckbox/__snapshots__/index.test.js.snap
@@ -1,66 +1,157 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<PerjuryCheckbox /> renders the component 1`] = `
-<FormGroup
-  className="unchecked"
-  controlId="perjury-checkbox"
+<PerjuryCheckbox
+  0="P"
+  1="e"
+  10="c"
+  11="k"
+  12="b"
+  13="o"
+  14="x"
+  2="r"
+  3="j"
+  4="u"
+  5="r"
+  6="y"
+  7="C"
+  8="h"
+  9="e"
 >
-  <FormText
-    as="h3"
+  <FormGroup
+    className="unchecked"
+    controlId="perjury-checkbox"
   >
-    Acknowledgement
-  </FormText>
-  <ul>
-    <li>
-      I understand the questions I answered through this automated system.
-    </li>
-    <li>
-      I know the law provides penalties if I make false statements or withhold facts to receive benefits; and my answers are true and correct.
-    </li>
-    <li>
-      I declare under penalty of perjury that I am a US Citizen or National; or an Alien in satisfactory immigration status and permitted to work by the United States Citizenship and Immigration Service.
-    </li>
-    <li>
-      I understand when submitting my request for benefits my submission is considered the same as my written signature.
-    </li>
-  </ul>
-  <FormRow>
-    <Col
-      md="auto"
+    <div
+      className="unchecked form-group"
     >
-      <FormCheck
-        checked={false}
-        disabled={false}
-        inline={false}
-        isInvalid={false}
-        isValid={false}
-        onChange={[Function]}
-        required={true}
-        title=""
-        type="checkbox"
-      />
-    </Col>
-    <Col>
-      <FormLabel
-        column={false}
-        srOnly={false}
+      <FormText
+        as="h3"
       >
-        You must indicate your acceptance of the statement by checking the box before your certification can be submitted.
-      </FormLabel>
-    </Col>
-  </FormRow>
-  <Feedback
-    type="invalid"
-  >
-    This field is required.
-  </Feedback>
-  <FormText
-    as="p"
-  >
-    <Trans
-      i18nKey="retrocerts-certification.submit-p1"
-      t={[Function]}
-    />
-  </FormText>
-</FormGroup>
+        <h3
+          className="form-text"
+        >
+          Acknowledgement
+        </h3>
+      </FormText>
+      <ul>
+        <li>
+          I understand the questions I answered through this automated system.
+        </li>
+        <li>
+          I know the law provides penalties if I make false statements or withhold facts to receive benefits; and my answers are true and correct.
+        </li>
+        <li>
+          I declare under penalty of perjury that I am a US Citizen or National; or an Alien in satisfactory immigration status and permitted to work by the United States Citizenship and Immigration Service.
+        </li>
+        <li>
+          I understand when submitting my request for benefits my submission is considered the same as my written signature.
+        </li>
+      </ul>
+      <FormRow>
+        <div
+          className="form-row"
+        >
+          <Col
+            md="auto"
+          >
+            <div
+              className="col-md-auto"
+            >
+              <FormCheck
+                checked={false}
+                disabled={false}
+                inline={false}
+                isInvalid={false}
+                isValid={false}
+                onChange={[Function]}
+                required={true}
+                title=""
+                type="checkbox"
+              >
+                <div
+                  className="form-check"
+                >
+                  <FormCheckInput
+                    as="input"
+                    checked={false}
+                    disabled={false}
+                    isInvalid={false}
+                    isStatic={true}
+                    isValid={false}
+                    onChange={[Function]}
+                    required={true}
+                    type="checkbox"
+                  >
+                    <input
+                      checked={false}
+                      className="form-check-input position-static"
+                      disabled={false}
+                      id="perjury-checkbox"
+                      onChange={[Function]}
+                      required={true}
+                      type="checkbox"
+                    />
+                  </FormCheckInput>
+                </div>
+              </FormCheck>
+            </div>
+          </Col>
+          <Col>
+            <div
+              className="col"
+            >
+              <FormLabel
+                column={false}
+                srOnly={false}
+              >
+                <label
+                  className="form-label"
+                  htmlFor="perjury-checkbox"
+                >
+                  You must indicate your acceptance of the statement by checking the box before your certification can be submitted.
+                </label>
+              </FormLabel>
+            </div>
+          </Col>
+        </div>
+      </FormRow>
+      <Feedback
+        type="invalid"
+      >
+        <div
+          className="invalid-feedback"
+        >
+          This field is required.
+        </div>
+      </Feedback>
+      <FormText
+        as="p"
+      >
+        <p
+          className="form-text"
+        >
+          <Trans
+            i18nKey="retrocerts-certification.submit-p1"
+            t={[Function]}
+          >
+            You are about to submit your retroactive certifications. You will 
+            <strong
+              key="strong-1"
+            >
+              not
+            </strong>
+             be able to change your answers once you select 
+            <strong
+              key="strong-3"
+            >
+              Submit
+            </strong>
+            .
+          </Trans>
+        </p>
+      </FormText>
+    </div>
+  </FormGroup>
+</PerjuryCheckbox>
 `;

--- a/src/client/components/PerjuryCheckbox/index.test.js
+++ b/src/client/components/PerjuryCheckbox/index.test.js
@@ -1,9 +1,9 @@
-import renderNonTransContent from "../../test-helpers/renderNonTransContent";
+import renderTransContent from "../../test-helpers/renderTransContent";
 import Component from "./index";
 
 describe("<PerjuryCheckbox />", () => {
   it("renders the component", async () => {
-    const wrapper = renderNonTransContent(Component, "PerjuryCheckbox");
+    const wrapper = renderTransContent(Component, "PerjuryCheckbox");
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/client/components/PerjuryCheckbox/index.test.js
+++ b/src/client/components/PerjuryCheckbox/index.test.js
@@ -3,7 +3,7 @@ import Component from "./index";
 
 describe("<PerjuryCheckbox />", () => {
   it("renders the component", async () => {
-    const wrapper = renderTransContent(Component, "PerjuryCheckbox");
+    const wrapper = renderTransContent(Component);
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/client/components/RetroCertsRoute/index.test.js
+++ b/src/client/components/RetroCertsRoute/index.test.js
@@ -10,7 +10,7 @@ const TestComponent = () => {
 describe("<RetroCertsRoute />", () => {
   it("basic route", async () => {
     sessionStorage.removeItem(AUTH_STRINGS.authToken);
-    const wrapper = renderNonTransContent(Component, "RetroCertsRoute", {
+    const wrapper = renderNonTransContent(Component, {
       path: "/path",
       pageComponent: TestComponent,
     });
@@ -20,7 +20,7 @@ describe("<RetroCertsRoute />", () => {
 
   it("route in production (should be PageNotFound)", async () => {
     sessionStorage.removeItem(AUTH_STRINGS.authToken);
-    const wrapper = renderNonTransContent(Component, "RetroCertsRoute", {
+    const wrapper = renderNonTransContent(Component, {
       path: "/path",
       pageComponent: TestComponent,
       isProduction: true,
@@ -31,7 +31,7 @@ describe("<RetroCertsRoute />", () => {
 
   it("route needing auth, but no data", async () => {
     sessionStorage.removeItem(AUTH_STRINGS.authToken);
-    const wrapper = renderNonTransContent(Component, "RetroCertsRoute", {
+    const wrapper = renderNonTransContent(Component, {
       path: "/path",
       pageComponent: TestComponent,
       pageProps: {
@@ -46,7 +46,7 @@ describe("<RetroCertsRoute />", () => {
 
   it("route needing auth with user data", async () => {
     sessionStorage.removeItem(AUTH_STRINGS.authToken);
-    const wrapper = renderNonTransContent(Component, "RetroCertsRoute", {
+    const wrapper = renderNonTransContent(Component, {
       path: "/path",
       pageComponent: TestComponent,
       pageProps: {
@@ -77,7 +77,7 @@ describe("<RetroCertsRoute />", () => {
     );
     global.fetch = mockFetch;
 
-    const wrapper = renderNonTransContent(Component, "RetroCertsRoute", {
+    const wrapper = renderNonTransContent(Component, {
       path: "/path",
       pageComponent: TestComponent,
       pageProps: {

--- a/src/client/components/SessionTimer/__snapshots__/index.test.js.snap
+++ b/src/client/components/SessionTimer/__snapshots__/index.test.js.snap
@@ -17,15 +17,8 @@ exports[`<SessionTimer /> clear 1`] = `
     </ModalTitle>
   </ModalHeader>
   <ModalBody>
-    <Trans
-      i18nKey="timeout-modal.warning"
-      t={[Function]}
-      values={
-        Object {
-          "numberOfMinutes": 5,
-        }
-      }
-    />
+    To protect your information, you will be logged out in 5 minutes if you do not continue working. Any unsaved changes will be lost.
+    /&gt;
   </ModalBody>
   <ModalFooter
     className="border-0"
@@ -60,15 +53,8 @@ exports[`<SessionTimer /> startOrUpdate 1`] = `
     </ModalTitle>
   </ModalHeader>
   <ModalBody>
-    <Trans
-      i18nKey="timeout-modal.warning"
-      t={[Function]}
-      values={
-        Object {
-          "numberOfMinutes": 5,
-        }
-      }
-    />
+    To protect your information, you will be logged out in 5 minutes if you do not continue working. Any unsaved changes will be lost.
+    /&gt;
   </ModalBody>
   <ModalFooter
     className="border-0"

--- a/src/client/components/SessionTimer/index.js
+++ b/src/client/components/SessionTimer/index.js
@@ -3,7 +3,7 @@ import { useHistory } from "react-router-dom";
 import PropTypes from "prop-types";
 import Modal from "react-bootstrap/Modal";
 import Button from "react-bootstrap/Button";
-import { useTranslation, Trans } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import { setUserDataPropType } from "../../commonPropTypes";
 import AUTH_STRINGS from "../../../data/authStrings";
 import routes from "../../../data/routes";
@@ -99,10 +99,7 @@ function SessionTimer(props) {
         </Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        <Trans
-          t={t}
-          i18nKey="timeout-modal.warning"
-          values={{ numberOfMinutes }}
+        {t("timeout-modal.warning", { numberOfMinutes })}
         />
       </Modal.Body>
       <Modal.Footer className="border-0">

--- a/src/client/components/SessionTimer/index.test.js
+++ b/src/client/components/SessionTimer/index.test.js
@@ -3,7 +3,7 @@ import Component from "./index";
 
 describe("<SessionTimer />", () => {
   it("startOrUpdate", async () => {
-    const wrapper = renderNonTransContent(Component, "SessionTimer", {
+    const wrapper = renderNonTransContent(Component, {
       action: "startOrUpdate",
       setUserData: () => {},
     });
@@ -14,7 +14,7 @@ describe("<SessionTimer />", () => {
   });
 
   it("clear", async () => {
-    const wrapper = renderNonTransContent(Component, "SessionTimer", {
+    const wrapper = renderNonTransContent(Component, {
       action: "clear",
       setUserData: () => {},
     });

--- a/src/client/components/StaffViewRoute/index.test.js
+++ b/src/client/components/StaffViewRoute/index.test.js
@@ -8,7 +8,7 @@ const TestComponent = () => {
 
 describe("<StaffViewRoute />", () => {
   it("basic route", async () => {
-    const wrapper = renderNonTransContent(Component, "StaffViewRoute", {
+    const wrapper = renderNonTransContent(Component, {
       path: "/path",
       pageComponent: TestComponent,
     });
@@ -17,7 +17,7 @@ describe("<StaffViewRoute />", () => {
   });
 
   it("route needing user data", async () => {
-    const wrapper = renderNonTransContent(Component, "StaffViewRoute", {
+    const wrapper = renderNonTransContent(Component, {
       path: "/retroactive-certification/staff-view/claimant-status",
       pageComponent: TestComponent,
       pageProps: {
@@ -31,7 +31,7 @@ describe("<StaffViewRoute />", () => {
   });
 
   it("route needing user data, without user data", async () => {
-    const wrapper = renderNonTransContent(Component, "StaffViewRoute", {
+    const wrapper = renderNonTransContent(Component, {
       path: "/retroactive-certification/staff-view/claimant-status",
       pageComponent: TestComponent,
       pageProps: {

--- a/src/client/components/Subheader/index.test.js
+++ b/src/client/components/Subheader/index.test.js
@@ -3,7 +3,7 @@ import Component from "./index";
 
 describe("<Subheader />", () => {
   it("renders vertical navigation bar", async () => {
-    const wrapper = renderNonTransContent(Component, "Subheader");
+    const wrapper = renderNonTransContent(Component);
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/client/components/TabbedContainer/index.test.js
+++ b/src/client/components/TabbedContainer/index.test.js
@@ -3,7 +3,7 @@ import Component from "./index";
 
 describe("<TabbedContainer />", () => {
   it("renders the component", async () => {
-    const wrapper = renderNonTransContent(Component, "TabbedContainer");
+    const wrapper = renderNonTransContent(Component);
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/client/pages/GuidePage/index.test.js
+++ b/src/client/pages/GuidePage/index.test.js
@@ -3,7 +3,7 @@ import Component from "./index";
 
 describe("<GuidePage />", () => {
   it("renders the component", async () => {
-    const wrapper = renderNonTransContent(Component, "GuidePage");
+    const wrapper = renderNonTransContent(Component);
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/client/pages/PageNotFound/index.test.js
+++ b/src/client/pages/PageNotFound/index.test.js
@@ -3,7 +3,7 @@ import Component from "./index";
 
 describe("<PageNotFound />", () => {
   it("renders a 404 page", async () => {
-    const wrapper = renderNonTransContent(Component, "PageNotFound");
+    const wrapper = renderNonTransContent(Component);
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/client/pages/RetroCertsAuthPage/index.test.js
+++ b/src/client/pages/RetroCertsAuthPage/index.test.js
@@ -4,7 +4,7 @@ import Component from "./index";
 
 describe("<RetroCertsAuthPage />", () => {
   it("retro certs auth page", async () => {
-    const wrapper = renderNonTransContent(Component, "RetroCertsAuthPage");
+    const wrapper = renderNonTransContent(Component);
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/client/pages/RetroCertsAuthPage/index.test.js
+++ b/src/client/pages/RetroCertsAuthPage/index.test.js
@@ -10,7 +10,7 @@ describe("<RetroCertsAuthPage />", () => {
   });
 
   it("retro certs auth page with user not found error", async () => {
-    const wrapper = renderNonTransContent(Component, "RetroCertsAuthPage", {
+    const wrapper = renderNonTransContent(Component, {
       userData: { status: AUTH_STRINGS.statusCode.userNotFound },
     });
 
@@ -18,7 +18,7 @@ describe("<RetroCertsAuthPage />", () => {
   });
 
   it("retro certs auth page with captcha timeout error", async () => {
-    const wrapper = renderNonTransContent(Component, "RetroCertsAuthPage", {
+    const wrapper = renderNonTransContent(Component, {
       userData: { status: AUTH_STRINGS.statusCode.recaptchaInvalid },
     });
 
@@ -26,7 +26,7 @@ describe("<RetroCertsAuthPage />", () => {
   });
 
   it("retro certs auth page with session timeout", async () => {
-    const wrapper = renderNonTransContent(Component, "RetroCertsAuthPage", {
+    const wrapper = renderNonTransContent(Component, {
       userData: { status: AUTH_STRINGS.statusCode.sessionTimedOut },
     });
 

--- a/src/client/pages/RetroCertsCertificationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsCertificationPage/__snapshots__/index.test.js.snap
@@ -1,489 +1,5446 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<RetroCertsCertificationPage /> Certify for 2nd week of 2 1`] = `
-<div
-  id="overflow-wrapper"
+<RetroCertsCertificationPage
+  routeComputedMatch={
+    Object {
+      "params": Object {
+        "week": "2020-02-15",
+      },
+    }
+  }
+  setUserData={[Function]}
+  userData={
+    Object {
+      "formData": Array [
+        Object {
+          "didYouLook": true,
+          "fullTime": true,
+          "refuseWork": true,
+          "schoolOrTraining": true,
+          "tooSick": true,
+          "weekIndex": 0,
+          "workOrEarn": true,
+        },
+        Object {
+          "didYouLook": false,
+          "fullTime": false,
+          "refuseWork": false,
+          "schoolOrTraining": false,
+          "tooSick": false,
+          "weekIndex": 0,
+          "workOrEarn": false,
+        },
+      ],
+      "programPlan": Array [
+        "UI full time",
+        "UI part time",
+      ],
+      "status": "ok",
+      "weeksToCertify": Array [
+        0,
+        1,
+      ],
+    }
+  }
 >
-  <Header />
-  <main
-    className="questions"
-    id="certification-page"
+  <div
+    id="overflow-wrapper"
   >
-    <div
-      className="container p-4"
+    <Header>
+      <header
+        className="header border-bottom border-secondary"
+      >
+        <Navbar
+          bg="primary"
+          className="justify-content-between"
+          collapseOnSelect={false}
+          expand={true}
+          variant="custom"
+        >
+          <nav
+            className="justify-content-between navbar navbar-expand navbar-custom bg-primary"
+          >
+            <NavbarBrand
+              href="https://ca.gov"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <a
+                className="navbar-brand"
+                href="https://ca.gov"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <img
+                  alt="California gov logo"
+                  height="30"
+                  src="images/Ca-Gov-Logo-Gold.svg"
+                  width="30"
+                />
+              </a>
+            </NavbarBrand>
+            <Nav
+              fill={false}
+              justify={false}
+            >
+              <ForwardRef
+                as="div"
+                className="navbar-nav"
+                onSelect={[Function]}
+              >
+                <div
+                  className="navbar-nav"
+                  onKeyDown={[Function]}
+                >
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov"
+                        disabled={false}
+                        href="https://edd.ca.gov"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov"
+                          href="https://edd.ca.gov"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="home icon"
+                            className="icon"
+                            height="15"
+                            src="images/home.svg"
+                            width="15"
+                          />
+                           
+                          <span
+                            className="text"
+                          >
+                            Home
+                          </span>
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/login.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/login.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/login.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/login.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/login.htm"
+                          href="https://edd.ca.gov/login.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <span>
+                            <img
+                              alt="key icon"
+                              className="icon"
+                              height="15"
+                              src="images/key.svg"
+                              width="15"
+                            />
+                             
+                            <span
+                              className="text"
+                            >
+                              Log In
+                            </span>
+                          </span>
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                </div>
+              </ForwardRef>
+            </Nav>
+          </nav>
+        </Navbar>
+        <Navbar
+          collapseOnSelect={true}
+          expand="md"
+          variant="light"
+        >
+          <nav
+            className="navbar navbar-expand-md navbar-light"
+          >
+            <NavbarBrand
+              href="https://edd.ca.gov"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <a
+                className="navbar-brand"
+                href="https://edd.ca.gov"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <img
+                  alt="California gov logo"
+                  className="d-inline-block align-top mr-5"
+                  height="50"
+                  src="images/edd-logo-2-Color.svg"
+                  width="150"
+                />
+              </a>
+            </NavbarBrand>
+            <NavbarToggle
+              aria-controls="responsive-navbar-nav"
+              label="Toggle navigation"
+            >
+              <button
+                aria-controls="responsive-navbar-nav"
+                aria-label="Toggle navigation"
+                className="navbar-toggler collapsed"
+                onClick={[Function]}
+                type="button"
+              >
+                <span
+                  className="navbar-toggler-icon"
+                />
+              </button>
+            </NavbarToggle>
+            <NavbarCollapse
+              className="justify-content-between ml-5 mr-5 pl-5"
+            >
+              <Collapse
+                appear={false}
+                className="justify-content-between ml-5 mr-5 pl-5"
+                dimension="height"
+                getDimensionValue={[Function]}
+                in={false}
+                mountOnEnter={false}
+                timeout={300}
+                unmountOnExit={false}
+              >
+                <Transition
+                  addEndListener={[Function]}
+                  appear={false}
+                  aria-expanded={null}
+                  enter={true}
+                  exit={true}
+                  in={false}
+                  mountOnEnter={false}
+                  onEnter={[Function]}
+                  onEntered={[Function]}
+                  onEntering={[Function]}
+                  onExit={[Function]}
+                  onExited={[Function]}
+                  onExiting={[Function]}
+                  timeout={300}
+                  unmountOnExit={false}
+                >
+                  <div
+                    aria-expanded={null}
+                    className="justify-content-between ml-5 mr-5 pl-5 navbar-collapse collapse"
+                  >
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/jobs.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/jobs.htm"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/jobs.htm"
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/jobs.htm"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Jobs
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/claims.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/claims.htm"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/claims.htm"
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/claims.htm"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Claims
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/employers.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/employers.htm"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/employers.htm"
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/employers.htm"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Employers
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/newsroom.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/newsroom.htm"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/newsroom.htm"
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/newsroom.htm"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Newsroom
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/serp.html?q="
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/serp.html?q="
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/serp.html?q="
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/serp.html?q="
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Search
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                  </div>
+                </Transition>
+              </Collapse>
+            </NavbarCollapse>
+          </nav>
+        </Navbar>
+      </header>
+    </Header>
+    <main
+      className="questions"
+      id="certification-page"
     >
-      <h1>
-        Retroactively Certify and Review
-      </h1>
-      <LanguageSelector
-        className="mt-3 mb-4"
-      />
-      <h2
-        className="h3 font-weight-bold mt-4"
+      <div
+        className="container p-4"
       >
-        <Trans
-          i18nKey="retrocerts-certification.form-header"
-          t={[Function]}
-          values={
-            Object {
-              "weekForUser": 2,
-              "weekString": "02/09/2020 - 02/15/2020",
-            }
-          }
-        />
-      </h2>
-      <p>
-        <Trans
-          i18nKey="retrocerts-certification.p1-multiple"
-          t={[Function]}
-          values={
-            Object {
-              "numberOfWeeks": 2,
-              "weekForUser": 2,
-            }
-          }
-        />
-         Your previous weeks are saved.
-      </p>
-      <Form
-        inline={false}
-        noValidate={true}
-        onSubmit={[Function]}
-        validated={false}
-      >
-        <YesNoQuestion
-          helpText={
-            <Trans
-              i18nKey="retrocerts-certification.questions.ui-part-time.help-tooSick"
-              t={[Function]}
-            />
-          }
-          ifYes={false}
-          inputName="tooSick"
-          key="1tooSick"
-          onChange={[Function]}
-          questionNumber={1}
-          questionText="Were you too sick or injured to work?"
+        <h1>
+          Retroactively Certify and Review
+        </h1>
+        <LanguageSelector
+          className="mt-3 mb-4"
         >
-          <DaysSickQuestion
-            helpText="You must report the numbers of days that you could not work during this week. Unemployment benefits are paid according to the number of days you are able to work this week."
-            onChange={[Function]}
-            questionText="If yes, enter the number of days (1-7) you were unable to work."
-          />
-        </YesNoQuestion>
-        <YesNoQuestion
-          helpText={
-            <Trans
-              i18nKey="retrocerts-certification.questions.ui-part-time.help-couldNotAcceptWork"
-              t={[Function]}
-            />
-          }
-          inputName="couldNotAcceptWork"
-          key="1couldNotAcceptWork"
-          onChange={[Function]}
-          questionNumber={2}
-          questionText={
-            <Trans
-              i18nKey="retrocerts-certification.questions.ui-part-time.couldNotAcceptWork"
-              t={[Function]}
-              values={
-                Object {
-                  "weekString": "02/09/2020 - 02/15/2020",
-                }
-              }
-            />
-          }
-        />
-        <YesNoQuestion
-          helpText={
-            <Trans
-              i18nKey="retrocerts-certification.questions.ui-part-time.help-didYouLook"
-              t={[Function]}
-            />
-          }
-          ifYes={false}
-          inputName="didYouLook"
-          key="1didYouLook"
-          onChange={[Function]}
-          questionNumber={3}
-          questionText={
-            <Trans
-              i18nKey="retrocerts-certification.questions.ui-part-time.didYouLook"
-              t={[Function]}
-              values={
-                Object {
-                  "weekString": "02/09/2020 - 02/15/2020",
-                }
-              }
-            />
-          }
-        />
-        <YesNoQuestion
-          helpText={
-            <Trans
-              i18nKey="retrocerts-certification.questions.ui-part-time.help-refuseWork"
-              t={[Function]}
-            />
-          }
-          ifYes={false}
-          inputName="refuseWork"
-          key="1refuseWork"
-          onChange={[Function]}
-          questionNumber={4}
-          questionText={
-            <Trans
-              i18nKey="retrocerts-certification.questions.ui-part-time.refuseWork"
-              t={[Function]}
-              values={
-                Object {
-                  "weekString": "02/09/2020 - 02/15/2020",
-                }
-              }
-            />
-          }
-        />
-        <YesNoQuestion
-          helpText={
-            <Trans
-              i18nKey="retrocerts-certification.questions.ui-part-time.help-schoolOrTraining"
-              t={[Function]}
-            />
-          }
-          ifYes={false}
-          inputName="schoolOrTraining"
-          key="1schoolOrTraining"
-          onChange={[Function]}
-          questionNumber={5}
-          questionText={
-            <Trans
-              i18nKey="retrocerts-certification.questions.ui-part-time.schoolOrTraining"
-              t={[Function]}
-              values={
-                Object {
-                  "weekString": "02/09/2020 - 02/15/2020",
-                }
-              }
-            />
-          }
-        />
-        <YesNoQuestion
-          helpText="Look at the date each week begins and ends. If you performed any work during this week, all earnings must be reported regardless if payment has been received."
-          ifYes={false}
-          inputName="workOrEarn"
-          key="1workOrEarn"
-          onChange={[Function]}
-          questionNumber={6}
-          questionText={
-            <Trans
-              i18nKey="retrocerts-certification.questions.ui-part-time.workOrEarn"
-              t={[Function]}
-            />
-          }
-        >
-          <EmployersQuestions
-            onChange={[Function]}
-          />
-        </YesNoQuestion>
-        <PerjuryCheckbox
-          isAnyWeekPua={false}
-        />
-        <FormRow>
-          <Col>
-            <Button
-              active={false}
-              as={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "displayName": "Link",
-                  "propTypes": Object {
-                    "innerRef": [Function],
-                    "onClick": [Function],
-                    "replace": [Function],
-                    "target": [Function],
-                    "to": [Function],
-                  },
-                  "render": [Function],
-                }
-              }
-              className="text-dark bg-light"
+          <Button
+            active={false}
+            className="text-dark bg-light mt-3 mb-4"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+            variant="outline-secondary"
+          >
+            <button
+              className="text-dark bg-light mt-3 mb-4 btn btn-outline-secondary"
               disabled={false}
               onClick={[Function]}
-              to="/retroactive-certification/certify/2020-02-08"
               type="button"
-              variant="outline-secondary"
             >
-              Back to Previous Week
-            </Button>
-          </Col>
-          <Col
-            style={
+              Español
+            </button>
+          </Button>
+        </LanguageSelector>
+        <h2
+          className="h3 font-weight-bold mt-4"
+        >
+          <Trans
+            i18nKey="retrocerts-certification.form-header"
+            t={[Function]}
+            values={
               Object {
-                "textAlign": "end",
+                "weekForUser": 2,
+                "weekString": "02/09/2020 - 02/15/2020",
               }
             }
           >
-            <Button
-              active={false}
-              disabled={false}
-              type="submit"
-              variant="secondary"
+            Week 2: 02/09/2020 - 02/15/2020
+          </Trans>
+        </h2>
+        <p>
+          <Trans
+            i18nKey="retrocerts-certification.p1-multiple"
+            t={[Function]}
+            values={
+              Object {
+                "numberOfWeeks": 2,
+                "weekForUser": 2,
+              }
+            }
+          >
+            You are on Week 2 of 2 weeks to retroactively certify.
+          </Trans>
+           Your previous weeks are saved.
+        </p>
+        <Form
+          inline={false}
+          noValidate={true}
+          onSubmit={[Function]}
+          validated={false}
+        >
+          <form
+            className=""
+            noValidate={true}
+            onSubmit={[Function]}
+          >
+            <YesNoQuestion
+              helpText={
+                <Trans
+                  i18nKey="retrocerts-certification.questions.ui-part-time.help-tooSick"
+                  t={[Function]}
+                />
+              }
+              ifYes={false}
+              inputName="tooSick"
+              key="1tooSick"
+              onChange={[Function]}
+              questionNumber={1}
+              questionText="Were you too sick or injured to work?"
             >
-              Submit
-            </Button>
-          </Col>
-        </FormRow>
-      </Form>
-    </div>
-  </main>
-  <Footer
-    backToTopTag="certification-page"
-  />
-</div>
+              <div
+                className="bg-light p-2 mt-2 mb-2"
+              >
+                <FormGroup
+                  className=""
+                  controlId="tooSick"
+                >
+                  <div
+                    className="form-group"
+                  >
+                    <fieldset>
+                      <FormLabel
+                        as="legend"
+                        column={false}
+                        srOnly={false}
+                      >
+                        <legend
+                          className="form-label"
+                          htmlFor="tooSick"
+                        >
+                          1
+                          . 
+                          Were you too sick or injured to work?
+                        </legend>
+                      </FormLabel>
+                      <FormText
+                        className="help-text"
+                      >
+                        <small
+                          className="help-text form-text"
+                        >
+                          <Trans
+                            i18nKey="retrocerts-certification.questions.ui-part-time.help-tooSick"
+                            t={[Function]}
+                          >
+                            You must be well enough to work every day of the week to receive full benefits. Check 
+                            <strong
+                              key="strong-1"
+                            >
+                              Yes
+                            </strong>
+                             if a workday was missed due to being sick or injured.
+                          </Trans>
+                        </small>
+                      </FormText>
+                      <FormCheck
+                        checked={false}
+                        disabled={false}
+                        id="tooSickradioYes"
+                        inline={true}
+                        isInvalid={false}
+                        isValid={false}
+                        key="Yes"
+                        label="Yes"
+                        name="tooSick"
+                        onChange={[Function]}
+                        required={true}
+                        title=""
+                        type="radio"
+                        value="Yes"
+                      >
+                        <div
+                          className="form-check form-check-inline"
+                        >
+                          <FormCheckInput
+                            as="input"
+                            checked={false}
+                            disabled={false}
+                            isInvalid={false}
+                            isStatic={false}
+                            isValid={false}
+                            name="tooSick"
+                            onChange={[Function]}
+                            required={true}
+                            type="radio"
+                            value="Yes"
+                          >
+                            <input
+                              checked={false}
+                              className="form-check-input"
+                              disabled={false}
+                              id="tooSickradioYes"
+                              name="tooSick"
+                              onChange={[Function]}
+                              required={true}
+                              type="radio"
+                              value="Yes"
+                            />
+                          </FormCheckInput>
+                          <FormCheckLabel
+                            title=""
+                          >
+                            <label
+                              className="form-check-label"
+                              htmlFor="tooSickradioYes"
+                              title=""
+                            >
+                              Yes
+                            </label>
+                          </FormCheckLabel>
+                        </div>
+                      </FormCheck>
+                      <FormCheck
+                        checked={true}
+                        disabled={false}
+                        id="tooSickradioNo"
+                        inline={true}
+                        isInvalid={false}
+                        isValid={false}
+                        key="No"
+                        label="No"
+                        name="tooSick"
+                        onChange={[Function]}
+                        required={true}
+                        title=""
+                        type="radio"
+                        value="No"
+                      >
+                        <div
+                          className="form-check form-check-inline"
+                        >
+                          <FormCheckInput
+                            as="input"
+                            checked={true}
+                            disabled={false}
+                            isInvalid={false}
+                            isStatic={false}
+                            isValid={false}
+                            name="tooSick"
+                            onChange={[Function]}
+                            required={true}
+                            type="radio"
+                            value="No"
+                          >
+                            <input
+                              checked={true}
+                              className="form-check-input"
+                              disabled={false}
+                              id="tooSickradioNo"
+                              name="tooSick"
+                              onChange={[Function]}
+                              required={true}
+                              type="radio"
+                              value="No"
+                            />
+                          </FormCheckInput>
+                          <FormCheckLabel
+                            title=""
+                          >
+                            <label
+                              className="form-check-label"
+                              htmlFor="tooSickradioNo"
+                              title=""
+                            >
+                              No
+                            </label>
+                          </FormCheckLabel>
+                        </div>
+                      </FormCheck>
+                      <Feedback
+                        type="invalid"
+                      >
+                        <div
+                          className="invalid-feedback"
+                        >
+                          This field is required.
+                        </div>
+                      </Feedback>
+                    </fieldset>
+                  </div>
+                </FormGroup>
+              </div>
+            </YesNoQuestion>
+            <YesNoQuestion
+              helpText={
+                <Trans
+                  i18nKey="retrocerts-certification.questions.ui-part-time.help-couldNotAcceptWork"
+                  t={[Function]}
+                />
+              }
+              inputName="couldNotAcceptWork"
+              key="1couldNotAcceptWork"
+              onChange={[Function]}
+              questionNumber={2}
+              questionText={
+                <Trans
+                  i18nKey="retrocerts-certification.questions.ui-part-time.couldNotAcceptWork"
+                  t={[Function]}
+                  values={
+                    Object {
+                      "weekString": "02/09/2020 - 02/15/2020",
+                    }
+                  }
+                />
+              }
+            >
+              <div
+                className="bg-light p-2 mt-2 mb-2"
+              >
+                <FormGroup
+                  className="unchecked"
+                  controlId="couldNotAcceptWork"
+                >
+                  <div
+                    className="unchecked form-group"
+                  >
+                    <fieldset>
+                      <FormLabel
+                        as="legend"
+                        column={false}
+                        srOnly={false}
+                      >
+                        <legend
+                          className="form-label"
+                          htmlFor="couldNotAcceptWork"
+                        >
+                          2
+                          . 
+                          <Trans
+                            i18nKey="retrocerts-certification.questions.ui-part-time.couldNotAcceptWork"
+                            t={[Function]}
+                            values={
+                              Object {
+                                "weekString": "02/09/2020 - 02/15/2020",
+                              }
+                            }
+                          >
+                            Was there any reason (other than sickness or injury) that you could not have accepted part-time work, 
+                            <strong
+                              key="strong-1"
+                            >
+                              as instructed by EDD
+                            </strong>
+                            ?
+                          </Trans>
+                        </legend>
+                      </FormLabel>
+                      <FormText
+                        className="help-text"
+                      >
+                        <small
+                          className="help-text form-text"
+                        >
+                          <Trans
+                            i18nKey="retrocerts-certification.questions.ui-part-time.help-couldNotAcceptWork"
+                            t={[Function]}
+                          >
+                            You must be available for work to receive unemployment benefits. Available means you are ready and willing to accept work that matches your occupational skills and educational background. If you refused part-time work for any reason other than being sick or injured, check 
+                            <strong
+                              key="strong-1"
+                            >
+                              Yes
+                            </strong>
+                            .
+                          </Trans>
+                        </small>
+                      </FormText>
+                      <FormCheck
+                        checked={false}
+                        disabled={false}
+                        id="couldNotAcceptWorkradioYes"
+                        inline={true}
+                        isInvalid={false}
+                        isValid={false}
+                        key="Yes"
+                        label="Yes"
+                        name="couldNotAcceptWork"
+                        onChange={[Function]}
+                        required={true}
+                        title=""
+                        type="radio"
+                        value="Yes"
+                      >
+                        <div
+                          className="form-check form-check-inline"
+                        >
+                          <FormCheckInput
+                            as="input"
+                            checked={false}
+                            disabled={false}
+                            isInvalid={false}
+                            isStatic={false}
+                            isValid={false}
+                            name="couldNotAcceptWork"
+                            onChange={[Function]}
+                            required={true}
+                            type="radio"
+                            value="Yes"
+                          >
+                            <input
+                              checked={false}
+                              className="form-check-input"
+                              disabled={false}
+                              id="couldNotAcceptWorkradioYes"
+                              name="couldNotAcceptWork"
+                              onChange={[Function]}
+                              required={true}
+                              type="radio"
+                              value="Yes"
+                            />
+                          </FormCheckInput>
+                          <FormCheckLabel
+                            title=""
+                          >
+                            <label
+                              className="form-check-label"
+                              htmlFor="couldNotAcceptWorkradioYes"
+                              title=""
+                            >
+                              Yes
+                            </label>
+                          </FormCheckLabel>
+                        </div>
+                      </FormCheck>
+                      <FormCheck
+                        checked={false}
+                        disabled={false}
+                        id="couldNotAcceptWorkradioNo"
+                        inline={true}
+                        isInvalid={false}
+                        isValid={false}
+                        key="No"
+                        label="No"
+                        name="couldNotAcceptWork"
+                        onChange={[Function]}
+                        required={true}
+                        title=""
+                        type="radio"
+                        value="No"
+                      >
+                        <div
+                          className="form-check form-check-inline"
+                        >
+                          <FormCheckInput
+                            as="input"
+                            checked={false}
+                            disabled={false}
+                            isInvalid={false}
+                            isStatic={false}
+                            isValid={false}
+                            name="couldNotAcceptWork"
+                            onChange={[Function]}
+                            required={true}
+                            type="radio"
+                            value="No"
+                          >
+                            <input
+                              checked={false}
+                              className="form-check-input"
+                              disabled={false}
+                              id="couldNotAcceptWorkradioNo"
+                              name="couldNotAcceptWork"
+                              onChange={[Function]}
+                              required={true}
+                              type="radio"
+                              value="No"
+                            />
+                          </FormCheckInput>
+                          <FormCheckLabel
+                            title=""
+                          >
+                            <label
+                              className="form-check-label"
+                              htmlFor="couldNotAcceptWorkradioNo"
+                              title=""
+                            >
+                              No
+                            </label>
+                          </FormCheckLabel>
+                        </div>
+                      </FormCheck>
+                      <Feedback
+                        type="invalid"
+                      >
+                        <div
+                          className="invalid-feedback"
+                        >
+                          This field is required.
+                        </div>
+                      </Feedback>
+                    </fieldset>
+                  </div>
+                </FormGroup>
+              </div>
+            </YesNoQuestion>
+            <YesNoQuestion
+              helpText={
+                <Trans
+                  i18nKey="retrocerts-certification.questions.ui-part-time.help-didYouLook"
+                  t={[Function]}
+                />
+              }
+              ifYes={false}
+              inputName="didYouLook"
+              key="1didYouLook"
+              onChange={[Function]}
+              questionNumber={3}
+              questionText={
+                <Trans
+                  i18nKey="retrocerts-certification.questions.ui-part-time.didYouLook"
+                  t={[Function]}
+                  values={
+                    Object {
+                      "weekString": "02/09/2020 - 02/15/2020",
+                    }
+                  }
+                />
+              }
+            >
+              <div
+                className="bg-light p-2 mt-2 mb-2"
+              >
+                <FormGroup
+                  className=""
+                  controlId="didYouLook"
+                >
+                  <div
+                    className="form-group"
+                  >
+                    <fieldset>
+                      <FormLabel
+                        as="legend"
+                        column={false}
+                        srOnly={false}
+                      >
+                        <legend
+                          className="form-label"
+                          htmlFor="didYouLook"
+                        >
+                          3
+                          . 
+                          <Trans
+                            i18nKey="retrocerts-certification.questions.ui-part-time.didYouLook"
+                            t={[Function]}
+                            values={
+                              Object {
+                                "weekString": "02/09/2020 - 02/15/2020",
+                              }
+                            }
+                          >
+                            Did you look for work?
+                          </Trans>
+                        </legend>
+                      </FormLabel>
+                      <FormText
+                        className="help-text"
+                      >
+                        <small
+                          className="help-text form-text"
+                        >
+                          <Trans
+                            i18nKey="retrocerts-certification.questions.ui-part-time.help-didYouLook"
+                            t={[Function]}
+                          >
+                            Work searches may include in person, mail, telephone, or internet contacts with employers.
+                          </Trans>
+                        </small>
+                      </FormText>
+                      <FormCheck
+                        checked={false}
+                        disabled={false}
+                        id="didYouLookradioYes"
+                        inline={true}
+                        isInvalid={false}
+                        isValid={false}
+                        key="Yes"
+                        label="Yes"
+                        name="didYouLook"
+                        onChange={[Function]}
+                        required={true}
+                        title=""
+                        type="radio"
+                        value="Yes"
+                      >
+                        <div
+                          className="form-check form-check-inline"
+                        >
+                          <FormCheckInput
+                            as="input"
+                            checked={false}
+                            disabled={false}
+                            isInvalid={false}
+                            isStatic={false}
+                            isValid={false}
+                            name="didYouLook"
+                            onChange={[Function]}
+                            required={true}
+                            type="radio"
+                            value="Yes"
+                          >
+                            <input
+                              checked={false}
+                              className="form-check-input"
+                              disabled={false}
+                              id="didYouLookradioYes"
+                              name="didYouLook"
+                              onChange={[Function]}
+                              required={true}
+                              type="radio"
+                              value="Yes"
+                            />
+                          </FormCheckInput>
+                          <FormCheckLabel
+                            title=""
+                          >
+                            <label
+                              className="form-check-label"
+                              htmlFor="didYouLookradioYes"
+                              title=""
+                            >
+                              Yes
+                            </label>
+                          </FormCheckLabel>
+                        </div>
+                      </FormCheck>
+                      <FormCheck
+                        checked={true}
+                        disabled={false}
+                        id="didYouLookradioNo"
+                        inline={true}
+                        isInvalid={false}
+                        isValid={false}
+                        key="No"
+                        label="No"
+                        name="didYouLook"
+                        onChange={[Function]}
+                        required={true}
+                        title=""
+                        type="radio"
+                        value="No"
+                      >
+                        <div
+                          className="form-check form-check-inline"
+                        >
+                          <FormCheckInput
+                            as="input"
+                            checked={true}
+                            disabled={false}
+                            isInvalid={false}
+                            isStatic={false}
+                            isValid={false}
+                            name="didYouLook"
+                            onChange={[Function]}
+                            required={true}
+                            type="radio"
+                            value="No"
+                          >
+                            <input
+                              checked={true}
+                              className="form-check-input"
+                              disabled={false}
+                              id="didYouLookradioNo"
+                              name="didYouLook"
+                              onChange={[Function]}
+                              required={true}
+                              type="radio"
+                              value="No"
+                            />
+                          </FormCheckInput>
+                          <FormCheckLabel
+                            title=""
+                          >
+                            <label
+                              className="form-check-label"
+                              htmlFor="didYouLookradioNo"
+                              title=""
+                            >
+                              No
+                            </label>
+                          </FormCheckLabel>
+                        </div>
+                      </FormCheck>
+                      <Feedback
+                        type="invalid"
+                      >
+                        <div
+                          className="invalid-feedback"
+                        >
+                          This field is required.
+                        </div>
+                      </Feedback>
+                    </fieldset>
+                  </div>
+                </FormGroup>
+              </div>
+            </YesNoQuestion>
+            <YesNoQuestion
+              helpText={
+                <Trans
+                  i18nKey="retrocerts-certification.questions.ui-part-time.help-refuseWork"
+                  t={[Function]}
+                />
+              }
+              ifYes={false}
+              inputName="refuseWork"
+              key="1refuseWork"
+              onChange={[Function]}
+              questionNumber={4}
+              questionText={
+                <Trans
+                  i18nKey="retrocerts-certification.questions.ui-part-time.refuseWork"
+                  t={[Function]}
+                  values={
+                    Object {
+                      "weekString": "02/09/2020 - 02/15/2020",
+                    }
+                  }
+                />
+              }
+            >
+              <div
+                className="bg-light p-2 mt-2 mb-2"
+              >
+                <FormGroup
+                  className=""
+                  controlId="refuseWork"
+                >
+                  <div
+                    className="form-group"
+                  >
+                    <fieldset>
+                      <FormLabel
+                        as="legend"
+                        column={false}
+                        srOnly={false}
+                      >
+                        <legend
+                          className="form-label"
+                          htmlFor="refuseWork"
+                        >
+                          4
+                          . 
+                          <Trans
+                            i18nKey="retrocerts-certification.questions.ui-part-time.refuseWork"
+                            t={[Function]}
+                            values={
+                              Object {
+                                "weekString": "02/09/2020 - 02/15/2020",
+                              }
+                            }
+                          >
+                            Did you refuse any work?
+                          </Trans>
+                        </legend>
+                      </FormLabel>
+                      <FormText
+                        className="help-text"
+                      >
+                        <small
+                          className="help-text form-text"
+                        >
+                          <Trans
+                            i18nKey="retrocerts-certification.questions.ui-part-time.help-refuseWork"
+                            t={[Function]}
+                          >
+                            If work was refused, a determination will be scheduled. Union members, check 
+                            <strong
+                              key="strong-1"
+                            >
+                              Yes
+                            </strong>
+                             if a union referral to a job was refused.
+                          </Trans>
+                        </small>
+                      </FormText>
+                      <FormCheck
+                        checked={false}
+                        disabled={false}
+                        id="refuseWorkradioYes"
+                        inline={true}
+                        isInvalid={false}
+                        isValid={false}
+                        key="Yes"
+                        label="Yes"
+                        name="refuseWork"
+                        onChange={[Function]}
+                        required={true}
+                        title=""
+                        type="radio"
+                        value="Yes"
+                      >
+                        <div
+                          className="form-check form-check-inline"
+                        >
+                          <FormCheckInput
+                            as="input"
+                            checked={false}
+                            disabled={false}
+                            isInvalid={false}
+                            isStatic={false}
+                            isValid={false}
+                            name="refuseWork"
+                            onChange={[Function]}
+                            required={true}
+                            type="radio"
+                            value="Yes"
+                          >
+                            <input
+                              checked={false}
+                              className="form-check-input"
+                              disabled={false}
+                              id="refuseWorkradioYes"
+                              name="refuseWork"
+                              onChange={[Function]}
+                              required={true}
+                              type="radio"
+                              value="Yes"
+                            />
+                          </FormCheckInput>
+                          <FormCheckLabel
+                            title=""
+                          >
+                            <label
+                              className="form-check-label"
+                              htmlFor="refuseWorkradioYes"
+                              title=""
+                            >
+                              Yes
+                            </label>
+                          </FormCheckLabel>
+                        </div>
+                      </FormCheck>
+                      <FormCheck
+                        checked={true}
+                        disabled={false}
+                        id="refuseWorkradioNo"
+                        inline={true}
+                        isInvalid={false}
+                        isValid={false}
+                        key="No"
+                        label="No"
+                        name="refuseWork"
+                        onChange={[Function]}
+                        required={true}
+                        title=""
+                        type="radio"
+                        value="No"
+                      >
+                        <div
+                          className="form-check form-check-inline"
+                        >
+                          <FormCheckInput
+                            as="input"
+                            checked={true}
+                            disabled={false}
+                            isInvalid={false}
+                            isStatic={false}
+                            isValid={false}
+                            name="refuseWork"
+                            onChange={[Function]}
+                            required={true}
+                            type="radio"
+                            value="No"
+                          >
+                            <input
+                              checked={true}
+                              className="form-check-input"
+                              disabled={false}
+                              id="refuseWorkradioNo"
+                              name="refuseWork"
+                              onChange={[Function]}
+                              required={true}
+                              type="radio"
+                              value="No"
+                            />
+                          </FormCheckInput>
+                          <FormCheckLabel
+                            title=""
+                          >
+                            <label
+                              className="form-check-label"
+                              htmlFor="refuseWorkradioNo"
+                              title=""
+                            >
+                              No
+                            </label>
+                          </FormCheckLabel>
+                        </div>
+                      </FormCheck>
+                      <Feedback
+                        type="invalid"
+                      >
+                        <div
+                          className="invalid-feedback"
+                        >
+                          This field is required.
+                        </div>
+                      </Feedback>
+                    </fieldset>
+                  </div>
+                </FormGroup>
+              </div>
+            </YesNoQuestion>
+            <YesNoQuestion
+              helpText={
+                <Trans
+                  i18nKey="retrocerts-certification.questions.ui-part-time.help-schoolOrTraining"
+                  t={[Function]}
+                />
+              }
+              ifYes={false}
+              inputName="schoolOrTraining"
+              key="1schoolOrTraining"
+              onChange={[Function]}
+              questionNumber={5}
+              questionText={
+                <Trans
+                  i18nKey="retrocerts-certification.questions.ui-part-time.schoolOrTraining"
+                  t={[Function]}
+                  values={
+                    Object {
+                      "weekString": "02/09/2020 - 02/15/2020",
+                    }
+                  }
+                />
+              }
+            >
+              <div
+                className="bg-light p-2 mt-2 mb-2"
+              >
+                <FormGroup
+                  className=""
+                  controlId="schoolOrTraining"
+                >
+                  <div
+                    className="form-group"
+                  >
+                    <fieldset>
+                      <FormLabel
+                        as="legend"
+                        column={false}
+                        srOnly={false}
+                      >
+                        <legend
+                          className="form-label"
+                          htmlFor="schoolOrTraining"
+                        >
+                          5
+                          . 
+                          <Trans
+                            i18nKey="retrocerts-certification.questions.ui-part-time.schoolOrTraining"
+                            t={[Function]}
+                            values={
+                              Object {
+                                "weekString": "02/09/2020 - 02/15/2020",
+                              }
+                            }
+                          >
+                            Did you 
+                            <strong
+                              key="strong-1"
+                            >
+                              begin
+                            </strong>
+                             attending any kind of school or training? Select 
+                            <strong
+                              key="strong-3"
+                            >
+                              Yes
+                            </strong>
+                             only if you began attending school between 02/09/2020 - 02/15/2020.
+                          </Trans>
+                        </legend>
+                      </FormLabel>
+                      <FormText
+                        className="help-text"
+                      >
+                        <small
+                          className="help-text form-text"
+                        >
+                          <Trans
+                            i18nKey="retrocerts-certification.questions.ui-part-time.help-schoolOrTraining"
+                            t={[Function]}
+                          >
+                            Check 
+                            <strong
+                              key="strong-1"
+                            >
+                              Yes
+                            </strong>
+                             only if school or training 
+                            <strong
+                              key="strong-3"
+                            >
+                              began
+                            </strong>
+                             during this work week.
+                          </Trans>
+                        </small>
+                      </FormText>
+                      <FormCheck
+                        checked={false}
+                        disabled={false}
+                        id="schoolOrTrainingradioYes"
+                        inline={true}
+                        isInvalid={false}
+                        isValid={false}
+                        key="Yes"
+                        label="Yes"
+                        name="schoolOrTraining"
+                        onChange={[Function]}
+                        required={true}
+                        title=""
+                        type="radio"
+                        value="Yes"
+                      >
+                        <div
+                          className="form-check form-check-inline"
+                        >
+                          <FormCheckInput
+                            as="input"
+                            checked={false}
+                            disabled={false}
+                            isInvalid={false}
+                            isStatic={false}
+                            isValid={false}
+                            name="schoolOrTraining"
+                            onChange={[Function]}
+                            required={true}
+                            type="radio"
+                            value="Yes"
+                          >
+                            <input
+                              checked={false}
+                              className="form-check-input"
+                              disabled={false}
+                              id="schoolOrTrainingradioYes"
+                              name="schoolOrTraining"
+                              onChange={[Function]}
+                              required={true}
+                              type="radio"
+                              value="Yes"
+                            />
+                          </FormCheckInput>
+                          <FormCheckLabel
+                            title=""
+                          >
+                            <label
+                              className="form-check-label"
+                              htmlFor="schoolOrTrainingradioYes"
+                              title=""
+                            >
+                              Yes
+                            </label>
+                          </FormCheckLabel>
+                        </div>
+                      </FormCheck>
+                      <FormCheck
+                        checked={true}
+                        disabled={false}
+                        id="schoolOrTrainingradioNo"
+                        inline={true}
+                        isInvalid={false}
+                        isValid={false}
+                        key="No"
+                        label="No"
+                        name="schoolOrTraining"
+                        onChange={[Function]}
+                        required={true}
+                        title=""
+                        type="radio"
+                        value="No"
+                      >
+                        <div
+                          className="form-check form-check-inline"
+                        >
+                          <FormCheckInput
+                            as="input"
+                            checked={true}
+                            disabled={false}
+                            isInvalid={false}
+                            isStatic={false}
+                            isValid={false}
+                            name="schoolOrTraining"
+                            onChange={[Function]}
+                            required={true}
+                            type="radio"
+                            value="No"
+                          >
+                            <input
+                              checked={true}
+                              className="form-check-input"
+                              disabled={false}
+                              id="schoolOrTrainingradioNo"
+                              name="schoolOrTraining"
+                              onChange={[Function]}
+                              required={true}
+                              type="radio"
+                              value="No"
+                            />
+                          </FormCheckInput>
+                          <FormCheckLabel
+                            title=""
+                          >
+                            <label
+                              className="form-check-label"
+                              htmlFor="schoolOrTrainingradioNo"
+                              title=""
+                            >
+                              No
+                            </label>
+                          </FormCheckLabel>
+                        </div>
+                      </FormCheck>
+                      <Feedback
+                        type="invalid"
+                      >
+                        <div
+                          className="invalid-feedback"
+                        >
+                          This field is required.
+                        </div>
+                      </Feedback>
+                    </fieldset>
+                  </div>
+                </FormGroup>
+              </div>
+            </YesNoQuestion>
+            <YesNoQuestion
+              helpText="Look at the date each week begins and ends. If you performed any work during this week, all earnings must be reported regardless if payment has been received."
+              ifYes={false}
+              inputName="workOrEarn"
+              key="1workOrEarn"
+              onChange={[Function]}
+              questionNumber={6}
+              questionText={
+                <Trans
+                  i18nKey="retrocerts-certification.questions.ui-part-time.workOrEarn"
+                  t={[Function]}
+                />
+              }
+            >
+              <div
+                className="bg-light p-2 mt-2 mb-2"
+              >
+                <FormGroup
+                  className=""
+                  controlId="workOrEarn"
+                >
+                  <div
+                    className="form-group"
+                  >
+                    <fieldset>
+                      <FormLabel
+                        as="legend"
+                        column={false}
+                        srOnly={false}
+                      >
+                        <legend
+                          className="form-label"
+                          htmlFor="workOrEarn"
+                        >
+                          6
+                          . 
+                          <Trans
+                            i18nKey="retrocerts-certification.questions.ui-part-time.workOrEarn"
+                            t={[Function]}
+                          >
+                            Did you work or earn any money, 
+                            <strong
+                              key="strong-1"
+                            >
+                              whether you were paid or not
+                            </strong>
+                            ?
+                          </Trans>
+                        </legend>
+                      </FormLabel>
+                      <FormText
+                        className="help-text"
+                      >
+                        <small
+                          className="help-text form-text"
+                        >
+                          Look at the date each week begins and ends. If you performed any work during this week, all earnings must be reported regardless if payment has been received.
+                        </small>
+                      </FormText>
+                      <FormCheck
+                        checked={false}
+                        disabled={false}
+                        id="workOrEarnradioYes"
+                        inline={true}
+                        isInvalid={false}
+                        isValid={false}
+                        key="Yes"
+                        label="Yes"
+                        name="workOrEarn"
+                        onChange={[Function]}
+                        required={true}
+                        title=""
+                        type="radio"
+                        value="Yes"
+                      >
+                        <div
+                          className="form-check form-check-inline"
+                        >
+                          <FormCheckInput
+                            as="input"
+                            checked={false}
+                            disabled={false}
+                            isInvalid={false}
+                            isStatic={false}
+                            isValid={false}
+                            name="workOrEarn"
+                            onChange={[Function]}
+                            required={true}
+                            type="radio"
+                            value="Yes"
+                          >
+                            <input
+                              checked={false}
+                              className="form-check-input"
+                              disabled={false}
+                              id="workOrEarnradioYes"
+                              name="workOrEarn"
+                              onChange={[Function]}
+                              required={true}
+                              type="radio"
+                              value="Yes"
+                            />
+                          </FormCheckInput>
+                          <FormCheckLabel
+                            title=""
+                          >
+                            <label
+                              className="form-check-label"
+                              htmlFor="workOrEarnradioYes"
+                              title=""
+                            >
+                              Yes
+                            </label>
+                          </FormCheckLabel>
+                        </div>
+                      </FormCheck>
+                      <FormCheck
+                        checked={true}
+                        disabled={false}
+                        id="workOrEarnradioNo"
+                        inline={true}
+                        isInvalid={false}
+                        isValid={false}
+                        key="No"
+                        label="No"
+                        name="workOrEarn"
+                        onChange={[Function]}
+                        required={true}
+                        title=""
+                        type="radio"
+                        value="No"
+                      >
+                        <div
+                          className="form-check form-check-inline"
+                        >
+                          <FormCheckInput
+                            as="input"
+                            checked={true}
+                            disabled={false}
+                            isInvalid={false}
+                            isStatic={false}
+                            isValid={false}
+                            name="workOrEarn"
+                            onChange={[Function]}
+                            required={true}
+                            type="radio"
+                            value="No"
+                          >
+                            <input
+                              checked={true}
+                              className="form-check-input"
+                              disabled={false}
+                              id="workOrEarnradioNo"
+                              name="workOrEarn"
+                              onChange={[Function]}
+                              required={true}
+                              type="radio"
+                              value="No"
+                            />
+                          </FormCheckInput>
+                          <FormCheckLabel
+                            title=""
+                          >
+                            <label
+                              className="form-check-label"
+                              htmlFor="workOrEarnradioNo"
+                              title=""
+                            >
+                              No
+                            </label>
+                          </FormCheckLabel>
+                        </div>
+                      </FormCheck>
+                      <Feedback
+                        type="invalid"
+                      >
+                        <div
+                          className="invalid-feedback"
+                        >
+                          This field is required.
+                        </div>
+                      </Feedback>
+                    </fieldset>
+                  </div>
+                </FormGroup>
+              </div>
+            </YesNoQuestion>
+            <PerjuryCheckbox
+              isAnyWeekPua={false}
+            >
+              <FormGroup
+                className="unchecked"
+                controlId="perjury-checkbox"
+              >
+                <div
+                  className="unchecked form-group"
+                >
+                  <FormText
+                    as="h3"
+                  >
+                    <h3
+                      className="form-text"
+                    >
+                      Acknowledgement
+                    </h3>
+                  </FormText>
+                  <ul>
+                    <li>
+                      I understand the questions I answered through this automated system.
+                    </li>
+                    <li>
+                      I know the law provides penalties if I make false statements or withhold facts to receive benefits; and my answers are true and correct.
+                    </li>
+                    <li>
+                      I declare under penalty of perjury that I am a US Citizen or National; or an Alien in satisfactory immigration status and permitted to work by the United States Citizenship and Immigration Service.
+                    </li>
+                    <li>
+                      I understand when submitting my request for benefits my submission is considered the same as my written signature.
+                    </li>
+                  </ul>
+                  <FormRow>
+                    <div
+                      className="form-row"
+                    >
+                      <Col
+                        md="auto"
+                      >
+                        <div
+                          className="col-md-auto"
+                        >
+                          <FormCheck
+                            checked={false}
+                            disabled={false}
+                            inline={false}
+                            isInvalid={false}
+                            isValid={false}
+                            onChange={[Function]}
+                            required={true}
+                            title=""
+                            type="checkbox"
+                          >
+                            <div
+                              className="form-check"
+                            >
+                              <FormCheckInput
+                                as="input"
+                                checked={false}
+                                disabled={false}
+                                isInvalid={false}
+                                isStatic={true}
+                                isValid={false}
+                                onChange={[Function]}
+                                required={true}
+                                type="checkbox"
+                              >
+                                <input
+                                  checked={false}
+                                  className="form-check-input position-static"
+                                  disabled={false}
+                                  id="perjury-checkbox"
+                                  onChange={[Function]}
+                                  required={true}
+                                  type="checkbox"
+                                />
+                              </FormCheckInput>
+                            </div>
+                          </FormCheck>
+                        </div>
+                      </Col>
+                      <Col>
+                        <div
+                          className="col"
+                        >
+                          <FormLabel
+                            column={false}
+                            srOnly={false}
+                          >
+                            <label
+                              className="form-label"
+                              htmlFor="perjury-checkbox"
+                            >
+                              You must indicate your acceptance of the statement by checking the box before your certification can be submitted.
+                            </label>
+                          </FormLabel>
+                        </div>
+                      </Col>
+                    </div>
+                  </FormRow>
+                  <Feedback
+                    type="invalid"
+                  >
+                    <div
+                      className="invalid-feedback"
+                    >
+                      This field is required.
+                    </div>
+                  </Feedback>
+                  <FormText
+                    as="p"
+                  >
+                    <p
+                      className="form-text"
+                    >
+                      <Trans
+                        i18nKey="retrocerts-certification.submit-p1"
+                        t={[Function]}
+                      >
+                        You are about to submit your retroactive certifications. You will 
+                        <strong
+                          key="strong-1"
+                        >
+                          not
+                        </strong>
+                         be able to change your answers once you select 
+                        <strong
+                          key="strong-3"
+                        >
+                          Submit
+                        </strong>
+                        .
+                      </Trans>
+                    </p>
+                  </FormText>
+                </div>
+              </FormGroup>
+            </PerjuryCheckbox>
+            <FormRow>
+              <div
+                className="form-row"
+              >
+                <Col>
+                  <div
+                    className="col"
+                  >
+                    <Button
+                      active={false}
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "Link",
+                          "propTypes": Object {
+                            "innerRef": [Function],
+                            "onClick": [Function],
+                            "replace": [Function],
+                            "target": [Function],
+                            "to": [Function],
+                          },
+                          "render": [Function],
+                        }
+                      }
+                      className="text-dark bg-light"
+                      disabled={false}
+                      onClick={[Function]}
+                      to="/retroactive-certification/certify/2020-02-08"
+                      type="button"
+                      variant="outline-secondary"
+                    >
+                      <Link
+                        className="text-dark bg-light btn btn-outline-secondary"
+                        disabled={false}
+                        onClick={[Function]}
+                        to="/retroactive-certification/certify/2020-02-08"
+                      >
+                        <LinkAnchor
+                          className="text-dark bg-light btn btn-outline-secondary"
+                          disabled={false}
+                          href="/retroactive-certification/certify/2020-02-08"
+                          navigate={[Function]}
+                          onClick={[Function]}
+                        >
+                          <a
+                            className="text-dark bg-light btn btn-outline-secondary"
+                            disabled={false}
+                            href="/retroactive-certification/certify/2020-02-08"
+                            onClick={[Function]}
+                          >
+                            Back to Previous Week
+                          </a>
+                        </LinkAnchor>
+                      </Link>
+                    </Button>
+                  </div>
+                </Col>
+                <Col
+                  style={
+                    Object {
+                      "textAlign": "end",
+                    }
+                  }
+                >
+                  <div
+                    className="col"
+                    style={
+                      Object {
+                        "textAlign": "end",
+                      }
+                    }
+                  >
+                    <Button
+                      active={false}
+                      disabled={false}
+                      type="submit"
+                      variant="secondary"
+                    >
+                      <button
+                        className="btn btn-secondary"
+                        disabled={false}
+                        type="submit"
+                      >
+                        Submit
+                      </button>
+                    </Button>
+                  </div>
+                </Col>
+              </div>
+            </FormRow>
+          </form>
+        </Form>
+      </div>
+    </main>
+    <Footer
+      backToTopTag="certification-page"
+    >
+      <footer
+        className="footer"
+      >
+        <Navbar
+          bg="dark"
+          className="justify-content-between"
+          collapseOnSelect={false}
+          expand={true}
+          variant="custom"
+        >
+          <nav
+            className="justify-content-between navbar navbar-expand navbar-custom bg-dark"
+          >
+            <Nav
+              className="flex-wrap"
+              fill={false}
+              justify={false}
+            >
+              <ForwardRef
+                as="div"
+                className="flex-wrap navbar-nav"
+                onSelect={[Function]}
+              >
+                <div
+                  className="flex-wrap navbar-nav"
+                  onKeyDown={[Function]}
+                >
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="/#certification-page"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="/#certification-page"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="/#certification-page"
+                        disabled={false}
+                        href="/#certification-page"
+                        onClick={[Function]}
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="/#certification-page"
+                          href="/#certification-page"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                        >
+                          Back to Top
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/"
+                          href="https://edd.ca.gov/about_edd/"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          About EDD
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/contact_edd.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/contact_edd.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/contact_edd.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/contact_edd.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/contact_edd.htm"
+                          href="https://edd.ca.gov/about_edd/contact_edd.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Contact EDD
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                          href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Conditions of Use
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                          href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Privacy Policy
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/accessibility.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/accessibility.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/accessibility.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/accessibility.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/accessibility.htm"
+                          href="https://edd.ca.gov/about_edd/accessibility.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Accessibility
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/sitemap.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/sitemap.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/sitemap.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/sitemap.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/sitemap.htm"
+                          href="https://edd.ca.gov/sitemap.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Site Map
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                </div>
+              </ForwardRef>
+            </Nav>
+            <Nav
+              className="flex-wrap"
+              fill={false}
+              justify={false}
+            >
+              <ForwardRef
+                as="div"
+                className="flex-wrap navbar-nav"
+                onSelect={[Function]}
+              >
+                <div
+                  className="flex-wrap navbar-nav"
+                  onKeyDown={[Function]}
+                >
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://www.facebook.com/californiaedd/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://www.facebook.com/californiaedd/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://www.facebook.com/californiaedd/"
+                        disabled={false}
+                        href="https://www.facebook.com/californiaedd/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://www.facebook.com/californiaedd/"
+                          href="https://www.facebook.com/californiaedd/"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="Facebook icon"
+                            height="15"
+                            src="images/facebook.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://twitter.com/CA_EDD"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://twitter.com/CA_EDD"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://twitter.com/CA_EDD"
+                        disabled={false}
+                        href="https://twitter.com/CA_EDD"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://twitter.com/CA_EDD"
+                          href="https://twitter.com/CA_EDD"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="Twitter icon"
+                            height="15"
+                            src="images/twitter.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://www.linkedin.com/company/californiaedd/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://www.linkedin.com/company/californiaedd/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://www.linkedin.com/company/californiaedd/"
+                        disabled={false}
+                        href="https://www.linkedin.com/company/californiaedd/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://www.linkedin.com/company/californiaedd/"
+                          href="https://www.linkedin.com/company/californiaedd/"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="LinkedIn icon"
+                            height="15"
+                            src="images/linkedin.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://www.instagram.com/ca_edd/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://www.instagram.com/ca_edd/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://www.instagram.com/ca_edd/"
+                        disabled={false}
+                        href="https://www.instagram.com/ca_edd/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://www.instagram.com/ca_edd/"
+                          href="https://www.instagram.com/ca_edd/"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="Instagram icon"
+                            height="15"
+                            src="images/instagram.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://www.youtube.com/user/CaliforniaEDD"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://www.youtube.com/user/CaliforniaEDD"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://www.youtube.com/user/CaliforniaEDD"
+                        disabled={false}
+                        href="https://www.youtube.com/user/CaliforniaEDD"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://www.youtube.com/user/CaliforniaEDD"
+                          href="https://www.youtube.com/user/CaliforniaEDD"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="YouTube icon"
+                            height="15"
+                            src="images/youtube.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                </div>
+              </ForwardRef>
+            </Nav>
+          </nav>
+        </Navbar>
+        <div
+          className="bg-light secondary-footer"
+        >
+          <Container
+            fluid={false}
+          >
+            <div
+              className="container"
+            >
+              Copyright © 2020 State of California
+            </div>
+          </Container>
+        </div>
+      </footer>
+    </Footer>
+  </div>
+</RetroCertsCertificationPage>
 `;
 
 exports[`<RetroCertsCertificationPage /> Certify for one week of 2 1`] = `
-<div
-  id="overflow-wrapper"
+<RetroCertsCertificationPage
+  routeComputedMatch={
+    Object {
+      "params": Object {
+        "week": "2020-02-08",
+      },
+    }
+  }
+  setUserData={[Function]}
+  userData={
+    Object {
+      "formData": Array [
+        Object {
+          "fullTime": true,
+          "tooSick": false,
+          "weekIndex": 0,
+        },
+      ],
+      "programPlan": Array [
+        "UI full time",
+        "UI part time",
+      ],
+      "status": "ok",
+      "weeksToCertify": Array [
+        0,
+        1,
+      ],
+    }
+  }
 >
-  <Header />
-  <main
-    className="questions"
-    id="certification-page"
+  <div
+    id="overflow-wrapper"
   >
-    <div
-      className="container p-4"
+    <Header>
+      <header
+        className="header border-bottom border-secondary"
+      >
+        <Navbar
+          bg="primary"
+          className="justify-content-between"
+          collapseOnSelect={false}
+          expand={true}
+          variant="custom"
+        >
+          <nav
+            className="justify-content-between navbar navbar-expand navbar-custom bg-primary"
+          >
+            <NavbarBrand
+              href="https://ca.gov"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <a
+                className="navbar-brand"
+                href="https://ca.gov"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <img
+                  alt="California gov logo"
+                  height="30"
+                  src="images/Ca-Gov-Logo-Gold.svg"
+                  width="30"
+                />
+              </a>
+            </NavbarBrand>
+            <Nav
+              fill={false}
+              justify={false}
+            >
+              <ForwardRef
+                as="div"
+                className="navbar-nav"
+                onSelect={[Function]}
+              >
+                <div
+                  className="navbar-nav"
+                  onKeyDown={[Function]}
+                >
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov"
+                        disabled={false}
+                        href="https://edd.ca.gov"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov"
+                          href="https://edd.ca.gov"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="home icon"
+                            className="icon"
+                            height="15"
+                            src="images/home.svg"
+                            width="15"
+                          />
+                           
+                          <span
+                            className="text"
+                          >
+                            Home
+                          </span>
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/login.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/login.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/login.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/login.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/login.htm"
+                          href="https://edd.ca.gov/login.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <span>
+                            <img
+                              alt="key icon"
+                              className="icon"
+                              height="15"
+                              src="images/key.svg"
+                              width="15"
+                            />
+                             
+                            <span
+                              className="text"
+                            >
+                              Log In
+                            </span>
+                          </span>
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                </div>
+              </ForwardRef>
+            </Nav>
+          </nav>
+        </Navbar>
+        <Navbar
+          collapseOnSelect={true}
+          expand="md"
+          variant="light"
+        >
+          <nav
+            className="navbar navbar-expand-md navbar-light"
+          >
+            <NavbarBrand
+              href="https://edd.ca.gov"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <a
+                className="navbar-brand"
+                href="https://edd.ca.gov"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <img
+                  alt="California gov logo"
+                  className="d-inline-block align-top mr-5"
+                  height="50"
+                  src="images/edd-logo-2-Color.svg"
+                  width="150"
+                />
+              </a>
+            </NavbarBrand>
+            <NavbarToggle
+              aria-controls="responsive-navbar-nav"
+              label="Toggle navigation"
+            >
+              <button
+                aria-controls="responsive-navbar-nav"
+                aria-label="Toggle navigation"
+                className="navbar-toggler collapsed"
+                onClick={[Function]}
+                type="button"
+              >
+                <span
+                  className="navbar-toggler-icon"
+                />
+              </button>
+            </NavbarToggle>
+            <NavbarCollapse
+              className="justify-content-between ml-5 mr-5 pl-5"
+            >
+              <Collapse
+                appear={false}
+                className="justify-content-between ml-5 mr-5 pl-5"
+                dimension="height"
+                getDimensionValue={[Function]}
+                in={false}
+                mountOnEnter={false}
+                timeout={300}
+                unmountOnExit={false}
+              >
+                <Transition
+                  addEndListener={[Function]}
+                  appear={false}
+                  aria-expanded={null}
+                  enter={true}
+                  exit={true}
+                  in={false}
+                  mountOnEnter={false}
+                  onEnter={[Function]}
+                  onEntered={[Function]}
+                  onEntering={[Function]}
+                  onExit={[Function]}
+                  onExited={[Function]}
+                  onExiting={[Function]}
+                  timeout={300}
+                  unmountOnExit={false}
+                >
+                  <div
+                    aria-expanded={null}
+                    className="justify-content-between ml-5 mr-5 pl-5 navbar-collapse collapse"
+                  >
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/jobs.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/jobs.htm"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/jobs.htm"
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/jobs.htm"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Jobs
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/claims.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/claims.htm"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/claims.htm"
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/claims.htm"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Claims
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/employers.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/employers.htm"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/employers.htm"
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/employers.htm"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Employers
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/newsroom.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/newsroom.htm"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/newsroom.htm"
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/newsroom.htm"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Newsroom
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/serp.html?q="
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/serp.html?q="
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/serp.html?q="
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/serp.html?q="
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Search
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                  </div>
+                </Transition>
+              </Collapse>
+            </NavbarCollapse>
+          </nav>
+        </Navbar>
+      </header>
+    </Header>
+    <main
+      className="questions"
+      id="certification-page"
     >
-      <h1>
-        Retroactively Certify and Review
-      </h1>
-      <LanguageSelector
-        className="mt-3 mb-4"
-      />
-      <h2
-        className="h3 font-weight-bold mt-4"
+      <div
+        className="container p-4"
       >
-        <Trans
-          i18nKey="retrocerts-certification.form-header"
-          t={[Function]}
-          values={
-            Object {
-              "weekForUser": 1,
-              "weekString": "02/02/2020 - 02/08/2020",
-            }
-          }
-        />
-      </h2>
-      <p>
-        <Trans
-          i18nKey="retrocerts-certification.p1-multiple"
-          t={[Function]}
-          values={
-            Object {
-              "numberOfWeeks": 2,
-              "weekForUser": 1,
-            }
-          }
-        />
-      </p>
-      <Form
-        inline={false}
-        noValidate={true}
-        onSubmit={[Function]}
-        validated={false}
-      >
-        <YesNoQuestion
-          helpText={
-            <Trans
-              i18nKey="retrocerts-certification.questions.ui-full-time.help-tooSick"
-              t={[Function]}
-            />
-          }
-          ifYes={false}
-          inputName="tooSick"
-          key="0tooSick"
-          onChange={[Function]}
-          questionNumber={1}
-          questionText="Were you too sick or injured to work?"
+        <h1>
+          Retroactively Certify and Review
+        </h1>
+        <LanguageSelector
+          className="mt-3 mb-4"
         >
-          <DaysSickQuestion
-            helpText="You must report the numbers of days that you could not work during this week. Unemployment benefits are paid according to the number of days you are able to work this week."
-            onChange={[Function]}
-            questionText="If yes, enter the number of days (1-7) you were unable to work."
-          />
-        </YesNoQuestion>
-        <YesNoQuestion
-          helpText={
-            <Trans
-              i18nKey="retrocerts-certification.questions.ui-full-time.help-couldNotAcceptWork"
-              t={[Function]}
-            />
-          }
-          inputName="couldNotAcceptWork"
-          key="0couldNotAcceptWork"
-          onChange={[Function]}
-          questionNumber={2}
-          questionText={
-            <Trans
-              i18nKey="retrocerts-certification.questions.ui-full-time.couldNotAcceptWork"
-              t={[Function]}
-              values={
-                Object {
-                  "weekString": "02/02/2020 - 02/08/2020",
-                }
-              }
-            />
-          }
-        />
-        <YesNoQuestion
-          helpText={
-            <Trans
-              i18nKey="retrocerts-certification.questions.ui-full-time.help-didYouLook"
-              t={[Function]}
-            />
-          }
-          inputName="didYouLook"
-          key="0didYouLook"
-          onChange={[Function]}
-          questionNumber={3}
-          questionText={
-            <Trans
-              i18nKey="retrocerts-certification.questions.ui-full-time.didYouLook"
-              t={[Function]}
-              values={
-                Object {
-                  "weekString": "02/02/2020 - 02/08/2020",
-                }
-              }
-            />
-          }
-        />
-        <YesNoQuestion
-          helpText={
-            <Trans
-              i18nKey="retrocerts-certification.questions.ui-full-time.help-refuseWork"
-              t={[Function]}
-            />
-          }
-          inputName="refuseWork"
-          key="0refuseWork"
-          onChange={[Function]}
-          questionNumber={4}
-          questionText={
-            <Trans
-              i18nKey="retrocerts-certification.questions.ui-full-time.refuseWork"
-              t={[Function]}
-              values={
-                Object {
-                  "weekString": "02/02/2020 - 02/08/2020",
-                }
-              }
-            />
-          }
-        />
-        <YesNoQuestion
-          helpText={
-            <Trans
-              i18nKey="retrocerts-certification.questions.ui-full-time.help-schoolOrTraining"
-              t={[Function]}
-            />
-          }
-          inputName="schoolOrTraining"
-          key="0schoolOrTraining"
-          onChange={[Function]}
-          questionNumber={5}
-          questionText={
-            <Trans
-              i18nKey="retrocerts-certification.questions.ui-full-time.schoolOrTraining"
-              t={[Function]}
-              values={
-                Object {
-                  "weekString": "02/02/2020 - 02/08/2020",
-                }
-              }
-            />
-          }
-        />
-        <YesNoQuestion
-          helpText="Look at the date each week begins and ends. If you performed any work during this week, all earnings must be reported regardless if payment has been received."
-          inputName="workOrEarn"
-          key="0workOrEarn"
-          onChange={[Function]}
-          questionNumber={6}
-          questionText={
-            <Trans
-              i18nKey="retrocerts-certification.questions.ui-full-time.workOrEarn"
-              t={[Function]}
-            />
-          }
-        >
-          <EmployersQuestions
-            onChange={[Function]}
-          />
-        </YesNoQuestion>
-        <FormRow>
-          <Col>
-            <Button
-              active={false}
-              as={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "displayName": "Link",
-                  "propTypes": Object {
-                    "innerRef": [Function],
-                    "onClick": [Function],
-                    "replace": [Function],
-                    "target": [Function],
-                    "to": [Function],
-                  },
-                  "render": [Function],
-                }
-              }
-              className="text-dark bg-light"
+          <Button
+            active={false}
+            className="text-dark bg-light mt-3 mb-4"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+            variant="outline-secondary"
+          >
+            <button
+              className="text-dark bg-light mt-3 mb-4 btn btn-outline-secondary"
               disabled={false}
               onClick={[Function]}
-              to="/retroactive-certification/weeks-to-certify"
               type="button"
-              variant="outline-secondary"
             >
-              Back
-            </Button>
-          </Col>
-          <Col
-            style={
+              Español
+            </button>
+          </Button>
+        </LanguageSelector>
+        <h2
+          className="h3 font-weight-bold mt-4"
+        >
+          <Trans
+            i18nKey="retrocerts-certification.form-header"
+            t={[Function]}
+            values={
               Object {
-                "textAlign": "end",
+                "weekForUser": 1,
+                "weekString": "02/02/2020 - 02/08/2020",
               }
             }
           >
-            <Button
-              active={false}
-              disabled={false}
-              type="submit"
-              variant="secondary"
+            Week 1: 02/02/2020 - 02/08/2020
+          </Trans>
+        </h2>
+        <p>
+          <Trans
+            i18nKey="retrocerts-certification.p1-multiple"
+            t={[Function]}
+            values={
+              Object {
+                "numberOfWeeks": 2,
+                "weekForUser": 1,
+              }
+            }
+          >
+            You are on Week 1 of 2 weeks to retroactively certify.
+          </Trans>
+        </p>
+        <Form
+          inline={false}
+          noValidate={true}
+          onSubmit={[Function]}
+          validated={false}
+        >
+          <form
+            className=""
+            noValidate={true}
+            onSubmit={[Function]}
+          >
+            <YesNoQuestion
+              helpText={
+                <Trans
+                  i18nKey="retrocerts-certification.questions.ui-full-time.help-tooSick"
+                  t={[Function]}
+                />
+              }
+              ifYes={false}
+              inputName="tooSick"
+              key="0tooSick"
+              onChange={[Function]}
+              questionNumber={1}
+              questionText="Were you too sick or injured to work?"
             >
-              <Trans
-                i18nKey="retrocerts-certification.button-next"
-                t={[Function]}
-                values={
-                  Object {
-                    "nextWeekForUser": 2,
+              <div
+                className="bg-light p-2 mt-2 mb-2"
+              >
+                <FormGroup
+                  className=""
+                  controlId="tooSick"
+                >
+                  <div
+                    className="form-group"
+                  >
+                    <fieldset>
+                      <FormLabel
+                        as="legend"
+                        column={false}
+                        srOnly={false}
+                      >
+                        <legend
+                          className="form-label"
+                          htmlFor="tooSick"
+                        >
+                          1
+                          . 
+                          Were you too sick or injured to work?
+                        </legend>
+                      </FormLabel>
+                      <FormText
+                        className="help-text"
+                      >
+                        <small
+                          className="help-text form-text"
+                        >
+                          <Trans
+                            i18nKey="retrocerts-certification.questions.ui-full-time.help-tooSick"
+                            t={[Function]}
+                          >
+                            You must be well enough to work every day of the week to receive full benefits. Check 
+                            <strong
+                              key="strong-1"
+                            >
+                              Yes
+                            </strong>
+                             if a workday was missed due to being sick or injured.
+                          </Trans>
+                        </small>
+                      </FormText>
+                      <FormCheck
+                        checked={false}
+                        disabled={false}
+                        id="tooSickradioYes"
+                        inline={true}
+                        isInvalid={false}
+                        isValid={false}
+                        key="Yes"
+                        label="Yes"
+                        name="tooSick"
+                        onChange={[Function]}
+                        required={true}
+                        title=""
+                        type="radio"
+                        value="Yes"
+                      >
+                        <div
+                          className="form-check form-check-inline"
+                        >
+                          <FormCheckInput
+                            as="input"
+                            checked={false}
+                            disabled={false}
+                            isInvalid={false}
+                            isStatic={false}
+                            isValid={false}
+                            name="tooSick"
+                            onChange={[Function]}
+                            required={true}
+                            type="radio"
+                            value="Yes"
+                          >
+                            <input
+                              checked={false}
+                              className="form-check-input"
+                              disabled={false}
+                              id="tooSickradioYes"
+                              name="tooSick"
+                              onChange={[Function]}
+                              required={true}
+                              type="radio"
+                              value="Yes"
+                            />
+                          </FormCheckInput>
+                          <FormCheckLabel
+                            title=""
+                          >
+                            <label
+                              className="form-check-label"
+                              htmlFor="tooSickradioYes"
+                              title=""
+                            >
+                              Yes
+                            </label>
+                          </FormCheckLabel>
+                        </div>
+                      </FormCheck>
+                      <FormCheck
+                        checked={true}
+                        disabled={false}
+                        id="tooSickradioNo"
+                        inline={true}
+                        isInvalid={false}
+                        isValid={false}
+                        key="No"
+                        label="No"
+                        name="tooSick"
+                        onChange={[Function]}
+                        required={true}
+                        title=""
+                        type="radio"
+                        value="No"
+                      >
+                        <div
+                          className="form-check form-check-inline"
+                        >
+                          <FormCheckInput
+                            as="input"
+                            checked={true}
+                            disabled={false}
+                            isInvalid={false}
+                            isStatic={false}
+                            isValid={false}
+                            name="tooSick"
+                            onChange={[Function]}
+                            required={true}
+                            type="radio"
+                            value="No"
+                          >
+                            <input
+                              checked={true}
+                              className="form-check-input"
+                              disabled={false}
+                              id="tooSickradioNo"
+                              name="tooSick"
+                              onChange={[Function]}
+                              required={true}
+                              type="radio"
+                              value="No"
+                            />
+                          </FormCheckInput>
+                          <FormCheckLabel
+                            title=""
+                          >
+                            <label
+                              className="form-check-label"
+                              htmlFor="tooSickradioNo"
+                              title=""
+                            >
+                              No
+                            </label>
+                          </FormCheckLabel>
+                        </div>
+                      </FormCheck>
+                      <Feedback
+                        type="invalid"
+                      >
+                        <div
+                          className="invalid-feedback"
+                        >
+                          This field is required.
+                        </div>
+                      </Feedback>
+                    </fieldset>
+                  </div>
+                </FormGroup>
+              </div>
+            </YesNoQuestion>
+            <YesNoQuestion
+              helpText={
+                <Trans
+                  i18nKey="retrocerts-certification.questions.ui-full-time.help-couldNotAcceptWork"
+                  t={[Function]}
+                />
+              }
+              inputName="couldNotAcceptWork"
+              key="0couldNotAcceptWork"
+              onChange={[Function]}
+              questionNumber={2}
+              questionText={
+                <Trans
+                  i18nKey="retrocerts-certification.questions.ui-full-time.couldNotAcceptWork"
+                  t={[Function]}
+                  values={
+                    Object {
+                      "weekString": "02/02/2020 - 02/08/2020",
+                    }
                   }
-                }
-              />
-            </Button>
-          </Col>
-        </FormRow>
-      </Form>
-    </div>
-  </main>
-  <Footer
-    backToTopTag="certification-page"
-  />
-</div>
+                />
+              }
+            >
+              <div
+                className="bg-light p-2 mt-2 mb-2"
+              >
+                <FormGroup
+                  className="unchecked"
+                  controlId="couldNotAcceptWork"
+                >
+                  <div
+                    className="unchecked form-group"
+                  >
+                    <fieldset>
+                      <FormLabel
+                        as="legend"
+                        column={false}
+                        srOnly={false}
+                      >
+                        <legend
+                          className="form-label"
+                          htmlFor="couldNotAcceptWork"
+                        >
+                          2
+                          . 
+                          <Trans
+                            i18nKey="retrocerts-certification.questions.ui-full-time.couldNotAcceptWork"
+                            t={[Function]}
+                            values={
+                              Object {
+                                "weekString": "02/02/2020 - 02/08/2020",
+                              }
+                            }
+                          >
+                            Was there any reason (other than sickness or injury) that you could not have accepted full-time work 
+                            <strong
+                              key="strong-1"
+                            >
+                              each workday
+                            </strong>
+                            ?
+                          </Trans>
+                        </legend>
+                      </FormLabel>
+                      <FormText
+                        className="help-text"
+                      >
+                        <small
+                          className="help-text form-text"
+                        >
+                          <Trans
+                            i18nKey="retrocerts-certification.questions.ui-full-time.help-couldNotAcceptWork"
+                            t={[Function]}
+                          >
+                            You must be available for work to receive unemployment benefits. Available means you are ready and willing to accept work that matches your occupational skills and educational background. If full-time work was refused for any reason other than being sick or injured, check 
+                            <strong
+                              key="strong-1"
+                            >
+                              Yes
+                            </strong>
+                            .
+                          </Trans>
+                        </small>
+                      </FormText>
+                      <FormCheck
+                        checked={false}
+                        disabled={false}
+                        id="couldNotAcceptWorkradioYes"
+                        inline={true}
+                        isInvalid={false}
+                        isValid={false}
+                        key="Yes"
+                        label="Yes"
+                        name="couldNotAcceptWork"
+                        onChange={[Function]}
+                        required={true}
+                        title=""
+                        type="radio"
+                        value="Yes"
+                      >
+                        <div
+                          className="form-check form-check-inline"
+                        >
+                          <FormCheckInput
+                            as="input"
+                            checked={false}
+                            disabled={false}
+                            isInvalid={false}
+                            isStatic={false}
+                            isValid={false}
+                            name="couldNotAcceptWork"
+                            onChange={[Function]}
+                            required={true}
+                            type="radio"
+                            value="Yes"
+                          >
+                            <input
+                              checked={false}
+                              className="form-check-input"
+                              disabled={false}
+                              id="couldNotAcceptWorkradioYes"
+                              name="couldNotAcceptWork"
+                              onChange={[Function]}
+                              required={true}
+                              type="radio"
+                              value="Yes"
+                            />
+                          </FormCheckInput>
+                          <FormCheckLabel
+                            title=""
+                          >
+                            <label
+                              className="form-check-label"
+                              htmlFor="couldNotAcceptWorkradioYes"
+                              title=""
+                            >
+                              Yes
+                            </label>
+                          </FormCheckLabel>
+                        </div>
+                      </FormCheck>
+                      <FormCheck
+                        checked={false}
+                        disabled={false}
+                        id="couldNotAcceptWorkradioNo"
+                        inline={true}
+                        isInvalid={false}
+                        isValid={false}
+                        key="No"
+                        label="No"
+                        name="couldNotAcceptWork"
+                        onChange={[Function]}
+                        required={true}
+                        title=""
+                        type="radio"
+                        value="No"
+                      >
+                        <div
+                          className="form-check form-check-inline"
+                        >
+                          <FormCheckInput
+                            as="input"
+                            checked={false}
+                            disabled={false}
+                            isInvalid={false}
+                            isStatic={false}
+                            isValid={false}
+                            name="couldNotAcceptWork"
+                            onChange={[Function]}
+                            required={true}
+                            type="radio"
+                            value="No"
+                          >
+                            <input
+                              checked={false}
+                              className="form-check-input"
+                              disabled={false}
+                              id="couldNotAcceptWorkradioNo"
+                              name="couldNotAcceptWork"
+                              onChange={[Function]}
+                              required={true}
+                              type="radio"
+                              value="No"
+                            />
+                          </FormCheckInput>
+                          <FormCheckLabel
+                            title=""
+                          >
+                            <label
+                              className="form-check-label"
+                              htmlFor="couldNotAcceptWorkradioNo"
+                              title=""
+                            >
+                              No
+                            </label>
+                          </FormCheckLabel>
+                        </div>
+                      </FormCheck>
+                      <Feedback
+                        type="invalid"
+                      >
+                        <div
+                          className="invalid-feedback"
+                        >
+                          This field is required.
+                        </div>
+                      </Feedback>
+                    </fieldset>
+                  </div>
+                </FormGroup>
+              </div>
+            </YesNoQuestion>
+            <YesNoQuestion
+              helpText={
+                <Trans
+                  i18nKey="retrocerts-certification.questions.ui-full-time.help-didYouLook"
+                  t={[Function]}
+                />
+              }
+              inputName="didYouLook"
+              key="0didYouLook"
+              onChange={[Function]}
+              questionNumber={3}
+              questionText={
+                <Trans
+                  i18nKey="retrocerts-certification.questions.ui-full-time.didYouLook"
+                  t={[Function]}
+                  values={
+                    Object {
+                      "weekString": "02/02/2020 - 02/08/2020",
+                    }
+                  }
+                />
+              }
+            >
+              <div
+                className="bg-light p-2 mt-2 mb-2"
+              >
+                <FormGroup
+                  className="unchecked"
+                  controlId="didYouLook"
+                >
+                  <div
+                    className="unchecked form-group"
+                  >
+                    <fieldset>
+                      <FormLabel
+                        as="legend"
+                        column={false}
+                        srOnly={false}
+                      >
+                        <legend
+                          className="form-label"
+                          htmlFor="didYouLook"
+                        >
+                          3
+                          . 
+                          <Trans
+                            i18nKey="retrocerts-certification.questions.ui-full-time.didYouLook"
+                            t={[Function]}
+                            values={
+                              Object {
+                                "weekString": "02/02/2020 - 02/08/2020",
+                              }
+                            }
+                          >
+                            Did you look for work?
+                          </Trans>
+                        </legend>
+                      </FormLabel>
+                      <FormText
+                        className="help-text"
+                      >
+                        <small
+                          className="help-text form-text"
+                        >
+                          <Trans
+                            i18nKey="retrocerts-certification.questions.ui-full-time.help-didYouLook"
+                            t={[Function]}
+                          >
+                            Work searches may include in person, mail, telephone, or internet contacts with employers.
+                          </Trans>
+                        </small>
+                      </FormText>
+                      <FormCheck
+                        checked={false}
+                        disabled={false}
+                        id="didYouLookradioYes"
+                        inline={true}
+                        isInvalid={false}
+                        isValid={false}
+                        key="Yes"
+                        label="Yes"
+                        name="didYouLook"
+                        onChange={[Function]}
+                        required={true}
+                        title=""
+                        type="radio"
+                        value="Yes"
+                      >
+                        <div
+                          className="form-check form-check-inline"
+                        >
+                          <FormCheckInput
+                            as="input"
+                            checked={false}
+                            disabled={false}
+                            isInvalid={false}
+                            isStatic={false}
+                            isValid={false}
+                            name="didYouLook"
+                            onChange={[Function]}
+                            required={true}
+                            type="radio"
+                            value="Yes"
+                          >
+                            <input
+                              checked={false}
+                              className="form-check-input"
+                              disabled={false}
+                              id="didYouLookradioYes"
+                              name="didYouLook"
+                              onChange={[Function]}
+                              required={true}
+                              type="radio"
+                              value="Yes"
+                            />
+                          </FormCheckInput>
+                          <FormCheckLabel
+                            title=""
+                          >
+                            <label
+                              className="form-check-label"
+                              htmlFor="didYouLookradioYes"
+                              title=""
+                            >
+                              Yes
+                            </label>
+                          </FormCheckLabel>
+                        </div>
+                      </FormCheck>
+                      <FormCheck
+                        checked={false}
+                        disabled={false}
+                        id="didYouLookradioNo"
+                        inline={true}
+                        isInvalid={false}
+                        isValid={false}
+                        key="No"
+                        label="No"
+                        name="didYouLook"
+                        onChange={[Function]}
+                        required={true}
+                        title=""
+                        type="radio"
+                        value="No"
+                      >
+                        <div
+                          className="form-check form-check-inline"
+                        >
+                          <FormCheckInput
+                            as="input"
+                            checked={false}
+                            disabled={false}
+                            isInvalid={false}
+                            isStatic={false}
+                            isValid={false}
+                            name="didYouLook"
+                            onChange={[Function]}
+                            required={true}
+                            type="radio"
+                            value="No"
+                          >
+                            <input
+                              checked={false}
+                              className="form-check-input"
+                              disabled={false}
+                              id="didYouLookradioNo"
+                              name="didYouLook"
+                              onChange={[Function]}
+                              required={true}
+                              type="radio"
+                              value="No"
+                            />
+                          </FormCheckInput>
+                          <FormCheckLabel
+                            title=""
+                          >
+                            <label
+                              className="form-check-label"
+                              htmlFor="didYouLookradioNo"
+                              title=""
+                            >
+                              No
+                            </label>
+                          </FormCheckLabel>
+                        </div>
+                      </FormCheck>
+                      <Feedback
+                        type="invalid"
+                      >
+                        <div
+                          className="invalid-feedback"
+                        >
+                          This field is required.
+                        </div>
+                      </Feedback>
+                    </fieldset>
+                  </div>
+                </FormGroup>
+              </div>
+            </YesNoQuestion>
+            <YesNoQuestion
+              helpText={
+                <Trans
+                  i18nKey="retrocerts-certification.questions.ui-full-time.help-refuseWork"
+                  t={[Function]}
+                />
+              }
+              inputName="refuseWork"
+              key="0refuseWork"
+              onChange={[Function]}
+              questionNumber={4}
+              questionText={
+                <Trans
+                  i18nKey="retrocerts-certification.questions.ui-full-time.refuseWork"
+                  t={[Function]}
+                  values={
+                    Object {
+                      "weekString": "02/02/2020 - 02/08/2020",
+                    }
+                  }
+                />
+              }
+            >
+              <div
+                className="bg-light p-2 mt-2 mb-2"
+              >
+                <FormGroup
+                  className="unchecked"
+                  controlId="refuseWork"
+                >
+                  <div
+                    className="unchecked form-group"
+                  >
+                    <fieldset>
+                      <FormLabel
+                        as="legend"
+                        column={false}
+                        srOnly={false}
+                      >
+                        <legend
+                          className="form-label"
+                          htmlFor="refuseWork"
+                        >
+                          4
+                          . 
+                          <Trans
+                            i18nKey="retrocerts-certification.questions.ui-full-time.refuseWork"
+                            t={[Function]}
+                            values={
+                              Object {
+                                "weekString": "02/02/2020 - 02/08/2020",
+                              }
+                            }
+                          >
+                            Did you refuse any work?
+                          </Trans>
+                        </legend>
+                      </FormLabel>
+                      <FormText
+                        className="help-text"
+                      >
+                        <small
+                          className="help-text form-text"
+                        >
+                          <Trans
+                            i18nKey="retrocerts-certification.questions.ui-full-time.help-refuseWork"
+                            t={[Function]}
+                          >
+                            If work was refused, a determination will be scheduled. Union members, check 
+                            <strong
+                              key="strong-1"
+                            >
+                              Yes
+                            </strong>
+                             if a union referral to a job was refused.
+                          </Trans>
+                        </small>
+                      </FormText>
+                      <FormCheck
+                        checked={false}
+                        disabled={false}
+                        id="refuseWorkradioYes"
+                        inline={true}
+                        isInvalid={false}
+                        isValid={false}
+                        key="Yes"
+                        label="Yes"
+                        name="refuseWork"
+                        onChange={[Function]}
+                        required={true}
+                        title=""
+                        type="radio"
+                        value="Yes"
+                      >
+                        <div
+                          className="form-check form-check-inline"
+                        >
+                          <FormCheckInput
+                            as="input"
+                            checked={false}
+                            disabled={false}
+                            isInvalid={false}
+                            isStatic={false}
+                            isValid={false}
+                            name="refuseWork"
+                            onChange={[Function]}
+                            required={true}
+                            type="radio"
+                            value="Yes"
+                          >
+                            <input
+                              checked={false}
+                              className="form-check-input"
+                              disabled={false}
+                              id="refuseWorkradioYes"
+                              name="refuseWork"
+                              onChange={[Function]}
+                              required={true}
+                              type="radio"
+                              value="Yes"
+                            />
+                          </FormCheckInput>
+                          <FormCheckLabel
+                            title=""
+                          >
+                            <label
+                              className="form-check-label"
+                              htmlFor="refuseWorkradioYes"
+                              title=""
+                            >
+                              Yes
+                            </label>
+                          </FormCheckLabel>
+                        </div>
+                      </FormCheck>
+                      <FormCheck
+                        checked={false}
+                        disabled={false}
+                        id="refuseWorkradioNo"
+                        inline={true}
+                        isInvalid={false}
+                        isValid={false}
+                        key="No"
+                        label="No"
+                        name="refuseWork"
+                        onChange={[Function]}
+                        required={true}
+                        title=""
+                        type="radio"
+                        value="No"
+                      >
+                        <div
+                          className="form-check form-check-inline"
+                        >
+                          <FormCheckInput
+                            as="input"
+                            checked={false}
+                            disabled={false}
+                            isInvalid={false}
+                            isStatic={false}
+                            isValid={false}
+                            name="refuseWork"
+                            onChange={[Function]}
+                            required={true}
+                            type="radio"
+                            value="No"
+                          >
+                            <input
+                              checked={false}
+                              className="form-check-input"
+                              disabled={false}
+                              id="refuseWorkradioNo"
+                              name="refuseWork"
+                              onChange={[Function]}
+                              required={true}
+                              type="radio"
+                              value="No"
+                            />
+                          </FormCheckInput>
+                          <FormCheckLabel
+                            title=""
+                          >
+                            <label
+                              className="form-check-label"
+                              htmlFor="refuseWorkradioNo"
+                              title=""
+                            >
+                              No
+                            </label>
+                          </FormCheckLabel>
+                        </div>
+                      </FormCheck>
+                      <Feedback
+                        type="invalid"
+                      >
+                        <div
+                          className="invalid-feedback"
+                        >
+                          This field is required.
+                        </div>
+                      </Feedback>
+                    </fieldset>
+                  </div>
+                </FormGroup>
+              </div>
+            </YesNoQuestion>
+            <YesNoQuestion
+              helpText={
+                <Trans
+                  i18nKey="retrocerts-certification.questions.ui-full-time.help-schoolOrTraining"
+                  t={[Function]}
+                />
+              }
+              inputName="schoolOrTraining"
+              key="0schoolOrTraining"
+              onChange={[Function]}
+              questionNumber={5}
+              questionText={
+                <Trans
+                  i18nKey="retrocerts-certification.questions.ui-full-time.schoolOrTraining"
+                  t={[Function]}
+                  values={
+                    Object {
+                      "weekString": "02/02/2020 - 02/08/2020",
+                    }
+                  }
+                />
+              }
+            >
+              <div
+                className="bg-light p-2 mt-2 mb-2"
+              >
+                <FormGroup
+                  className="unchecked"
+                  controlId="schoolOrTraining"
+                >
+                  <div
+                    className="unchecked form-group"
+                  >
+                    <fieldset>
+                      <FormLabel
+                        as="legend"
+                        column={false}
+                        srOnly={false}
+                      >
+                        <legend
+                          className="form-label"
+                          htmlFor="schoolOrTraining"
+                        >
+                          5
+                          . 
+                          <Trans
+                            i18nKey="retrocerts-certification.questions.ui-full-time.schoolOrTraining"
+                            t={[Function]}
+                            values={
+                              Object {
+                                "weekString": "02/02/2020 - 02/08/2020",
+                              }
+                            }
+                          >
+                            Did you 
+                            <strong
+                              key="strong-1"
+                            >
+                              begin
+                            </strong>
+                             attending any kind of school or training? Select 
+                            <strong
+                              key="strong-3"
+                            >
+                              Yes
+                            </strong>
+                             only if you began attending school between 02/02/2020 - 02/08/2020.
+                          </Trans>
+                        </legend>
+                      </FormLabel>
+                      <FormText
+                        className="help-text"
+                      >
+                        <small
+                          className="help-text form-text"
+                        >
+                          <Trans
+                            i18nKey="retrocerts-certification.questions.ui-full-time.help-schoolOrTraining"
+                            t={[Function]}
+                          >
+                            Check 
+                            <strong
+                              key="strong-1"
+                            >
+                              Yes
+                            </strong>
+                             only if school or training 
+                            <strong
+                              key="strong-3"
+                            >
+                              began
+                            </strong>
+                             during this work week.
+                          </Trans>
+                        </small>
+                      </FormText>
+                      <FormCheck
+                        checked={false}
+                        disabled={false}
+                        id="schoolOrTrainingradioYes"
+                        inline={true}
+                        isInvalid={false}
+                        isValid={false}
+                        key="Yes"
+                        label="Yes"
+                        name="schoolOrTraining"
+                        onChange={[Function]}
+                        required={true}
+                        title=""
+                        type="radio"
+                        value="Yes"
+                      >
+                        <div
+                          className="form-check form-check-inline"
+                        >
+                          <FormCheckInput
+                            as="input"
+                            checked={false}
+                            disabled={false}
+                            isInvalid={false}
+                            isStatic={false}
+                            isValid={false}
+                            name="schoolOrTraining"
+                            onChange={[Function]}
+                            required={true}
+                            type="radio"
+                            value="Yes"
+                          >
+                            <input
+                              checked={false}
+                              className="form-check-input"
+                              disabled={false}
+                              id="schoolOrTrainingradioYes"
+                              name="schoolOrTraining"
+                              onChange={[Function]}
+                              required={true}
+                              type="radio"
+                              value="Yes"
+                            />
+                          </FormCheckInput>
+                          <FormCheckLabel
+                            title=""
+                          >
+                            <label
+                              className="form-check-label"
+                              htmlFor="schoolOrTrainingradioYes"
+                              title=""
+                            >
+                              Yes
+                            </label>
+                          </FormCheckLabel>
+                        </div>
+                      </FormCheck>
+                      <FormCheck
+                        checked={false}
+                        disabled={false}
+                        id="schoolOrTrainingradioNo"
+                        inline={true}
+                        isInvalid={false}
+                        isValid={false}
+                        key="No"
+                        label="No"
+                        name="schoolOrTraining"
+                        onChange={[Function]}
+                        required={true}
+                        title=""
+                        type="radio"
+                        value="No"
+                      >
+                        <div
+                          className="form-check form-check-inline"
+                        >
+                          <FormCheckInput
+                            as="input"
+                            checked={false}
+                            disabled={false}
+                            isInvalid={false}
+                            isStatic={false}
+                            isValid={false}
+                            name="schoolOrTraining"
+                            onChange={[Function]}
+                            required={true}
+                            type="radio"
+                            value="No"
+                          >
+                            <input
+                              checked={false}
+                              className="form-check-input"
+                              disabled={false}
+                              id="schoolOrTrainingradioNo"
+                              name="schoolOrTraining"
+                              onChange={[Function]}
+                              required={true}
+                              type="radio"
+                              value="No"
+                            />
+                          </FormCheckInput>
+                          <FormCheckLabel
+                            title=""
+                          >
+                            <label
+                              className="form-check-label"
+                              htmlFor="schoolOrTrainingradioNo"
+                              title=""
+                            >
+                              No
+                            </label>
+                          </FormCheckLabel>
+                        </div>
+                      </FormCheck>
+                      <Feedback
+                        type="invalid"
+                      >
+                        <div
+                          className="invalid-feedback"
+                        >
+                          This field is required.
+                        </div>
+                      </Feedback>
+                    </fieldset>
+                  </div>
+                </FormGroup>
+              </div>
+            </YesNoQuestion>
+            <YesNoQuestion
+              helpText="Look at the date each week begins and ends. If you performed any work during this week, all earnings must be reported regardless if payment has been received."
+              inputName="workOrEarn"
+              key="0workOrEarn"
+              onChange={[Function]}
+              questionNumber={6}
+              questionText={
+                <Trans
+                  i18nKey="retrocerts-certification.questions.ui-full-time.workOrEarn"
+                  t={[Function]}
+                />
+              }
+            >
+              <div
+                className="bg-light p-2 mt-2 mb-2"
+              >
+                <FormGroup
+                  className="unchecked"
+                  controlId="workOrEarn"
+                >
+                  <div
+                    className="unchecked form-group"
+                  >
+                    <fieldset>
+                      <FormLabel
+                        as="legend"
+                        column={false}
+                        srOnly={false}
+                      >
+                        <legend
+                          className="form-label"
+                          htmlFor="workOrEarn"
+                        >
+                          6
+                          . 
+                          <Trans
+                            i18nKey="retrocerts-certification.questions.ui-full-time.workOrEarn"
+                            t={[Function]}
+                          >
+                            Did you work or earn any money, 
+                            <strong
+                              key="strong-1"
+                            >
+                              whether you were paid or not
+                            </strong>
+                            ?
+                          </Trans>
+                        </legend>
+                      </FormLabel>
+                      <FormText
+                        className="help-text"
+                      >
+                        <small
+                          className="help-text form-text"
+                        >
+                          Look at the date each week begins and ends. If you performed any work during this week, all earnings must be reported regardless if payment has been received.
+                        </small>
+                      </FormText>
+                      <FormCheck
+                        checked={false}
+                        disabled={false}
+                        id="workOrEarnradioYes"
+                        inline={true}
+                        isInvalid={false}
+                        isValid={false}
+                        key="Yes"
+                        label="Yes"
+                        name="workOrEarn"
+                        onChange={[Function]}
+                        required={true}
+                        title=""
+                        type="radio"
+                        value="Yes"
+                      >
+                        <div
+                          className="form-check form-check-inline"
+                        >
+                          <FormCheckInput
+                            as="input"
+                            checked={false}
+                            disabled={false}
+                            isInvalid={false}
+                            isStatic={false}
+                            isValid={false}
+                            name="workOrEarn"
+                            onChange={[Function]}
+                            required={true}
+                            type="radio"
+                            value="Yes"
+                          >
+                            <input
+                              checked={false}
+                              className="form-check-input"
+                              disabled={false}
+                              id="workOrEarnradioYes"
+                              name="workOrEarn"
+                              onChange={[Function]}
+                              required={true}
+                              type="radio"
+                              value="Yes"
+                            />
+                          </FormCheckInput>
+                          <FormCheckLabel
+                            title=""
+                          >
+                            <label
+                              className="form-check-label"
+                              htmlFor="workOrEarnradioYes"
+                              title=""
+                            >
+                              Yes
+                            </label>
+                          </FormCheckLabel>
+                        </div>
+                      </FormCheck>
+                      <FormCheck
+                        checked={false}
+                        disabled={false}
+                        id="workOrEarnradioNo"
+                        inline={true}
+                        isInvalid={false}
+                        isValid={false}
+                        key="No"
+                        label="No"
+                        name="workOrEarn"
+                        onChange={[Function]}
+                        required={true}
+                        title=""
+                        type="radio"
+                        value="No"
+                      >
+                        <div
+                          className="form-check form-check-inline"
+                        >
+                          <FormCheckInput
+                            as="input"
+                            checked={false}
+                            disabled={false}
+                            isInvalid={false}
+                            isStatic={false}
+                            isValid={false}
+                            name="workOrEarn"
+                            onChange={[Function]}
+                            required={true}
+                            type="radio"
+                            value="No"
+                          >
+                            <input
+                              checked={false}
+                              className="form-check-input"
+                              disabled={false}
+                              id="workOrEarnradioNo"
+                              name="workOrEarn"
+                              onChange={[Function]}
+                              required={true}
+                              type="radio"
+                              value="No"
+                            />
+                          </FormCheckInput>
+                          <FormCheckLabel
+                            title=""
+                          >
+                            <label
+                              className="form-check-label"
+                              htmlFor="workOrEarnradioNo"
+                              title=""
+                            >
+                              No
+                            </label>
+                          </FormCheckLabel>
+                        </div>
+                      </FormCheck>
+                      <Feedback
+                        type="invalid"
+                      >
+                        <div
+                          className="invalid-feedback"
+                        >
+                          This field is required.
+                        </div>
+                      </Feedback>
+                    </fieldset>
+                  </div>
+                </FormGroup>
+              </div>
+            </YesNoQuestion>
+            <FormRow>
+              <div
+                className="form-row"
+              >
+                <Col>
+                  <div
+                    className="col"
+                  >
+                    <Button
+                      active={false}
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "Link",
+                          "propTypes": Object {
+                            "innerRef": [Function],
+                            "onClick": [Function],
+                            "replace": [Function],
+                            "target": [Function],
+                            "to": [Function],
+                          },
+                          "render": [Function],
+                        }
+                      }
+                      className="text-dark bg-light"
+                      disabled={false}
+                      onClick={[Function]}
+                      to="/retroactive-certification/weeks-to-certify"
+                      type="button"
+                      variant="outline-secondary"
+                    >
+                      <Link
+                        className="text-dark bg-light btn btn-outline-secondary"
+                        disabled={false}
+                        onClick={[Function]}
+                        to="/retroactive-certification/weeks-to-certify"
+                      >
+                        <LinkAnchor
+                          className="text-dark bg-light btn btn-outline-secondary"
+                          disabled={false}
+                          href="/retroactive-certification/weeks-to-certify"
+                          navigate={[Function]}
+                          onClick={[Function]}
+                        >
+                          <a
+                            className="text-dark bg-light btn btn-outline-secondary"
+                            disabled={false}
+                            href="/retroactive-certification/weeks-to-certify"
+                            onClick={[Function]}
+                          >
+                            Back
+                          </a>
+                        </LinkAnchor>
+                      </Link>
+                    </Button>
+                  </div>
+                </Col>
+                <Col
+                  style={
+                    Object {
+                      "textAlign": "end",
+                    }
+                  }
+                >
+                  <div
+                    className="col"
+                    style={
+                      Object {
+                        "textAlign": "end",
+                      }
+                    }
+                  >
+                    <Button
+                      active={false}
+                      disabled={false}
+                      type="submit"
+                      variant="secondary"
+                    >
+                      <button
+                        className="btn btn-secondary"
+                        disabled={false}
+                        type="submit"
+                      >
+                        <Trans
+                          i18nKey="retrocerts-certification.button-next"
+                          t={[Function]}
+                          values={
+                            Object {
+                              "nextWeekForUser": 2,
+                            }
+                          }
+                        >
+                          Save and Continue to Week 2
+                        </Trans>
+                      </button>
+                    </Button>
+                  </div>
+                </Col>
+              </div>
+            </FormRow>
+          </form>
+        </Form>
+      </div>
+    </main>
+    <Footer
+      backToTopTag="certification-page"
+    >
+      <footer
+        className="footer"
+      >
+        <Navbar
+          bg="dark"
+          className="justify-content-between"
+          collapseOnSelect={false}
+          expand={true}
+          variant="custom"
+        >
+          <nav
+            className="justify-content-between navbar navbar-expand navbar-custom bg-dark"
+          >
+            <Nav
+              className="flex-wrap"
+              fill={false}
+              justify={false}
+            >
+              <ForwardRef
+                as="div"
+                className="flex-wrap navbar-nav"
+                onSelect={[Function]}
+              >
+                <div
+                  className="flex-wrap navbar-nav"
+                  onKeyDown={[Function]}
+                >
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="/#certification-page"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="/#certification-page"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="/#certification-page"
+                        disabled={false}
+                        href="/#certification-page"
+                        onClick={[Function]}
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="/#certification-page"
+                          href="/#certification-page"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                        >
+                          Back to Top
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/"
+                          href="https://edd.ca.gov/about_edd/"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          About EDD
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/contact_edd.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/contact_edd.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/contact_edd.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/contact_edd.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/contact_edd.htm"
+                          href="https://edd.ca.gov/about_edd/contact_edd.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Contact EDD
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                          href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Conditions of Use
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                          href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Privacy Policy
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/accessibility.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/accessibility.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/accessibility.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/accessibility.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/accessibility.htm"
+                          href="https://edd.ca.gov/about_edd/accessibility.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Accessibility
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/sitemap.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/sitemap.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/sitemap.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/sitemap.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/sitemap.htm"
+                          href="https://edd.ca.gov/sitemap.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Site Map
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                </div>
+              </ForwardRef>
+            </Nav>
+            <Nav
+              className="flex-wrap"
+              fill={false}
+              justify={false}
+            >
+              <ForwardRef
+                as="div"
+                className="flex-wrap navbar-nav"
+                onSelect={[Function]}
+              >
+                <div
+                  className="flex-wrap navbar-nav"
+                  onKeyDown={[Function]}
+                >
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://www.facebook.com/californiaedd/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://www.facebook.com/californiaedd/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://www.facebook.com/californiaedd/"
+                        disabled={false}
+                        href="https://www.facebook.com/californiaedd/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://www.facebook.com/californiaedd/"
+                          href="https://www.facebook.com/californiaedd/"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="Facebook icon"
+                            height="15"
+                            src="images/facebook.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://twitter.com/CA_EDD"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://twitter.com/CA_EDD"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://twitter.com/CA_EDD"
+                        disabled={false}
+                        href="https://twitter.com/CA_EDD"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://twitter.com/CA_EDD"
+                          href="https://twitter.com/CA_EDD"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="Twitter icon"
+                            height="15"
+                            src="images/twitter.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://www.linkedin.com/company/californiaedd/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://www.linkedin.com/company/californiaedd/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://www.linkedin.com/company/californiaedd/"
+                        disabled={false}
+                        href="https://www.linkedin.com/company/californiaedd/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://www.linkedin.com/company/californiaedd/"
+                          href="https://www.linkedin.com/company/californiaedd/"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="LinkedIn icon"
+                            height="15"
+                            src="images/linkedin.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://www.instagram.com/ca_edd/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://www.instagram.com/ca_edd/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://www.instagram.com/ca_edd/"
+                        disabled={false}
+                        href="https://www.instagram.com/ca_edd/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://www.instagram.com/ca_edd/"
+                          href="https://www.instagram.com/ca_edd/"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="Instagram icon"
+                            height="15"
+                            src="images/instagram.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://www.youtube.com/user/CaliforniaEDD"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://www.youtube.com/user/CaliforniaEDD"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://www.youtube.com/user/CaliforniaEDD"
+                        disabled={false}
+                        href="https://www.youtube.com/user/CaliforniaEDD"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://www.youtube.com/user/CaliforniaEDD"
+                          href="https://www.youtube.com/user/CaliforniaEDD"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="YouTube icon"
+                            height="15"
+                            src="images/youtube.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                </div>
+              </ForwardRef>
+            </Nav>
+          </nav>
+        </Navbar>
+        <div
+          className="bg-light secondary-footer"
+        >
+          <Container
+            fluid={false}
+          >
+            <div
+              className="container"
+            >
+              Copyright © 2020 State of California
+            </div>
+          </Container>
+        </div>
+      </footer>
+    </Footer>
+  </div>
+</RetroCertsCertificationPage>
 `;
 
 exports[`<RetroCertsCertificationPage /> Certify week not found. 1`] = `
-<Redirect
-  to="/retroactive-certification/weeks-to-certify"
-/>
+<RetroCertsCertificationPage
+  routeComputedMatch={
+    Object {
+      "params": Object {
+        "week": "2020-02-07",
+      },
+    }
+  }
+  setUserData={[Function]}
+  userData={
+    Object {
+      "programPlan": Array [
+        "UI full time",
+        "UI part time",
+      ],
+      "status": "ok",
+      "weeksToCertify": Array [
+        0,
+        1,
+      ],
+    }
+  }
+>
+  <Redirect
+    to="/retroactive-certification/weeks-to-certify"
+  >
+    <Lifecycle
+      onMount={[Function]}
+      onUpdate={[Function]}
+      to="/retroactive-certification/weeks-to-certify"
+    />
+  </Redirect>
+</RetroCertsCertificationPage>
 `;

--- a/src/client/pages/RetroCertsCertificationPage/index.test.js
+++ b/src/client/pages/RetroCertsCertificationPage/index.test.js
@@ -1,90 +1,78 @@
-import renderNonTransContent from "../../test-helpers/renderNonTransContent";
+import renderTransContent from "../../test-helpers/renderTransContent";
 import Component from "./index";
 import AUTH_STRINGS from "../../../data/authStrings";
 
 describe("<RetroCertsCertificationPage />", () => {
   it("Certify week not found.", async () => {
-    const wrapper = renderNonTransContent(
-      Component,
-      "RetroCertsCertificationPage",
-      {
-        userData: {
-          status: AUTH_STRINGS.statusCode.ok,
-          weeksToCertify: [0, 1],
-          programPlan: ["UI full time", "UI part time"],
+    const wrapper = renderTransContent(Component, {
+      userData: {
+        status: AUTH_STRINGS.statusCode.ok,
+        weeksToCertify: [0, 1],
+        programPlan: ["UI full time", "UI part time"],
+      },
+      setUserData: () => {},
+      routeComputedMatch: {
+        params: {
+          week: "2020-02-07", // This date is invalid.
         },
-        setUserData: () => {},
-        routeComputedMatch: {
-          params: {
-            week: "2020-02-07", // This date is invalid.
-          },
-        },
-      }
-    );
+      },
+    });
     expect(wrapper).toMatchSnapshot();
   });
 
   it("Certify for one week of 2", async () => {
-    const wrapper = renderNonTransContent(
-      Component,
-      "RetroCertsCertificationPage",
-      {
-        userData: {
-          status: AUTH_STRINGS.statusCode.ok,
-          weeksToCertify: [0, 1],
-          programPlan: ["UI full time", "UI part time"],
-          formData: [{ weekIndex: 0, tooSick: false, fullTime: true }],
+    const wrapper = renderTransContent(Component, {
+      userData: {
+        status: AUTH_STRINGS.statusCode.ok,
+        weeksToCertify: [0, 1],
+        programPlan: ["UI full time", "UI part time"],
+        formData: [{ weekIndex: 0, tooSick: false, fullTime: true }],
+      },
+      setUserData: () => {},
+      routeComputedMatch: {
+        params: {
+          week: "2020-02-08",
         },
-        setUserData: () => {},
-        routeComputedMatch: {
-          params: {
-            week: "2020-02-08",
-          },
-        },
-      }
-    );
+      },
+    });
 
     expect(wrapper).toMatchSnapshot();
   });
 
   it("Certify for 2nd week of 2", async () => {
-    const wrapper = renderNonTransContent(
-      Component,
-      "RetroCertsCertificationPage",
-      {
-        userData: {
-          status: AUTH_STRINGS.statusCode.ok,
-          weeksToCertify: [0, 1],
-          programPlan: ["UI full time", "UI part time"],
-          formData: [
-            {
-              weekIndex: 0,
-              tooSick: true,
-              fullTime: true,
-              didYouLook: true,
-              refuseWork: true,
-              schoolOrTraining: true,
-              workOrEarn: true,
-            },
-            {
-              weekIndex: 0,
-              tooSick: false,
-              fullTime: false,
-              didYouLook: false,
-              refuseWork: false,
-              schoolOrTraining: false,
-              workOrEarn: false,
-            },
-          ],
-        },
-        setUserData: () => {},
-        routeComputedMatch: {
-          params: {
-            week: "2020-02-15",
+    const wrapper = renderTransContent(Component, {
+      userData: {
+        status: AUTH_STRINGS.statusCode.ok,
+        weeksToCertify: [0, 1],
+        programPlan: ["UI full time", "UI part time"],
+        formData: [
+          {
+            weekIndex: 0,
+            tooSick: true,
+            fullTime: true,
+            didYouLook: true,
+            refuseWork: true,
+            schoolOrTraining: true,
+            workOrEarn: true,
           },
+          {
+            weekIndex: 0,
+            tooSick: false,
+            fullTime: false,
+            didYouLook: false,
+            refuseWork: false,
+            schoolOrTraining: false,
+            workOrEarn: false,
+          },
+        ],
+      },
+      setUserData: () => {},
+      routeComputedMatch: {
+        params: {
+          week: "2020-02-15",
         },
-      }
-    );
+      },
+    });
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/client/pages/RetroCertsConfirmationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsConfirmationPage/__snapshots__/index.test.js.snap
@@ -1,129 +1,2677 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<RetroCertsConfirmationPage /> no confirmation number 1`] = `
-<Redirect
-  to="/retroactive-certification/weeks-to-certify"
-/>
+<RetroCertsConfirmationPage
+  setUserData={[Function]}
+  userData={
+    Object {
+      "programPlan": Array [
+        "UI full time",
+      ],
+      "status": "ok",
+      "weeksToCertify": Array [
+        0,
+        1,
+        2,
+        5,
+        6,
+      ],
+    }
+  }
+>
+  <Redirect
+    to="/retroactive-certification/weeks-to-certify"
+  >
+    <Lifecycle
+      onMount={[Function]}
+      onUpdate={[Function]}
+      to="/retroactive-certification/weeks-to-certify"
+    />
+  </Redirect>
+</RetroCertsConfirmationPage>
 `;
 
 exports[`<RetroCertsConfirmationPage /> with confirmation number 1`] = `
-<div
-  id="overflow-wrapper"
+<RetroCertsConfirmationPage
+  setUserData={[Function]}
+  userData={
+    Object {
+      "confirmationNumber": "CONFIRMATION_NUMBER",
+      "formData": Array [
+        Object {
+          "couldNotAcceptWork": false,
+          "didYouLook": false,
+          "refuseWork": false,
+          "schoolOrTraining": false,
+          "tooSick": false,
+          "workOrEarn": false,
+        },
+        Object {
+          "couldNotAcceptWork": false,
+          "didYouLook": false,
+          "refuseWork": false,
+          "schoolOrTraining": false,
+          "tooSick": false,
+          "workOrEarn": false,
+        },
+        Object {
+          "couldNotAcceptWork": false,
+          "didYouLook": false,
+          "refuseWork": false,
+          "schoolOrTraining": false,
+          "tooSick": false,
+          "workOrEarn": false,
+        },
+      ],
+      "programPlan": Array [
+        "UI full time",
+      ],
+      "status": "ok",
+      "weeksToCertify": Array [
+        1,
+        2,
+        3,
+      ],
+    }
+  }
 >
-  <Header />
-  <main
-    id="certification-page"
+  <div
+    id="overflow-wrapper"
   >
-    <div
-      className="container p-4"
+    <Header>
+      <header
+        className="header border-bottom border-secondary"
+      >
+        <Navbar
+          bg="primary"
+          className="justify-content-between"
+          collapseOnSelect={false}
+          expand={true}
+          variant="custom"
+        >
+          <nav
+            className="justify-content-between navbar navbar-expand navbar-custom bg-primary"
+          >
+            <NavbarBrand
+              href="https://ca.gov"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <a
+                className="navbar-brand"
+                href="https://ca.gov"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <img
+                  alt="California gov logo"
+                  height="30"
+                  src="images/Ca-Gov-Logo-Gold.svg"
+                  width="30"
+                />
+              </a>
+            </NavbarBrand>
+            <Nav
+              fill={false}
+              justify={false}
+            >
+              <ForwardRef
+                as="div"
+                className="navbar-nav"
+                onSelect={[Function]}
+              >
+                <div
+                  className="navbar-nav"
+                  onKeyDown={[Function]}
+                >
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov"
+                        disabled={false}
+                        href="https://edd.ca.gov"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov"
+                          href="https://edd.ca.gov"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="home icon"
+                            className="icon"
+                            height="15"
+                            src="images/home.svg"
+                            width="15"
+                          />
+                           
+                          <span
+                            className="text"
+                          >
+                            Home
+                          </span>
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/login.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/login.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/login.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/login.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/login.htm"
+                          href="https://edd.ca.gov/login.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <span>
+                            <img
+                              alt="key icon"
+                              className="icon"
+                              height="15"
+                              src="images/key.svg"
+                              width="15"
+                            />
+                             
+                            <span
+                              className="text"
+                            >
+                              Log In
+                            </span>
+                          </span>
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                </div>
+              </ForwardRef>
+            </Nav>
+          </nav>
+        </Navbar>
+        <Navbar
+          collapseOnSelect={true}
+          expand="md"
+          variant="light"
+        >
+          <nav
+            className="navbar navbar-expand-md navbar-light"
+          >
+            <NavbarBrand
+              href="https://edd.ca.gov"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <a
+                className="navbar-brand"
+                href="https://edd.ca.gov"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <img
+                  alt="California gov logo"
+                  className="d-inline-block align-top mr-5"
+                  height="50"
+                  src="images/edd-logo-2-Color.svg"
+                  width="150"
+                />
+              </a>
+            </NavbarBrand>
+            <NavbarToggle
+              aria-controls="responsive-navbar-nav"
+              label="Toggle navigation"
+            >
+              <button
+                aria-controls="responsive-navbar-nav"
+                aria-label="Toggle navigation"
+                className="navbar-toggler collapsed"
+                onClick={[Function]}
+                type="button"
+              >
+                <span
+                  className="navbar-toggler-icon"
+                />
+              </button>
+            </NavbarToggle>
+            <NavbarCollapse
+              className="justify-content-between ml-5 mr-5 pl-5"
+            >
+              <Collapse
+                appear={false}
+                className="justify-content-between ml-5 mr-5 pl-5"
+                dimension="height"
+                getDimensionValue={[Function]}
+                in={false}
+                mountOnEnter={false}
+                timeout={300}
+                unmountOnExit={false}
+              >
+                <Transition
+                  addEndListener={[Function]}
+                  appear={false}
+                  aria-expanded={null}
+                  enter={true}
+                  exit={true}
+                  in={false}
+                  mountOnEnter={false}
+                  onEnter={[Function]}
+                  onEntered={[Function]}
+                  onEntering={[Function]}
+                  onExit={[Function]}
+                  onExited={[Function]}
+                  onExiting={[Function]}
+                  timeout={300}
+                  unmountOnExit={false}
+                >
+                  <div
+                    aria-expanded={null}
+                    className="justify-content-between ml-5 mr-5 pl-5 navbar-collapse collapse"
+                  >
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/jobs.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/jobs.htm"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/jobs.htm"
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/jobs.htm"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Jobs
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/claims.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/claims.htm"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/claims.htm"
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/claims.htm"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Claims
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/employers.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/employers.htm"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/employers.htm"
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/employers.htm"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Employers
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/newsroom.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/newsroom.htm"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/newsroom.htm"
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/newsroom.htm"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Newsroom
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                    <NavLink
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      href="https://edd.ca.gov/serp.html?q="
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <ForwardRef
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "displayName": "SafeAnchor",
+                            "render": [Function],
+                          }
+                        }
+                        className="nav-link"
+                        disabled={false}
+                        href="https://edd.ca.gov/serp.html?q="
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <SafeAnchor
+                          className="nav-link"
+                          disabled={false}
+                          href="https://edd.ca.gov/serp.html?q="
+                          onClick={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <a
+                            className="nav-link"
+                            href="https://edd.ca.gov/serp.html?q="
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            <span>
+                              Search
+                            </span>
+                          </a>
+                        </SafeAnchor>
+                      </ForwardRef>
+                    </NavLink>
+                  </div>
+                </Transition>
+              </Collapse>
+            </NavbarCollapse>
+          </nav>
+        </Navbar>
+      </header>
+    </Header>
+    <main
+      id="certification-page"
     >
-      <h1>
-        Retroactive Certification for Unemployment
-      </h1>
-      <LanguageSelector
-        className="mt-3 mb-4"
-      />
-      <Alert
-        className="mt-4"
-        closeLabel="Close alert"
-        show={true}
-        transition={
-          Object {
-            "$$typeof": Symbol(react.forward_ref),
-            "defaultProps": Object {
-              "appear": false,
-              "in": false,
-              "mountOnEnter": false,
-              "timeout": 300,
-              "unmountOnExit": false,
-            },
-            "displayName": "Fade",
-            "render": [Function],
-          }
-        }
-        variant="success"
+      <div
+        className="container p-4"
       >
-        <img
-          alt="checkmark"
-          className="checkmark"
-          src="/images/check-circle-fill.svg"
-        />
-        You have successfully submitted your retroactive certification. No further action is required.
-      </Alert>
-      <h2
-        className="mt-5"
-      >
-        Confirmation Number
-      </h2>
-      <p>
-        <Trans
-          i18nKey="retrocerts-confirmation.p1"
-          t={[Function]}
-          values={
+        <h1>
+          Retroactive Certification for Unemployment
+        </h1>
+        <LanguageSelector
+          className="mt-3 mb-4"
+        >
+          <Button
+            active={false}
+            className="text-dark bg-light mt-3 mb-4"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+            variant="outline-secondary"
+          >
+            <button
+              className="text-dark bg-light mt-3 mb-4 btn btn-outline-secondary"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
+            >
+              Español
+            </button>
+          </Button>
+        </LanguageSelector>
+        <Alert
+          className="mt-4"
+          closeLabel="Close alert"
+          show={true}
+          transition={
             Object {
-              "confirmationNumber": "_NUMBER",
+              "$$typeof": Symbol(react.forward_ref),
+              "defaultProps": Object {
+                "appear": false,
+                "in": false,
+                "mountOnEnter": false,
+                "timeout": 300,
+                "unmountOnExit": false,
+              },
+              "displayName": "Fade",
+              "render": [Function],
             }
           }
-        />
-      </p>
-      <p>
-        Keep this number for your records.
-      </p>
-      <p>
-        You’ve been logged out of the system and may close this window.
-      </p>
-      <Button
-        active={false}
-        className="text-dark bg-light"
-        disabled={false}
-        onClick={[Function]}
-        type="button"
-        variant="outline-secondary"
-      >
-        Print
-      </Button>
-      <h2
-        className="mt-5"
-      >
-        Certifications Submitted
-      </h2>
-      <ListOfCertifications
-        userData={
-          Object {
-            "confirmationNumber": "CONFIRMATION_NUMBER",
-            "programPlan": Array [
-              "PUA full time",
-            ],
-            "status": "ok",
-            "weeksToCertify": Array [
-              0,
-              1,
-              2,
-              5,
-              6,
-            ],
-          }
-        }
-      />
-      <p>
-        <Trans
-          i18nKey="retrocerts-confirmation.p2"
-          t={[Function]}
+          variant="success"
         >
-          If you are still unemployed, continue to certify for benefits every two weeks. The fastest way is to use
-           
-          <a
-            href="https://edd.ca.gov/Unemployment/UI_Online.htm"
+          <Fade
+            appear={false}
+            in={true}
+            mountOnEnter={false}
+            timeout={300}
+            unmountOnExit={true}
           >
-            UI Online
-          </a>
-          .
-        </Trans>
-      </p>
-    </div>
-  </main>
-  <Footer
-    backToTopTag="certification-page"
-  />
-</div>
+            <Transition
+              addEndListener={[Function]}
+              appear={false}
+              enter={true}
+              exit={true}
+              in={true}
+              mountOnEnter={false}
+              onEnter={[Function]}
+              onEntered={[Function]}
+              onEntering={[Function]}
+              onExit={[Function]}
+              onExited={[Function]}
+              onExiting={[Function]}
+              timeout={300}
+              unmountOnExit={true}
+            >
+              <div
+                className="fade mt-4 alert alert-success show"
+                role="alert"
+              >
+                <img
+                  alt="checkmark"
+                  className="checkmark"
+                  src="/images/check-circle-fill.svg"
+                />
+                You have successfully submitted your retroactive certification. No further action is required.
+              </div>
+            </Transition>
+          </Fade>
+        </Alert>
+        <h2
+          className="mt-5"
+        >
+          Confirmation Number
+        </h2>
+        <p>
+          <Trans
+            i18nKey="retrocerts-confirmation.p1"
+            t={[Function]}
+            values={
+              Object {
+                "confirmationNumber": "_NUMBER",
+              }
+            }
+          >
+            Your retroactive certification has been submitted. Your confirmation number is 
+            <strong
+              key="strong-1"
+            >
+              _NUMBER
+            </strong>
+            .
+          </Trans>
+        </p>
+        <p>
+          Keep this number for your records.
+        </p>
+        <p>
+          You’ve been logged out of the system and may close this window.
+        </p>
+        <Button
+          active={false}
+          className="text-dark bg-light"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+          variant="outline-secondary"
+        >
+          <button
+            className="text-dark bg-light btn btn-outline-secondary"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            Print
+          </button>
+        </Button>
+        <h2
+          className="mt-5"
+        >
+          Certifications Submitted
+        </h2>
+        <ListOfCertifications
+          userData={
+            Object {
+              "confirmationNumber": "CONFIRMATION_NUMBER",
+              "formData": Array [
+                Object {
+                  "couldNotAcceptWork": false,
+                  "didYouLook": false,
+                  "refuseWork": false,
+                  "schoolOrTraining": false,
+                  "tooSick": false,
+                  "workOrEarn": false,
+                },
+                Object {
+                  "couldNotAcceptWork": false,
+                  "didYouLook": false,
+                  "refuseWork": false,
+                  "schoolOrTraining": false,
+                  "tooSick": false,
+                  "workOrEarn": false,
+                },
+                Object {
+                  "couldNotAcceptWork": false,
+                  "didYouLook": false,
+                  "refuseWork": false,
+                  "schoolOrTraining": false,
+                  "tooSick": false,
+                  "workOrEarn": false,
+                },
+              ],
+              "programPlan": Array [
+                "UI full time",
+              ],
+              "status": "ok",
+              "weeksToCertify": Array [
+                1,
+                2,
+                3,
+              ],
+            }
+          }
+        >
+          <Button
+            active={false}
+            className="text-dark bg-light mb-3"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+            variant="outline-secondary"
+          >
+            <button
+              className="text-dark bg-light mb-3 btn btn-outline-secondary"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
+            >
+              Show all
+            </button>
+          </Button>
+          <ListOfWeeksWithDetail
+            showContentArray={
+              Array [
+                false,
+                false,
+                false,
+                false,
+              ]
+            }
+            toggleContent={[Function]}
+            userData={
+              Object {
+                "confirmationNumber": "CONFIRMATION_NUMBER",
+                "formData": Array [
+                  Object {
+                    "couldNotAcceptWork": false,
+                    "didYouLook": false,
+                    "refuseWork": false,
+                    "schoolOrTraining": false,
+                    "tooSick": false,
+                    "workOrEarn": false,
+                  },
+                  Object {
+                    "couldNotAcceptWork": false,
+                    "didYouLook": false,
+                    "refuseWork": false,
+                    "schoolOrTraining": false,
+                    "tooSick": false,
+                    "workOrEarn": false,
+                  },
+                  Object {
+                    "couldNotAcceptWork": false,
+                    "didYouLook": false,
+                    "refuseWork": false,
+                    "schoolOrTraining": false,
+                    "tooSick": false,
+                    "workOrEarn": false,
+                  },
+                ],
+                "programPlan": Array [
+                  "UI full time",
+                ],
+                "status": "ok",
+                "weeksToCertify": Array [
+                  1,
+                  2,
+                  3,
+                ],
+              }
+            }
+          >
+            <WeekWithDetail
+              index={0}
+              key="0"
+              showContentArray={
+                Array [
+                  false,
+                  false,
+                  false,
+                  false,
+                ]
+              }
+              toggleContent={[Function]}
+              weekData={
+                Object {
+                  "couldNotAcceptWork": false,
+                  "didYouLook": false,
+                  "refuseWork": false,
+                  "schoolOrTraining": false,
+                  "tooSick": false,
+                  "workOrEarn": false,
+                }
+              }
+              weekIndex={1}
+              weekProgramPlan="UI full time"
+            >
+              <AccordionItem
+                content={
+                  <WeekConfirmationDetails
+                    questionAnswers={
+                      Array [
+                        "No",
+                        false,
+                        "No",
+                        "No",
+                        "No",
+                        "No",
+                        "No",
+                      ]
+                    }
+                    questionKeys={
+                      Array [
+                        "retrocerts-certification.questions.ui-full-time.tooSick",
+                        "retrocerts-certification.questions.ui-full-time.tooSickNumberOfDays",
+                        "retrocerts-certification.questions.ui-full-time.couldNotAcceptWork",
+                        "retrocerts-certification.questions.ui-full-time.didYouLook",
+                        "retrocerts-certification.questions.ui-full-time.refuseWork",
+                        "retrocerts-certification.questions.ui-full-time.schoolOrTraining",
+                        "retrocerts-certification.questions.ui-full-time.workOrEarn",
+                      ]
+                    }
+                    weekString="02/09/2020 - 02/15/2020"
+                  />
+                }
+                header={
+                  <Trans
+                    i18nKey="retrocerts-week-list-item"
+                    t={[Function]}
+                    values={
+                      Object {
+                        "endDate": "02/15/2020",
+                        "startDate": "02/09/2020",
+                        "weekForUser": 1,
+                      }
+                    }
+                  />
+                }
+                showContent={false}
+                toggleContent={[Function]}
+              >
+                <Alert
+                  className="d-flex toggleAccordion"
+                  closeLabel="Close alert"
+                  onClick={[Function]}
+                  show={true}
+                  transition={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "defaultProps": Object {
+                        "appear": false,
+                        "in": false,
+                        "mountOnEnter": false,
+                        "timeout": 300,
+                        "unmountOnExit": false,
+                      },
+                      "displayName": "Fade",
+                      "render": [Function],
+                    }
+                  }
+                  variant="secondary"
+                >
+                  <Fade
+                    appear={false}
+                    in={true}
+                    mountOnEnter={false}
+                    onClick={[Function]}
+                    timeout={300}
+                    unmountOnExit={true}
+                  >
+                    <Transition
+                      addEndListener={[Function]}
+                      appear={false}
+                      enter={true}
+                      exit={true}
+                      in={true}
+                      mountOnEnter={false}
+                      onClick={[Function]}
+                      onEnter={[Function]}
+                      onEntered={[Function]}
+                      onEntering={[Function]}
+                      onExit={[Function]}
+                      onExited={[Function]}
+                      onExiting={[Function]}
+                      timeout={300}
+                      unmountOnExit={true}
+                    >
+                      <div
+                        className="fade d-flex toggleAccordion alert alert-secondary show"
+                        onClick={[Function]}
+                        role="alert"
+                      >
+                        <button
+                          aria-label="Show details for this week"
+                        >
+                          <div
+                            className="flex-fill"
+                          >
+                            <span
+                              className="toggleCharacter"
+                            >
+                              +
+                            </span>
+                            <Trans
+                              i18nKey="retrocerts-week-list-item"
+                              t={[Function]}
+                              values={
+                                Object {
+                                  "endDate": "02/15/2020",
+                                  "startDate": "02/09/2020",
+                                  "weekForUser": 1,
+                                }
+                              }
+                            >
+                              <strong
+                                key="strong-0"
+                              >
+                                Week 1
+                              </strong>
+                              : Sunday, 02/09/2020 – Saturday, 02/15/2020
+                            </Trans>
+                          </div>
+                        </button>
+                      </div>
+                    </Transition>
+                  </Fade>
+                </Alert>
+                <div
+                  className="detail"
+                  style={
+                    Object {
+                      "display": "none",
+                    }
+                  }
+                >
+                  <WeekConfirmationDetails
+                    questionAnswers={
+                      Array [
+                        "No",
+                        false,
+                        "No",
+                        "No",
+                        "No",
+                        "No",
+                        "No",
+                      ]
+                    }
+                    questionKeys={
+                      Array [
+                        "retrocerts-certification.questions.ui-full-time.tooSick",
+                        "retrocerts-certification.questions.ui-full-time.tooSickNumberOfDays",
+                        "retrocerts-certification.questions.ui-full-time.couldNotAcceptWork",
+                        "retrocerts-certification.questions.ui-full-time.didYouLook",
+                        "retrocerts-certification.questions.ui-full-time.refuseWork",
+                        "retrocerts-certification.questions.ui-full-time.schoolOrTraining",
+                        "retrocerts-certification.questions.ui-full-time.workOrEarn",
+                      ]
+                    }
+                    weekString="02/09/2020 - 02/15/2020"
+                  >
+                    <p>
+                      1. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.tooSick"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/09/2020 - 02/15/2020",
+                          }
+                        }
+                      >
+                        Were you too sick or injured to work?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      2. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.couldNotAcceptWork"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/09/2020 - 02/15/2020",
+                          }
+                        }
+                      >
+                        Was there any reason (other than sickness or injury) that you could not have accepted full-time work 
+                        <strong
+                          key="strong-1"
+                        >
+                          each workday
+                        </strong>
+                        ?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      3. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.didYouLook"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/09/2020 - 02/15/2020",
+                          }
+                        }
+                      >
+                        Did you look for work?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      4. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.refuseWork"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/09/2020 - 02/15/2020",
+                          }
+                        }
+                      >
+                        Did you refuse any work?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      5. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.schoolOrTraining"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/09/2020 - 02/15/2020",
+                          }
+                        }
+                      >
+                        Did you 
+                        <strong
+                          key="strong-1"
+                        >
+                          begin
+                        </strong>
+                         attending any kind of school or training? Select 
+                        <strong
+                          key="strong-3"
+                        >
+                          Yes
+                        </strong>
+                         only if you began attending school between 02/09/2020 - 02/15/2020.
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      6. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.workOrEarn"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/09/2020 - 02/15/2020",
+                          }
+                        }
+                      >
+                        Did you work or earn any money, 
+                        <strong
+                          key="strong-1"
+                        >
+                          whether you were paid or not
+                        </strong>
+                        ?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                  </WeekConfirmationDetails>
+                </div>
+              </AccordionItem>
+            </WeekWithDetail>
+            <WeekWithDetail
+              index={1}
+              key="1"
+              showContentArray={
+                Array [
+                  false,
+                  false,
+                  false,
+                  false,
+                ]
+              }
+              toggleContent={[Function]}
+              weekData={
+                Object {
+                  "couldNotAcceptWork": false,
+                  "didYouLook": false,
+                  "refuseWork": false,
+                  "schoolOrTraining": false,
+                  "tooSick": false,
+                  "workOrEarn": false,
+                }
+              }
+              weekIndex={2}
+              weekProgramPlan="UI full time"
+            >
+              <AccordionItem
+                content={
+                  <WeekConfirmationDetails
+                    questionAnswers={
+                      Array [
+                        "No",
+                        false,
+                        "No",
+                        "No",
+                        "No",
+                        "No",
+                        "No",
+                      ]
+                    }
+                    questionKeys={
+                      Array [
+                        "retrocerts-certification.questions.ui-full-time.tooSick",
+                        "retrocerts-certification.questions.ui-full-time.tooSickNumberOfDays",
+                        "retrocerts-certification.questions.ui-full-time.couldNotAcceptWork",
+                        "retrocerts-certification.questions.ui-full-time.didYouLook",
+                        "retrocerts-certification.questions.ui-full-time.refuseWork",
+                        "retrocerts-certification.questions.ui-full-time.schoolOrTraining",
+                        "retrocerts-certification.questions.ui-full-time.workOrEarn",
+                      ]
+                    }
+                    weekString="02/16/2020 - 02/22/2020"
+                  />
+                }
+                header={
+                  <Trans
+                    i18nKey="retrocerts-week-list-item"
+                    t={[Function]}
+                    values={
+                      Object {
+                        "endDate": "02/22/2020",
+                        "startDate": "02/16/2020",
+                        "weekForUser": 2,
+                      }
+                    }
+                  />
+                }
+                showContent={false}
+                toggleContent={[Function]}
+              >
+                <Alert
+                  className="d-flex toggleAccordion"
+                  closeLabel="Close alert"
+                  onClick={[Function]}
+                  show={true}
+                  transition={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "defaultProps": Object {
+                        "appear": false,
+                        "in": false,
+                        "mountOnEnter": false,
+                        "timeout": 300,
+                        "unmountOnExit": false,
+                      },
+                      "displayName": "Fade",
+                      "render": [Function],
+                    }
+                  }
+                  variant="secondary"
+                >
+                  <Fade
+                    appear={false}
+                    in={true}
+                    mountOnEnter={false}
+                    onClick={[Function]}
+                    timeout={300}
+                    unmountOnExit={true}
+                  >
+                    <Transition
+                      addEndListener={[Function]}
+                      appear={false}
+                      enter={true}
+                      exit={true}
+                      in={true}
+                      mountOnEnter={false}
+                      onClick={[Function]}
+                      onEnter={[Function]}
+                      onEntered={[Function]}
+                      onEntering={[Function]}
+                      onExit={[Function]}
+                      onExited={[Function]}
+                      onExiting={[Function]}
+                      timeout={300}
+                      unmountOnExit={true}
+                    >
+                      <div
+                        className="fade d-flex toggleAccordion alert alert-secondary show"
+                        onClick={[Function]}
+                        role="alert"
+                      >
+                        <button
+                          aria-label="Show details for this week"
+                        >
+                          <div
+                            className="flex-fill"
+                          >
+                            <span
+                              className="toggleCharacter"
+                            >
+                              +
+                            </span>
+                            <Trans
+                              i18nKey="retrocerts-week-list-item"
+                              t={[Function]}
+                              values={
+                                Object {
+                                  "endDate": "02/22/2020",
+                                  "startDate": "02/16/2020",
+                                  "weekForUser": 2,
+                                }
+                              }
+                            >
+                              <strong
+                                key="strong-0"
+                              >
+                                Week 2
+                              </strong>
+                              : Sunday, 02/16/2020 – Saturday, 02/22/2020
+                            </Trans>
+                          </div>
+                        </button>
+                      </div>
+                    </Transition>
+                  </Fade>
+                </Alert>
+                <div
+                  className="detail"
+                  style={
+                    Object {
+                      "display": "none",
+                    }
+                  }
+                >
+                  <WeekConfirmationDetails
+                    questionAnswers={
+                      Array [
+                        "No",
+                        false,
+                        "No",
+                        "No",
+                        "No",
+                        "No",
+                        "No",
+                      ]
+                    }
+                    questionKeys={
+                      Array [
+                        "retrocerts-certification.questions.ui-full-time.tooSick",
+                        "retrocerts-certification.questions.ui-full-time.tooSickNumberOfDays",
+                        "retrocerts-certification.questions.ui-full-time.couldNotAcceptWork",
+                        "retrocerts-certification.questions.ui-full-time.didYouLook",
+                        "retrocerts-certification.questions.ui-full-time.refuseWork",
+                        "retrocerts-certification.questions.ui-full-time.schoolOrTraining",
+                        "retrocerts-certification.questions.ui-full-time.workOrEarn",
+                      ]
+                    }
+                    weekString="02/16/2020 - 02/22/2020"
+                  >
+                    <p>
+                      1. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.tooSick"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/16/2020 - 02/22/2020",
+                          }
+                        }
+                      >
+                        Were you too sick or injured to work?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      2. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.couldNotAcceptWork"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/16/2020 - 02/22/2020",
+                          }
+                        }
+                      >
+                        Was there any reason (other than sickness or injury) that you could not have accepted full-time work 
+                        <strong
+                          key="strong-1"
+                        >
+                          each workday
+                        </strong>
+                        ?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      3. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.didYouLook"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/16/2020 - 02/22/2020",
+                          }
+                        }
+                      >
+                        Did you look for work?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      4. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.refuseWork"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/16/2020 - 02/22/2020",
+                          }
+                        }
+                      >
+                        Did you refuse any work?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      5. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.schoolOrTraining"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/16/2020 - 02/22/2020",
+                          }
+                        }
+                      >
+                        Did you 
+                        <strong
+                          key="strong-1"
+                        >
+                          begin
+                        </strong>
+                         attending any kind of school or training? Select 
+                        <strong
+                          key="strong-3"
+                        >
+                          Yes
+                        </strong>
+                         only if you began attending school between 02/16/2020 - 02/22/2020.
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      6. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.workOrEarn"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/16/2020 - 02/22/2020",
+                          }
+                        }
+                      >
+                        Did you work or earn any money, 
+                        <strong
+                          key="strong-1"
+                        >
+                          whether you were paid or not
+                        </strong>
+                        ?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                  </WeekConfirmationDetails>
+                </div>
+              </AccordionItem>
+            </WeekWithDetail>
+            <WeekWithDetail
+              index={2}
+              key="2"
+              showContentArray={
+                Array [
+                  false,
+                  false,
+                  false,
+                  false,
+                ]
+              }
+              toggleContent={[Function]}
+              weekData={
+                Object {
+                  "couldNotAcceptWork": false,
+                  "didYouLook": false,
+                  "refuseWork": false,
+                  "schoolOrTraining": false,
+                  "tooSick": false,
+                  "workOrEarn": false,
+                }
+              }
+              weekIndex={3}
+              weekProgramPlan="UI full time"
+            >
+              <AccordionItem
+                content={
+                  <WeekConfirmationDetails
+                    questionAnswers={
+                      Array [
+                        "No",
+                        false,
+                        "No",
+                        "No",
+                        "No",
+                        "No",
+                        "No",
+                      ]
+                    }
+                    questionKeys={
+                      Array [
+                        "retrocerts-certification.questions.ui-full-time.tooSick",
+                        "retrocerts-certification.questions.ui-full-time.tooSickNumberOfDays",
+                        "retrocerts-certification.questions.ui-full-time.couldNotAcceptWork",
+                        "retrocerts-certification.questions.ui-full-time.didYouLook",
+                        "retrocerts-certification.questions.ui-full-time.refuseWork",
+                        "retrocerts-certification.questions.ui-full-time.schoolOrTraining",
+                        "retrocerts-certification.questions.ui-full-time.workOrEarn",
+                      ]
+                    }
+                    weekString="02/23/2020 - 02/29/2020"
+                  />
+                }
+                header={
+                  <Trans
+                    i18nKey="retrocerts-week-list-item"
+                    t={[Function]}
+                    values={
+                      Object {
+                        "endDate": "02/29/2020",
+                        "startDate": "02/23/2020",
+                        "weekForUser": 3,
+                      }
+                    }
+                  />
+                }
+                showContent={false}
+                toggleContent={[Function]}
+              >
+                <Alert
+                  className="d-flex toggleAccordion"
+                  closeLabel="Close alert"
+                  onClick={[Function]}
+                  show={true}
+                  transition={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "defaultProps": Object {
+                        "appear": false,
+                        "in": false,
+                        "mountOnEnter": false,
+                        "timeout": 300,
+                        "unmountOnExit": false,
+                      },
+                      "displayName": "Fade",
+                      "render": [Function],
+                    }
+                  }
+                  variant="secondary"
+                >
+                  <Fade
+                    appear={false}
+                    in={true}
+                    mountOnEnter={false}
+                    onClick={[Function]}
+                    timeout={300}
+                    unmountOnExit={true}
+                  >
+                    <Transition
+                      addEndListener={[Function]}
+                      appear={false}
+                      enter={true}
+                      exit={true}
+                      in={true}
+                      mountOnEnter={false}
+                      onClick={[Function]}
+                      onEnter={[Function]}
+                      onEntered={[Function]}
+                      onEntering={[Function]}
+                      onExit={[Function]}
+                      onExited={[Function]}
+                      onExiting={[Function]}
+                      timeout={300}
+                      unmountOnExit={true}
+                    >
+                      <div
+                        className="fade d-flex toggleAccordion alert alert-secondary show"
+                        onClick={[Function]}
+                        role="alert"
+                      >
+                        <button
+                          aria-label="Show details for this week"
+                        >
+                          <div
+                            className="flex-fill"
+                          >
+                            <span
+                              className="toggleCharacter"
+                            >
+                              +
+                            </span>
+                            <Trans
+                              i18nKey="retrocerts-week-list-item"
+                              t={[Function]}
+                              values={
+                                Object {
+                                  "endDate": "02/29/2020",
+                                  "startDate": "02/23/2020",
+                                  "weekForUser": 3,
+                                }
+                              }
+                            >
+                              <strong
+                                key="strong-0"
+                              >
+                                Week 3
+                              </strong>
+                              : Sunday, 02/23/2020 – Saturday, 02/29/2020
+                            </Trans>
+                          </div>
+                        </button>
+                      </div>
+                    </Transition>
+                  </Fade>
+                </Alert>
+                <div
+                  className="detail"
+                  style={
+                    Object {
+                      "display": "none",
+                    }
+                  }
+                >
+                  <WeekConfirmationDetails
+                    questionAnswers={
+                      Array [
+                        "No",
+                        false,
+                        "No",
+                        "No",
+                        "No",
+                        "No",
+                        "No",
+                      ]
+                    }
+                    questionKeys={
+                      Array [
+                        "retrocerts-certification.questions.ui-full-time.tooSick",
+                        "retrocerts-certification.questions.ui-full-time.tooSickNumberOfDays",
+                        "retrocerts-certification.questions.ui-full-time.couldNotAcceptWork",
+                        "retrocerts-certification.questions.ui-full-time.didYouLook",
+                        "retrocerts-certification.questions.ui-full-time.refuseWork",
+                        "retrocerts-certification.questions.ui-full-time.schoolOrTraining",
+                        "retrocerts-certification.questions.ui-full-time.workOrEarn",
+                      ]
+                    }
+                    weekString="02/23/2020 - 02/29/2020"
+                  >
+                    <p>
+                      1. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.tooSick"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/23/2020 - 02/29/2020",
+                          }
+                        }
+                      >
+                        Were you too sick or injured to work?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      2. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.couldNotAcceptWork"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/23/2020 - 02/29/2020",
+                          }
+                        }
+                      >
+                        Was there any reason (other than sickness or injury) that you could not have accepted full-time work 
+                        <strong
+                          key="strong-1"
+                        >
+                          each workday
+                        </strong>
+                        ?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      3. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.didYouLook"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/23/2020 - 02/29/2020",
+                          }
+                        }
+                      >
+                        Did you look for work?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      4. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.refuseWork"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/23/2020 - 02/29/2020",
+                          }
+                        }
+                      >
+                        Did you refuse any work?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      5. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.schoolOrTraining"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/23/2020 - 02/29/2020",
+                          }
+                        }
+                      >
+                        Did you 
+                        <strong
+                          key="strong-1"
+                        >
+                          begin
+                        </strong>
+                         attending any kind of school or training? Select 
+                        <strong
+                          key="strong-3"
+                        >
+                          Yes
+                        </strong>
+                         only if you began attending school between 02/23/2020 - 02/29/2020.
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                    <hr />
+                    <p>
+                      6. 
+                      <Trans
+                        i18nKey="retrocerts-certification.questions.ui-full-time.workOrEarn"
+                        t={[Function]}
+                        values={
+                          Object {
+                            "weekString": "02/23/2020 - 02/29/2020",
+                          }
+                        }
+                      >
+                        Did you work or earn any money, 
+                        <strong
+                          key="strong-1"
+                        >
+                          whether you were paid or not
+                        </strong>
+                        ?
+                      </Trans>
+                    </p>
+                    <p>
+                      <strong>
+                        No
+                      </strong>
+                    </p>
+                  </WeekConfirmationDetails>
+                </div>
+              </AccordionItem>
+            </WeekWithDetail>
+          </ListOfWeeksWithDetail>
+          <AccordionItem
+            content={
+              <AcknowledgementDetail
+                className="detail"
+              />
+            }
+            header={
+              <strong>
+                Acknowledgement
+              </strong>
+            }
+            showContent={false}
+            toggleContent={[Function]}
+          >
+            <Alert
+              className="d-flex toggleAccordion"
+              closeLabel="Close alert"
+              onClick={[Function]}
+              show={true}
+              transition={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "defaultProps": Object {
+                    "appear": false,
+                    "in": false,
+                    "mountOnEnter": false,
+                    "timeout": 300,
+                    "unmountOnExit": false,
+                  },
+                  "displayName": "Fade",
+                  "render": [Function],
+                }
+              }
+              variant="secondary"
+            >
+              <Fade
+                appear={false}
+                in={true}
+                mountOnEnter={false}
+                onClick={[Function]}
+                timeout={300}
+                unmountOnExit={true}
+              >
+                <Transition
+                  addEndListener={[Function]}
+                  appear={false}
+                  enter={true}
+                  exit={true}
+                  in={true}
+                  mountOnEnter={false}
+                  onClick={[Function]}
+                  onEnter={[Function]}
+                  onEntered={[Function]}
+                  onEntering={[Function]}
+                  onExit={[Function]}
+                  onExited={[Function]}
+                  onExiting={[Function]}
+                  timeout={300}
+                  unmountOnExit={true}
+                >
+                  <div
+                    className="fade d-flex toggleAccordion alert alert-secondary show"
+                    onClick={[Function]}
+                    role="alert"
+                  >
+                    <button
+                      aria-label="Show details for this week"
+                    >
+                      <div
+                        className="flex-fill"
+                      >
+                        <span
+                          className="toggleCharacter"
+                        >
+                          +
+                        </span>
+                        <strong>
+                          Acknowledgement
+                        </strong>
+                      </div>
+                    </button>
+                  </div>
+                </Transition>
+              </Fade>
+            </Alert>
+            <div
+              className="detail"
+              style={
+                Object {
+                  "display": "none",
+                }
+              }
+            >
+              <AcknowledgementDetail
+                className="detail"
+              >
+                <ul>
+                  <li>
+                    I understand the questions I answered through this automated system.
+                  </li>
+                  <li>
+                    I know the law provides penalties if I make false statements or withhold facts to receive benefits; and my answers are true and correct.
+                  </li>
+                  <li>
+                    I declare under penalty of perjury that I am a US Citizen or National; or an Alien in satisfactory immigration status and permitted to work by the United States Citizenship and Immigration Service.
+                  </li>
+                  <li>
+                    I understand when submitting my request for benefits my submission is considered the same as my written signature.
+                  </li>
+                </ul>
+                <input
+                  checked={true}
+                  disabled={true}
+                  type="checkbox"
+                />
+                You must indicate your acceptance of the statement by checking the box before your certification can be submitted.
+              </AcknowledgementDetail>
+            </div>
+          </AccordionItem>
+        </ListOfCertifications>
+        <p>
+          <Trans
+            i18nKey="retrocerts-confirmation.p2"
+            t={[Function]}
+          >
+            If you are still unemployed, continue to certify for benefits every two weeks. The fastest way is to use 
+            <a
+              href="https://edd.ca.gov/Unemployment/UI_Online.htm"
+              key="1"
+            >
+              UI Online
+            </a>
+            .
+          </Trans>
+        </p>
+      </div>
+    </main>
+    <Footer
+      backToTopTag="certification-page"
+    >
+      <footer
+        className="footer"
+      >
+        <Navbar
+          bg="dark"
+          className="justify-content-between"
+          collapseOnSelect={false}
+          expand={true}
+          variant="custom"
+        >
+          <nav
+            className="justify-content-between navbar navbar-expand navbar-custom bg-dark"
+          >
+            <Nav
+              className="flex-wrap"
+              fill={false}
+              justify={false}
+            >
+              <ForwardRef
+                as="div"
+                className="flex-wrap navbar-nav"
+                onSelect={[Function]}
+              >
+                <div
+                  className="flex-wrap navbar-nav"
+                  onKeyDown={[Function]}
+                >
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="/#certification-page"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="/#certification-page"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="/#certification-page"
+                        disabled={false}
+                        href="/#certification-page"
+                        onClick={[Function]}
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="/#certification-page"
+                          href="/#certification-page"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                        >
+                          Back to Top
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/"
+                          href="https://edd.ca.gov/about_edd/"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          About EDD
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/contact_edd.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/contact_edd.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/contact_edd.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/contact_edd.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/contact_edd.htm"
+                          href="https://edd.ca.gov/about_edd/contact_edd.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Contact EDD
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                          href="https://edd.ca.gov/about_edd/conditions_of_use.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Conditions of Use
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                          href="https://edd.ca.gov/about_edd/privacy_policy.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Privacy Policy
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/about_edd/accessibility.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/about_edd/accessibility.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/about_edd/accessibility.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/about_edd/accessibility.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/about_edd/accessibility.htm"
+                          href="https://edd.ca.gov/about_edd/accessibility.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Accessibility
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://edd.ca.gov/sitemap.htm"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://edd.ca.gov/sitemap.htm"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://edd.ca.gov/sitemap.htm"
+                        disabled={false}
+                        href="https://edd.ca.gov/sitemap.htm"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://edd.ca.gov/sitemap.htm"
+                          href="https://edd.ca.gov/sitemap.htm"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Site Map
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                </div>
+              </ForwardRef>
+            </Nav>
+            <Nav
+              className="flex-wrap"
+              fill={false}
+              justify={false}
+            >
+              <ForwardRef
+                as="div"
+                className="flex-wrap navbar-nav"
+                onSelect={[Function]}
+              >
+                <div
+                  className="flex-wrap navbar-nav"
+                  onKeyDown={[Function]}
+                >
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://www.facebook.com/californiaedd/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://www.facebook.com/californiaedd/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://www.facebook.com/californiaedd/"
+                        disabled={false}
+                        href="https://www.facebook.com/californiaedd/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://www.facebook.com/californiaedd/"
+                          href="https://www.facebook.com/californiaedd/"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="Facebook icon"
+                            height="15"
+                            src="images/facebook.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://twitter.com/CA_EDD"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://twitter.com/CA_EDD"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://twitter.com/CA_EDD"
+                        disabled={false}
+                        href="https://twitter.com/CA_EDD"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://twitter.com/CA_EDD"
+                          href="https://twitter.com/CA_EDD"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="Twitter icon"
+                            height="15"
+                            src="images/twitter.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://www.linkedin.com/company/californiaedd/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://www.linkedin.com/company/californiaedd/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://www.linkedin.com/company/californiaedd/"
+                        disabled={false}
+                        href="https://www.linkedin.com/company/californiaedd/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://www.linkedin.com/company/californiaedd/"
+                          href="https://www.linkedin.com/company/californiaedd/"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="LinkedIn icon"
+                            height="15"
+                            src="images/linkedin.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://www.instagram.com/ca_edd/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://www.instagram.com/ca_edd/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://www.instagram.com/ca_edd/"
+                        disabled={false}
+                        href="https://www.instagram.com/ca_edd/"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://www.instagram.com/ca_edd/"
+                          href="https://www.instagram.com/ca_edd/"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="Instagram icon"
+                            height="15"
+                            src="images/instagram.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                  <NavLink
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "displayName": "SafeAnchor",
+                        "render": [Function],
+                      }
+                    }
+                    disabled={false}
+                    href="https://www.youtube.com/user/CaliforniaEDD"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ForwardRef
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "displayName": "SafeAnchor",
+                          "render": [Function],
+                        }
+                      }
+                      className="nav-link"
+                      disabled={false}
+                      href="https://www.youtube.com/user/CaliforniaEDD"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <SafeAnchor
+                        className="nav-link"
+                        data-rb-event-key="https://www.youtube.com/user/CaliforniaEDD"
+                        disabled={false}
+                        href="https://www.youtube.com/user/CaliforniaEDD"
+                        onClick={[Function]}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <a
+                          className="nav-link"
+                          data-rb-event-key="https://www.youtube.com/user/CaliforniaEDD"
+                          href="https://www.youtube.com/user/CaliforniaEDD"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <img
+                            alt="YouTube icon"
+                            height="15"
+                            src="images/youtube.svg"
+                            width="15"
+                          />
+                           
+                        </a>
+                      </SafeAnchor>
+                    </ForwardRef>
+                  </NavLink>
+                </div>
+              </ForwardRef>
+            </Nav>
+          </nav>
+        </Navbar>
+        <div
+          className="bg-light secondary-footer"
+        >
+          <Container
+            fluid={false}
+          >
+            <div
+              className="container"
+            >
+              Copyright © 2020 State of California
+            </div>
+          </Container>
+        </div>
+      </footer>
+    </Footer>
+  </div>
+</RetroCertsConfirmationPage>
 `;

--- a/src/client/pages/RetroCertsConfirmationPage/index.test.js
+++ b/src/client/pages/RetroCertsConfirmationPage/index.test.js
@@ -1,39 +1,41 @@
-import renderNonTransContent from "../../test-helpers/renderNonTransContent";
+import renderTransContent from "../../test-helpers/renderTransContent";
 import Component from "./index";
 import AUTH_STRINGS from "../../../data/authStrings";
 
 describe("<RetroCertsConfirmationPage />", () => {
+  const weekOfAnswers = {
+    tooSick: false,
+    couldNotAcceptWork: false,
+    didYouLook: false,
+    refuseWork: false,
+    schoolOrTraining: false,
+    workOrEarn: false,
+  };
+
   it("with confirmation number", async () => {
-    const wrapper = renderNonTransContent(
-      Component,
-      "RetroCertsConfirmationPage",
-      {
-        userData: {
-          status: AUTH_STRINGS.statusCode.ok,
-          weeksToCertify: [0, 1, 2, 5, 6],
-          confirmationNumber: "CONFIRMATION_NUMBER",
-          programPlan: ["PUA full time"],
-        },
-        setUserData: () => {},
-      }
-    );
+    const wrapper = renderTransContent(Component, {
+      userData: {
+        status: AUTH_STRINGS.statusCode.ok,
+        formData: [weekOfAnswers, weekOfAnswers, weekOfAnswers],
+        weeksToCertify: [1, 2, 3],
+        programPlan: ["UI full time"],
+        confirmationNumber: "CONFIRMATION_NUMBER",
+      },
+      setUserData: () => {},
+    });
 
     expect(wrapper).toMatchSnapshot();
   });
 
   it("no confirmation number", async () => {
-    const wrapper = renderNonTransContent(
-      Component,
-      "RetroCertsConfirmationPage",
-      {
-        userData: {
-          status: AUTH_STRINGS.statusCode.ok,
-          weeksToCertify: [0, 1, 2, 5, 6],
-          programPlan: ["UI full time"],
-        },
-        setUserData: () => {},
-      }
-    );
+    const wrapper = renderTransContent(Component, {
+      userData: {
+        status: AUTH_STRINGS.statusCode.ok,
+        weeksToCertify: [0, 1, 2, 5, 6],
+        programPlan: ["UI full time"],
+      },
+      setUserData: () => {},
+    });
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/client/pages/RetroCertsWeeksToCertifyPage/index.test.js
+++ b/src/client/pages/RetroCertsWeeksToCertifyPage/index.test.js
@@ -4,17 +4,13 @@ import AUTH_STRINGS from "../../../data/authStrings";
 
 describe("<RetroCertsWeeksToCertifyPage />", () => {
   it("has user data", async () => {
-    const wrapper = renderNonTransContent(
-      Component,
-      "RetroCertsWeeksToCertifyPage",
-      {
-        userData: {
-          status: AUTH_STRINGS.statusCode.ok,
-          weeksToCertify: [0],
-        },
-        setUserData: () => {},
-      }
-    );
+    const wrapper = renderNonTransContent(Component, {
+      userData: {
+        status: AUTH_STRINGS.statusCode.ok,
+        weeksToCertify: [0],
+      },
+      setUserData: () => {},
+    });
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/client/pages/StaffViewAuthPage/index.test.js
+++ b/src/client/pages/StaffViewAuthPage/index.test.js
@@ -4,7 +4,7 @@ import Component from "./index";
 
 describe("<StaffViewAuthPage />", () => {
   it("retro certs auth page", async () => {
-    const wrapper = renderNonTransContent(Component, "StaffViewAuthPage");
+    const wrapper = renderNonTransContent(Component);
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/client/pages/StaffViewAuthPage/index.test.js
+++ b/src/client/pages/StaffViewAuthPage/index.test.js
@@ -10,7 +10,7 @@ describe("<StaffViewAuthPage />", () => {
   });
 
   it("retro certs auth page with user not found error", async () => {
-    const wrapper = renderNonTransContent(Component, "StaffViewAuthPage", {
+    const wrapper = renderNonTransContent(Component, {
       userData: { status: AUTH_STRINGS.statusCode.userNotFound },
     });
 

--- a/src/client/pages/StaffViewConfirmationPage/_index.scss
+++ b/src/client/pages/StaffViewConfirmationPage/_index.scss
@@ -38,7 +38,7 @@ input[type="checkbox"] {
 
 @mixin status($bg-color) {
   font-size: 100%;
-  padding: 0.4em 0.3em;
+  padding: 0.3em 0.4em;
   background-color: $bg-color;
 }
 

--- a/src/client/test-helpers/renderNonTransContent.js
+++ b/src/client/test-helpers/renderNonTransContent.js
@@ -1,17 +1,22 @@
 import React from "react";
 import { shallow } from "enzyme";
-import { I18nextProvider } from "react-i18next";
+import { I18nextProvider, Trans } from "react-i18next";
 import i18n from "./i18nForTests";
 import shallowUntilTarget from "./shallowUntilTarget";
 
-function renderNonTransContent(Component, componentName, props = {}) {
+function renderNonTransContent(Component, props = {}) {
   const providersWrapper = shallow(
     <I18nextProvider i18n={i18n}>
       <Component {...props} />
     </I18nextProvider>
   );
 
-  const wrapper = shallowUntilTarget(providersWrapper, componentName);
+  const wrapper = shallowUntilTarget(providersWrapper, Component.name);
+  // Incorrectly using renderNonTransContent to render a component that
+  // contains a Trans component results in a silent failure (the rendered
+  // snapshot will contain the Trans component itself instead of the rendered
+  // contents). This test makes that silent failure more obvious.
+  expect(wrapper.containsMatchingElement(<Trans />)).toBe(false);
 
   return wrapper;
 }


### PR DESCRIPTION
This PR updates tests to render contents of all Trans components properly. Some tests used renderNonTransContent to render components with Trans content, which made the resulting snapshot less useful. 

It also adds a test inside renderNonTransContent to make it more obvious when renderTransContent should be used instead:

```
  // Incorrectly using renderNonTransContent to render a component that
  // contains a Trans component results in a silent failure (the rendered
  // snapshot will contain the Trans component itself instead of the rendered
  // contents). This test makes that silent failure more obvious.
  expect(wrapper.containsMatchingElement(<Trans />)).toBe(false);
```

It also updates the function signature for renderNonTransContent to match renderTransContent, to make it easier to switch between them.

A future improvement should update renderTransContent to only call `mount` on Trans components and ancestors, so that renderTransContent doesn't redundantly render other descendant components, given that those components have their own tests. [Will create an issue for this]

===

Resolves #568

- [x] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [x] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
