### PR TITLE
Script to export users who haven't completed retrocert

### DIFF
--- a/scripts/get_users_to_remind.py
+++ b/scripts/get_users_to_remind.py
@@ -1,0 +1,20 @@
+# The two inputs for this script are intentionally not shared
+# The users.py file is constant between runs and contains the hashes for all users
+# The forms.json file is exported directly from CosmosDB using the Data Migration Tool
+
+from users import *
+import json
+
+with open('/scripts/forms.json') as json_file:
+    data = json.load(json_file)
+
+userIdsOnCompletedForms = [i['id'] for i in data]
+
+incompleteUsers = list(set(userIds) - set(userIdsOnCompletedForms))
+
+print(len(userIds));
+print(len(userIdsOnCompletedForms));
+print(len(incompleteUsers));
+
+with open('result.txt', 'w') as file:
+    file.writelines("%s\n" % user for user in incompleteUsers)

--- a/scripts/get_users_to_remind.py
+++ b/scripts/get_users_to_remind.py
@@ -4,17 +4,19 @@
 
 from users import *
 import json
+from datetime import date
 
 with open('/scripts/forms.json') as json_file:
     data = json.load(json_file)
 
 userIdsOnCompletedForms = [i['id'] for i in data]
-
 incompleteUsers = list(set(userIds) - set(userIdsOnCompletedForms))
 
 print(len(userIds));
 print(len(userIdsOnCompletedForms));
 print(len(incompleteUsers));
 
-with open('result.txt', 'w') as file:
+outputFilename = ('hashesForUsersWhoHaveNotCompletedTheForm-{}.txt'
+    .format(date.today().strftime("%Y%m%d")))
+with open(outputFilename, 'w') as file:
     file.writelines("%s\n" % user for user in incompleteUsers)


### PR DESCRIPTION
We've used a version of this script every month for the past few months to generate a list of claimants who haven't yet completed retroactive certification. We expect it will only be used a few more times at most.
