### PR TITLE
Making checkbox accessible on screen readers

### DIFF
--- a/src/client/components/ListOfCertifications/index.js
+++ b/src/client/components/ListOfCertifications/index.js
@@ -1,6 +1,8 @@
 import Button from "react-bootstrap/Button";
+import Col from "react-bootstrap/Col";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
+import Form from "react-bootstrap/Form";
 import { userDataPropType } from "../../commonPropTypes";
 import ListOfWeeksWithDetail from "../../components/ListOfWeeksWithDetail";
 import programPlan from "../../../data/programPlan";
@@ -55,8 +57,16 @@ function ListOfCertifications(props) {
             <li>{t("retrocerts-certification.ack-list-item-4")}</li>
           </ul>
         )}
-        <input type="checkbox" checked disabled />
-        {t("retrocerts-certification.ack-label")}
+        <Form.Group>
+          <Form.Row>
+            <Col md="auto">
+              <Form.Check type="checkbox" checked disabled />
+            </Col>
+            <Col>
+              <Form.Label>{t("retrocerts-certification.ack-label")}</Form.Label>
+            </Col>
+          </Form.Row>
+        </Form.Group>
       </React.Fragment>
     );
   }

--- a/src/client/pages/RetroCertsConfirmationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsConfirmationPage/__snapshots__/index.test.js.snap
@@ -1956,12 +1956,72 @@ exports[`<RetroCertsConfirmationPage /> with confirmation number 1`] = `
                     I understand when submitting my request for benefits my submission is considered the same as my written signature.
                   </li>
                 </ul>
-                <input
-                  checked={true}
-                  disabled={true}
-                  type="checkbox"
-                />
-                You must indicate your acceptance of the statement by checking the box before your certification can be submitted.
+                <FormGroup>
+                  <div
+                    className="form-group"
+                  >
+                    <FormRow>
+                      <div
+                        className="form-row"
+                      >
+                        <Col
+                          md="auto"
+                        >
+                          <div
+                            className="col-md-auto"
+                          >
+                            <FormCheck
+                              checked={true}
+                              disabled={true}
+                              inline={false}
+                              isInvalid={false}
+                              isValid={false}
+                              title=""
+                              type="checkbox"
+                            >
+                              <div
+                                className="form-check"
+                              >
+                                <FormCheckInput
+                                  as="input"
+                                  checked={true}
+                                  disabled={true}
+                                  isInvalid={false}
+                                  isStatic={true}
+                                  isValid={false}
+                                  type="checkbox"
+                                >
+                                  <input
+                                    checked={true}
+                                    className="form-check-input position-static"
+                                    disabled={true}
+                                    type="checkbox"
+                                  />
+                                </FormCheckInput>
+                              </div>
+                            </FormCheck>
+                          </div>
+                        </Col>
+                        <Col>
+                          <div
+                            className="col"
+                          >
+                            <FormLabel
+                              column={false}
+                              srOnly={false}
+                            >
+                              <label
+                                className="form-label"
+                              >
+                                You must indicate your acceptance of the statement by checking the box before your certification can be submitted.
+                              </label>
+                            </FormLabel>
+                          </div>
+                        </Col>
+                      </div>
+                    </FormRow>
+                  </div>
+                </FormGroup>
               </AcknowledgementDetail>
             </div>
           </AccordionItem>

--- a/src/client/pages/StaffViewConfirmationPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/StaffViewConfirmationPage/__snapshots__/index.test.js.snap
@@ -1918,12 +1918,72 @@ exports[`<StaffViewConfirmationPage /> when claimant completed 1`] = `
                     I understand when submitting my request for benefits my submission is considered the same as my written signature.
                   </li>
                 </ul>
-                <input
-                  checked={true}
-                  disabled={true}
-                  type="checkbox"
-                />
-                You must indicate your acceptance of the statement by checking the box before your certification can be submitted.
+                <FormGroup>
+                  <div
+                    className="form-group"
+                  >
+                    <FormRow>
+                      <div
+                        className="form-row"
+                      >
+                        <Col
+                          md="auto"
+                        >
+                          <div
+                            className="col-md-auto"
+                          >
+                            <FormCheck
+                              checked={true}
+                              disabled={true}
+                              inline={false}
+                              isInvalid={false}
+                              isValid={false}
+                              title=""
+                              type="checkbox"
+                            >
+                              <div
+                                className="form-check"
+                              >
+                                <FormCheckInput
+                                  as="input"
+                                  checked={true}
+                                  disabled={true}
+                                  isInvalid={false}
+                                  isStatic={true}
+                                  isValid={false}
+                                  type="checkbox"
+                                >
+                                  <input
+                                    checked={true}
+                                    className="form-check-input position-static"
+                                    disabled={true}
+                                    type="checkbox"
+                                  />
+                                </FormCheckInput>
+                              </div>
+                            </FormCheck>
+                          </div>
+                        </Col>
+                        <Col>
+                          <div
+                            className="col"
+                          >
+                            <FormLabel
+                              column={false}
+                              srOnly={false}
+                            >
+                              <label
+                                className="form-label"
+                              >
+                                You must indicate your acceptance of the statement by checking the box before your certification can be submitted.
+                              </label>
+                            </FormLabel>
+                          </div>
+                        </Col>
+                      </div>
+                    </FormRow>
+                  </div>
+                </FormGroup>
               </AcknowledgementDetail>
             </div>
           </AccordionItem>


### PR DESCRIPTION
The label wasn't connected to the checkbox for screen readers. I added Bootstrap's built in checkbox functionality to connect the label.

===

Connects #577 

- [x] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [x] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [ ] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
