### PR TITLE
Redirect retrocert login url

### DIFF
--- a/src/routes/single-page-app.js
+++ b/src/routes/single-page-app.js
@@ -33,6 +33,11 @@ singlePageAppRouter.get(
   }
 );
 
+// Retroactive certification ended Nov 2020, so redirect to EDD's landing page
+singlePageAppRouter.get("^/retroactive-certification/?", (req, res) => {
+  res.redirect(302, "https://edd.ca.gov/Unemployment/retro-certify.htm");
+});
+
 singlePageAppRouter.get("/*", (req, res) => {
   const contentSecurityPolicy = buildPolicies();
 


### PR DESCRIPTION
This PR redirects https://unemployment.edd.ca.gov/retroactive-certification/ (with or without a trailing slash) to https://edd.ca.gov/Unemployment/retro-certify.htm. This was implemented in Azure Front Door on Sunday at midnight as requested (although the trailing slash redirect wasn't added until Monday morning) but a very small number of submissions are continuing somehow, so now we're redirecting on the server as well.

The staff view URL/page remains active.
