### PR TITLE
Prevent logging in or saving on retrocerts

### DIFF
--- a/src/routes/retro-certs.js
+++ b/src/routes/retro-certs.js
@@ -1,10 +1,7 @@
 /* eslint-disable no-console */
 const { Router } = require("express");
-const { v4: uuidv4 } = require("uuid");
 const AUTH_STRINGS = require("../data/authStrings");
-const ReCaptcha = require("../services/reCaptcha");
 const cosmos = require("../data/cosmos");
-const weeksCompleted = require("../utils/checkFormData");
 
 function createRouter() {
   const router = Router();
@@ -41,43 +38,6 @@ function createRouter() {
     return responseJson;
   }
 
-  async function authStatus(postJson, responseJson) {
-    responseJson.status = AUTH_STRINGS.statusCode.userNotFound;
-
-    const reCaptcha = new ReCaptcha(postJson.reCaptcha);
-    const isDev = process.env.NODE_ENV === "development";
-    const [reCaptchaResponse, userRecord] = await Promise.all([
-      isDev || reCaptcha.validateUser(),
-      cosmos.getUserByNameDobSsn(
-        postJson.lastName || "",
-        postJson.dob,
-        postJson.ssn
-      ),
-    ]);
-
-    if (!reCaptchaResponse) {
-      console.log("failed recaptcha");
-      responseJson.status = AUTH_STRINGS.statusCode.recaptchaInvalid;
-      return responseJson;
-    }
-
-    if (userRecord) {
-      console.log("login", userRecord.id);
-      const formRecord = await cosmos.getFormDataByUserIdWithNewAuthToken(
-        userRecord.id
-      );
-      responseJson.status = AUTH_STRINGS.statusCode.ok;
-      responseJson.authToken = formRecord.authToken;
-      responseJson.weeksToCertify = userRecord.weeksToCertify;
-      responseJson.programPlan = userRecord.programPlan;
-      responseJson.formData = formRecord.formData;
-      responseJson.confirmationNumber = formRecord.confirmationNumber;
-    } else {
-      console.log("failed login");
-    }
-    return responseJson;
-  }
-
   async function authWithToken(postJson, responseJson) {
     responseJson.status = AUTH_STRINGS.statusCode.userNotFound;
     if (postJson.authToken) {
@@ -99,43 +59,6 @@ function createRouter() {
     return responseJson;
   }
 
-  async function saveFormData(postJson, responseJson) {
-    if (postJson.authToken) {
-      const formRecord = await cosmos.getFormDataByAuthToken(
-        postJson.authToken
-      );
-      if (formRecord) {
-        responseJson.status = AUTH_STRINGS.statusCode.ok;
-        // If the user already submitted data, don't overwrite it.
-        if (formRecord.confirmationNumber) {
-          responseJson.confirmationNumber = formRecord.confirmationNumber;
-        } else {
-          const userRecord = await cosmos.getUserById(formRecord.id);
-
-          formRecord.formData = postJson.formData;
-          if (
-            userRecord.weeksToCertify.length ===
-              weeksCompleted(formRecord.formData, userRecord.programPlan) &&
-            postJson.completed === true
-          ) {
-            formRecord.completedAt = Date.now();
-            formRecord.confirmationNumber = uuidv4();
-            responseJson.confirmationNumber = formRecord.confirmationNumber;
-          }
-          await cosmos.upsertFormData(formRecord);
-          console.log(
-            "saved data",
-            postJson.authToken,
-            responseJson.confirmationNumber || ""
-          );
-        }
-      } else {
-        console.log("save with invalid token", postJson.authToken);
-      }
-    }
-    return responseJson;
-  }
-
   router.post(AUTH_STRINGS.staffView.login, async (req, res) => {
     try {
       const responseJson = await staffViewAuthStatus(req.body, {});
@@ -150,16 +73,8 @@ function createRouter() {
   });
 
   router.post(AUTH_STRINGS.apiPath.login, async (req, res) => {
-    try {
-      const responseJson = await authStatus(req.body, {});
-      const httpStatus =
-        responseJson.status === AUTH_STRINGS.statusCode.ok ? 200 : 401;
-
-      res.status(httpStatus).type("json").send(JSON.stringify(responseJson));
-    } catch (e) {
-      console.error("Error during /api/login", e);
-      res.status(500).send();
-    }
+    console.error("Login after end of retroactive certification period");
+    res.status(500).send();
   });
 
   router.post(AUTH_STRINGS.apiPath.data, async (req, res) => {
@@ -176,24 +91,8 @@ function createRouter() {
   });
 
   router.post(AUTH_STRINGS.apiPath.save, async (req, res) => {
-    const formDataAsString = JSON.stringify(req.body.formData || {});
-    // Reject inputs that might be trying to inject malicious scripts.
-    if (formDataAsString.match(/<[^ ]/)) {
-      console.log("rejected input", req.body.authToken);
-      res.status(400).type("json").send();
-      return;
-    }
-
-    try {
-      const responseJson = await saveFormData(req.body, {});
-      const httpStatus =
-        responseJson.status === AUTH_STRINGS.statusCode.ok ? 200 : 401;
-
-      res.status(httpStatus).type("json").send(JSON.stringify(responseJson));
-    } catch (e) {
-      console.error("Error during /api/save", e);
-      res.status(500).send();
-    }
+    console.error("Save after end of retroactive certification period");
+    res.status(500).send();
   });
 
   return router;

--- a/src/routes/retro-certs.test.js
+++ b/src/routes/retro-certs.test.js
@@ -10,27 +10,15 @@ import ReCaptcha from "../services/reCaptcha";
 import programPlan from "../data/programPlan";
 
 describe("Router: API tests", () => {
-  it("retro-certs POST feature enabled", async () => {
-    const getUserByNameDobSsnMock = jest.spyOn(cosmos, "getUserByNameDobSsn");
-    getUserByNameDobSsnMock.mockImplementation(
-      jest.fn(() => Promise.resolve(null))
-    );
-
+  it("retro-certs POST feature disabled", async () => {
     const server = init();
     const testPaths = Object.values(AUTH_STRINGS.apiPath);
 
     for (const testPath of testPaths.slice(0, 1)) {
       const res = await request(server).post(testPath);
-      expect(res.status).toBe(401);
-      expect(res.body).toEqual({
-        status: AUTH_STRINGS.statusCode.userNotFound,
-      });
+      // Retroactive certification ended, so POST requests should return 500
+      expect(res.status).toBe(500);
     }
-    expect(getUserByNameDobSsnMock.mock.calls).toEqual([
-      ["", undefined, undefined],
-    ]);
-
-    getUserByNameDobSsnMock.mockRestore();
   });
 
   it("retro-certs /api/login tests", async () => {
@@ -100,8 +88,6 @@ describe("Router: API tests", () => {
         recaptchaResponse,
         getUserResponse,
         getFormDataByUserIdWithNewAuthTokenResponse,
-        httpStatus,
-        responseJson,
       ] = testCase;
       const validateUserMock = jest.spyOn(ReCaptcha.prototype, "validateUser");
       validateUserMock.mockImplementation(() => recaptchaResponse);
@@ -123,9 +109,8 @@ describe("Router: API tests", () => {
         .post(AUTH_STRINGS.apiPath.login)
         .send(JSON.stringify(reqJson))
         .type("json");
-      expect(res.status).toBe(httpStatus);
-      expect(res.header["content-type"]).toMatch(/json/);
-      expect(res.body).toEqual(responseJson);
+      // Retroactive certification ended, so login requests should return 500
+      expect(res.status).toBe(500);
 
       validateUserMock.mockRestore();
       getUserByNameDobSsnMock.mockRestore();
@@ -318,8 +303,6 @@ describe("Router: API tests", () => {
         reqJson,
         getFormDataByAuthTokenResponse,
         getUserByIdResponse,
-        httpStatus,
-        responseJson,
       ] = testCase;
       const getFormDataByAuthTokenMock = jest.spyOn(
         cosmos,
@@ -339,9 +322,8 @@ describe("Router: API tests", () => {
         .post(AUTH_STRINGS.apiPath.save)
         .send(JSON.stringify(reqJson))
         .type("json");
-      expect(res.status).toBe(httpStatus);
-      expect(res.header["content-type"]).toMatch(/json/);
-      expect(res.body).toEqual(responseJson);
+      // Retroactive certification ended, so save requests should return 500
+      expect(res.status).toBe(500);
 
       getFormDataByAuthTokenMock.mockRestore();
       getUserByIdMock.mockRestore();


### PR DESCRIPTION
This is a followup to #654; two users somehow managed to submit still, so this PR updates the login and save endpoints to return errors. Tested locally with the staging db that the staff view login continues to work as required.