### PR TITLE
Countdown fix

### DIFF
--- a/src/client/components/SessionTimer/__snapshots__/index.test.js.snap
+++ b/src/client/components/SessionTimer/__snapshots__/index.test.js.snap
@@ -22,7 +22,7 @@ exports[`<SessionTimer /> clear 1`] = `
       t={[Function]}
       values={
         Object {
-          "numberOfMinutes": undefined,
+          "numberOfMinutes": 5,
         }
       }
     />
@@ -65,7 +65,7 @@ exports[`<SessionTimer /> startOrUpdate 1`] = `
       t={[Function]}
       values={
         Object {
-          "numberOfMinutes": undefined,
+          "numberOfMinutes": 5,
         }
       }
     />

--- a/src/client/components/SessionTimer/index.js
+++ b/src/client/components/SessionTimer/index.js
@@ -65,7 +65,6 @@ function SessionTimer(props) {
     warningTimerId = setTimeout(() => {
       if (sessionStorage.getItem(AUTH_STRINGS.authToken)) {
         setShowWarningModal(true);
-        setNumberOfMinutes(TIMEOUT_DISPLAY_TIME_IN_MINUTES);
       }
     }, TIMEOUT_WARNING_MS);
     timeOutTimerId = setTimeout(() => {

--- a/src/client/components/SessionTimer/index.js
+++ b/src/client/components/SessionTimer/index.js
@@ -65,6 +65,7 @@ function SessionTimer(props) {
     warningTimerId = setTimeout(() => {
       if (sessionStorage.getItem(AUTH_STRINGS.authToken)) {
         setShowWarningModal(true);
+        setNumberOfMinutes(TIMEOUT_DISPLAY_TIME_IN_MINUTES);
       }
     }, TIMEOUT_WARNING_MS);
     timeOutTimerId = setTimeout(() => {

--- a/src/client/components/SessionTimer/index.js
+++ b/src/client/components/SessionTimer/index.js
@@ -23,7 +23,9 @@ function SessionTimer(props) {
   const { action, setUserData } = props;
 
   const [showWarningModal, setShowWarningModal] = useState();
-  const [numberOfMinutes, setNumberOfMinutes] = useState();
+  const [numberOfMinutes, setNumberOfMinutes] = useState(
+    TIMEOUT_DISPLAY_TIME_IN_MINUTES
+  );
 
   useEffect(() => {
     if (showWarningModal) {
@@ -62,8 +64,8 @@ function SessionTimer(props) {
     clear();
     warningTimerId = setTimeout(() => {
       if (sessionStorage.getItem(AUTH_STRINGS.authToken)) {
-        setNumberOfMinutes(TIMEOUT_DISPLAY_TIME_IN_MINUTES);
         setShowWarningModal(true);
+        setNumberOfMinutes(TIMEOUT_DISPLAY_TIME_IN_MINUTES);
       }
     }, TIMEOUT_WARNING_MS);
     timeOutTimerId = setTimeout(() => {


### PR DESCRIPTION
Setting the number of minutes to display right before showing the timeout warning was resetting the timeout counter. This PR updates the logic to set the number of minutes at page load.

===

Resolves #XXX

- [ ] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
