### PR TITLE
Setting staff view live in prod

### DIFF
--- a/src/client/components/StaffViewRoute/index.js
+++ b/src/client/components/StaffViewRoute/index.js
@@ -3,7 +3,6 @@ import { Route, Redirect } from "react-router-dom";
 import React from "react";
 import { userDataPropType, setUserDataPropType } from "../../commonPropTypes";
 import routes from "../../../data/routes";
-import { isProdEnv } from "../../utils";
 
 function userDataIsSet(userData) {
   return !!userData.weeksToCertify;
@@ -13,10 +12,7 @@ function StaffViewRoute(props) {
   const { pageComponent: Component, pageProps, ...routeProps } = props;
 
   let routeChild = <div>Loading...</div>;
-  if (isProdEnv) {
-    // Staff view should currently not load on production at all,
-    routeChild = <Redirect to={routes.retroCertsAuth} push />;
-  } else if (
+  if (
     routeProps.path === routes.staffViewConfirmation &&
     !userDataIsSet(pageProps.userData)
   ) {

--- a/src/client/components/StaffViewRoute/index.js
+++ b/src/client/components/StaffViewRoute/index.js
@@ -9,6 +9,7 @@ function userDataIsSet(userData) {
 }
 
 function StaffViewRoute(props) {
+  // These routes are restricted to certain IP addresses in app.js
   const { pageComponent: Component, pageProps, ...routeProps } = props;
 
   let routeChild = <div>Loading...</div>;


### PR DESCRIPTION
Removing URL restrictions from staff view routes

===

Resolves #528 

- [x] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [ ] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
