### PR TITLE
Added link to Retro Certs landing page, needs spanish translation still

### DIFF
--- a/src/client/pages/RetroCertsAuthPage/__snapshots__/index.test.js.snap
+++ b/src/client/pages/RetroCertsAuthPage/__snapshots__/index.test.js.snap
@@ -22,7 +22,16 @@ exports[`<RetroCertsAuthPage /> retro certs auth page 1`] = `
       >
         You are required to certify for Unemployment Insurance (UI) and Pandemic Unemployment Assistance (PUA) benefits you received for weeks of your claim early in the pandemic through the week ending May 9, 2020. The exact dates you are required to certify for will depend on your specific claim history.
       </p>
-      <h2>
+      <p>
+        <a
+          href="https://edd.ca.gov/Unemployment/retro-certify.htm"
+        >
+          Learn about retroactive certification and how it works.
+        </a>
+      </p>
+      <h2
+        className="h3 font-weight-bold mb-3"
+      >
         Enter Your Information
       </h2>
       <p>
@@ -286,7 +295,9 @@ exports[`<RetroCertsAuthPage /> retro certs auth page 1`] = `
             </div>
           </FormGroup>
         </Row>
-        <h2>
+        <h2
+          className="h3 font-weight-bold mb-3"
+        >
           Security Check
         </h2>
         <Row
@@ -347,7 +358,16 @@ exports[`<RetroCertsAuthPage /> retro certs auth page with captcha timeout error
       >
         You are required to certify for Unemployment Insurance (UI) and Pandemic Unemployment Assistance (PUA) benefits you received for weeks of your claim early in the pandemic through the week ending May 9, 2020. The exact dates you are required to certify for will depend on your specific claim history.
       </p>
-      <h2>
+      <p>
+        <a
+          href="https://edd.ca.gov/Unemployment/retro-certify.htm"
+        >
+          Learn about retroactive certification and how it works.
+        </a>
+      </p>
+      <h2
+        className="h3 font-weight-bold mb-3"
+      >
         Enter Your Information
       </h2>
       <p>
@@ -611,7 +631,9 @@ exports[`<RetroCertsAuthPage /> retro certs auth page with captcha timeout error
             </div>
           </FormGroup>
         </Row>
-        <h2>
+        <h2
+          className="h3 font-weight-bold mb-3"
+        >
           Security Check
         </h2>
         <Row
@@ -730,7 +752,16 @@ exports[`<RetroCertsAuthPage /> retro certs auth page with session timeout 1`] =
       >
         You are required to certify for Unemployment Insurance (UI) and Pandemic Unemployment Assistance (PUA) benefits you received for weeks of your claim early in the pandemic through the week ending May 9, 2020. The exact dates you are required to certify for will depend on your specific claim history.
       </p>
-      <h2>
+      <p>
+        <a
+          href="https://edd.ca.gov/Unemployment/retro-certify.htm"
+        >
+          Learn about retroactive certification and how it works.
+        </a>
+      </p>
+      <h2
+        className="h3 font-weight-bold mb-3"
+      >
         Enter Your Information
       </h2>
       <p>
@@ -994,7 +1025,9 @@ exports[`<RetroCertsAuthPage /> retro certs auth page with session timeout 1`] =
             </div>
           </FormGroup>
         </Row>
-        <h2>
+        <h2
+          className="h3 font-weight-bold mb-3"
+        >
           Security Check
         </h2>
         <Row
@@ -1055,7 +1088,16 @@ exports[`<RetroCertsAuthPage /> retro certs auth page with user not found error 
       >
         You are required to certify for Unemployment Insurance (UI) and Pandemic Unemployment Assistance (PUA) benefits you received for weeks of your claim early in the pandemic through the week ending May 9, 2020. The exact dates you are required to certify for will depend on your specific claim history.
       </p>
-      <h2>
+      <p>
+        <a
+          href="https://edd.ca.gov/Unemployment/retro-certify.htm"
+        >
+          Learn about retroactive certification and how it works.
+        </a>
+      </p>
+      <h2
+        className="h3 font-weight-bold mb-3"
+      >
         Enter Your Information
       </h2>
       <p>
@@ -1319,7 +1361,9 @@ exports[`<RetroCertsAuthPage /> retro certs auth page with user not found error 
             </div>
           </FormGroup>
         </Row>
-        <h2>
+        <h2
+          className="h3 font-weight-bold mb-3"
+        >
           Security Check
         </h2>
         <Row

--- a/src/client/pages/RetroCertsAuthPage/index.js
+++ b/src/client/pages/RetroCertsAuthPage/index.js
@@ -191,7 +191,14 @@ function RetroCertsAuthPage(props) {
           {showGenericValidationError && validated && genericValidationError}
           {errorTransKey === "retrocert-login.session-timed-out" && errorAlert}
           <p className="mt-3">{t("retrocert-login.help")}</p>
-          <h2>{t("retrocert-login.instructions-header")}</h2>
+          <p>
+            <a href={t("links.edd-retro-cert")}>
+              {t("retrocert-login.learn-more")}
+            </a>
+          </p>
+          <h2 className="h3 font-weight-bold mb-3">
+            {t("retrocert-login.instructions-header")}
+          </h2>
           <p>{t("retrocert-login.instructions")}</p>
           <p>
             <span className="text-danger">* </span>
@@ -320,7 +327,9 @@ function RetroCertsAuthPage(props) {
                 </div>
               </Form.Group>
             </Row>
-            <h2>{t("retrocert-login.security-header")}</h2>
+            <h2 className="h3 font-weight-bold mb-3">
+              {t("retrocert-login.security-header")}
+            </h2>
             <Row>
               <Form.Group controlId="formReCaptcha" className="col-md-6 mt-3">
                 <ReCAPTCHA

--- a/src/data/locales/en/translation.json
+++ b/src/data/locales/en/translation.json
@@ -57,7 +57,8 @@
     "caljobs": "https://www.caljobs.ca.gov/vosnet/Default.aspx",
     "edd-debit": "https://www.edd.ca.gov/about_edd/The_EDD_Debit_Card.htm",
     "edd-coronavirus-faqs": "https://edd.ca.gov/about_edd/coronavirus-2019/faqs.htm",
-    "edd-coronavirus-claims": "https://edd.ca.gov/about_edd/coronavirus-2019/unemployment-claims.htm"
+    "edd-coronavirus-claims": "https://edd.ca.gov/about_edd/coronavirus-2019/unemployment-claims.htm",
+    "edd-retro-cert": "https://edd.ca.gov/Unemployment/retro-certify.htm"
   },
   "certification-header1": "What is certification?",
   "certification-p1": "Certification is the required process of updating the EDD every two weeks with your unemployment status with basic eligibility information:",
@@ -190,6 +191,7 @@
   "retrocert-login": {
     "title": "Retroactive Certification for Unemployment",
     "help": "You are required to certify for Unemployment Insurance (UI) and Pandemic Unemployment Assistance (PUA) benefits you received for weeks of your claim early in the pandemic through the week ending May 9, 2020. The exact dates you are required to certify for will depend on your specific claim history.",
+    "learn-more": "Learn about retroactive certification and how it works.",
     "instructions-header": "Enter Your Information",
     "instructions": "Confirm any benefit weeks you still need to certify for.",
     "last-name-label": "Last Name",

--- a/src/data/locales/es/translation.json
+++ b/src/data/locales/es/translation.json
@@ -191,7 +191,7 @@
   "retrocert-login": {
     "title": "Certificación retroactiva para el Seguro de Desempleo",
     "help": "Usted debe realizar la certificación para los beneficios del Seguro de Desempleo (UI, por sus siglas en inglés) y de la Asistencia de Desempleo por la Pandemia (PUA, por sus siglas en inglés) que recibió durante las semanas en que comenzó la pandemia correspondiente a su solicitud, hasta la semana que termina el 9 de mayo de 2020. Las fechas exactas para las que debe realizar la certificación dependerán específicamente del historial de su solicitud.",
-    "learn-more": "Learn about retroactive certification and how it works en espanol.",
+    "learn-more": "Conozca sobre la certificación retroactiva y cómo funciona.",
     "instructions-header": "Ingrese su información",
     "instructions": "Confirme las semanas de beneficios para las que aún necesita certificar.",
     "last-name-label": "Apellido",

--- a/src/data/locales/es/translation.json
+++ b/src/data/locales/es/translation.json
@@ -57,7 +57,8 @@
     "caljobs": "https://www.caljobs.ca.gov/vosnet/Default.aspx?enc=KrXBHc1OhrZGzl2XGVPM3g==",
     "edd-debit": "https://www.edd.ca.gov/about_edd/The_EDD_Debit_Card_Espanol.htm",
     "edd-coronavirus-faqs": "https://edd.ca.gov/about_edd/coronavirus-2019/faqs-espanol.htm",
-    "edd-coronavirus-claims": "https://edd.ca.gov/about_edd/coronavirus-2019/unemployment-claims-espanol.htm"
+    "edd-coronavirus-claims": "https://edd.ca.gov/about_edd/coronavirus-2019/unemployment-claims-espanol.htm",
+    "edd-retro-cert": "https://edd.ca.gov/Unemployment/retro-certify-espanol.htm"
   },
   "certification-header1": "¿Qué es la certificación?",
   "certification-p1": "Realizar la certificación es el proceso requerido para actualizar al EDD con su estatus de empleo y la siguiente información básica de elegibilidad, cada dos semanas:",
@@ -190,6 +191,7 @@
   "retrocert-login": {
     "title": "Certificación retroactiva para el Seguro de Desempleo",
     "help": "Usted debe realizar la certificación para los beneficios del Seguro de Desempleo (UI, por sus siglas en inglés) y de la Asistencia de Desempleo por la Pandemia (PUA, por sus siglas en inglés) que recibió durante las semanas en que comenzó la pandemia correspondiente a su solicitud, hasta la semana que termina el 9 de mayo de 2020. Las fechas exactas para las que debe realizar la certificación dependerán específicamente del historial de su solicitud.",
+    "learn-more": "Learn about retroactive certification and how it works en espanol.",
     "instructions-header": "Ingrese su información",
     "instructions": "Confirme las semanas de beneficios para las que aún necesita certificar.",
     "last-name-label": "Apellido",


### PR DESCRIPTION
Added a link to the Retro Cert landing page, and adjusted the H2 titles to have the appropriate styling (it was previously the same size as H1). 

We are still waiting for the spanish translation.

===

Resolves #624 

- [x] Snapshots updated, if output HTML/JS has changed (`npm run test:update-snapshots`)
- [x] Changes reviewed on mobile using devtools, if output HTML/CSS has changed
- [x] Spanish checked by adding `?lng=es` to URL e.g. `/guide/benefits?lng=es`, if Spanish updated
- [ ] Automated tests added, if new functionality added
- [ ] Documentation (e.g. READMEs) updated, if relevant
- [ ] IE11 and Edge compatibility confirmed via manual testing in Browserstack, if new libraries added or newish JS/HTML/CSS features used for the first time in this codebase
- [ ] Accessibility & performance audit run using Google Lighthouse, if major changes made
